### PR TITLE
Add genie-llm-warmup.service to pre-warm Phi-4-mini after boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- `genie-llm-warmup.service` — a oneshot systemd unit ordered `After=genie-llm.service`
+  that polls `/health` and sends one tiny `/completion` request to force
+  Phi-4-mini into iGPU memory before the first user-visible voice cycle.
+  Without this the first voice interaction after boot would either block
+  on the ~30-60 s cold model load or time out with `503: Loading model`.
+  Wired into `setup-jetson.sh`'s enable loop so a fresh `make deploy` +
+  reboot ends with the LLM already hot. Closes #3.
+
 ## 1.0.0-alpha.5 - 2026-05-11
 
 Alpha 5 is the voice-frontend release. It takes GenieClaw from a chat/HTTP

--- a/deploy/setup-jetson.sh
+++ b/deploy/setup-jetson.sh
@@ -255,7 +255,7 @@ fi
 
 # Enable core services. genie-audio runs the I2S/AHUB route setup at boot
 # (no-op if /opt/geniepod/bin/genie-audio-init is missing, see ConditionPathExists).
-for svc in homeassistant genie-audio genie-whisper genie-llm genie-core genie-governor genie-health genie-api genie-mqtt; do
+for svc in homeassistant genie-audio genie-whisper genie-llm genie-llm-warmup genie-core genie-governor genie-health genie-api genie-mqtt; do
     if sudo systemctl enable "$svc.service" 2>/dev/null; then
         echo "  Enabled: $svc"
     else

--- a/deploy/systemd/genie-llm-warmup.service
+++ b/deploy/systemd/genie-llm-warmup.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=GeniePod LLM Warmup (force Phi-4-mini into iGPU before first voice cycle)
+Documentation=https://github.com/GeniePod/genie-claw/issues/3
+After=genie-llm.service
+Wants=genie-llm.service
+ConditionPathExists=/opt/geniepod/bin/llama-server
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Poll /health for up to 90 s while llama-server boots, then send one
+# tiny /completion request to force the model load into iGPU memory.
+# Without this, the first user-visible voice cycle either blocks on
+# the ~30-60 s cold load or times out with 503 "Loading model".
+# Failures are non-fatal (|| true) so a broken LLM does not block boot.
+ExecStart=/bin/sh -c '\
+    for i in $(seq 1 90); do \
+        if curl -sf -o /dev/null http://127.0.0.1:8080/health; then break; fi; \
+        sleep 1; \
+    done; \
+    curl -sf -X POST http://127.0.0.1:8080/completion \
+        -H "Content-Type: application/json" \
+        -d "{\"prompt\":\"hi\",\"n_predict\":1}" > /dev/null || true; \
+    echo "[genie-llm-warmup] done"'
+TimeoutStartSec=180
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=geniepod.target


### PR DESCRIPTION
## Summary

- Adds a oneshot systemd unit `genie-llm-warmup.service` that, after `genie-llm.service` starts, polls `/health` for up to 90 s, then sends one tiny `/completion` request (`{\"prompt\":\"hi\",\"n_predict\":1}`) to force the Phi-4-mini-Q4_K_M model into iGPU memory.
- Wired into `setup-jetson.sh`'s enable loop so it's pulled in by `geniepod.target` on every boot.
- Failures are non-fatal (`|| true`) so a broken or slow llama-server does not wedge the boot.

Closes #3.

## Why

Without this, on alpha.5 the **first** user-visible voice cycle after a reboot either:
- blocks for 30-60 s while llama-server cold-loads the 2.4 GB model into iGPU, or
- times out with `503: Loading model` and the cycle fails entirely

`/health` returns 200 long before the model is actually in VRAM (it just checks the HTTP server). The only thing that forces a real model load is an actual inference request. This service issues that request as part of boot so the first user interaction is already hot.

Manual workaround that was documented in the alpha.5 README footer:

\`\`\`bash
curl -s -X POST http://127.0.0.1:8080/completion \\
  -H 'Content-Type: application/json' \\
  -d '{\"prompt\":\"hi\",\"n_predict\":1}' > /dev/null
\`\`\`

This PR automates it.

## Test plan

- [x] `genie-llm-warmup.service` syntax accepted by systemd (`systemd-analyze verify`)
- [ ] Fresh `make deploy` + reboot of the Jetson — first voice cycle completes in <12 s instead of ~60 s
- [ ] `journalctl -u genie-llm-warmup.service` shows `[genie-llm-warmup] done` after llama-server is ready
- [ ] If `llama-server` is intentionally stopped (`sudo systemctl stop genie-llm`), warmup just times out at 90 s and exits without blocking other services
- [ ] `geniepod.target` start order: `genie-llm.service` → `genie-llm-warmup.service` → first genie-core voice cycle stays fast

## Acceptance criteria (from #3)

- [x] New unit lives at `deploy/systemd/genie-llm-warmup.service`
- [x] `setup-jetson.sh` enables it
- [x] Tracked by `geniepod.target` so it's pulled in on every boot
- [ ] First voice cycle after a cold boot completes within 12 s (verify on hardware)
- [x] CHANGELOG entry under alpha.6 (currently Unreleased)