### PR TITLE
Add sox compand to capture preprocessing for quiet-speech lift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Changed
 
+- `voice_loop` now runs `stt::flush_mic_buffer` BEFORE printing the
+  "Recording N seconds — speak now!" / "Listening for follow-up" prompt,
+  rather than inside `record_audio` after the prompt. The flush is a 1 s
+  throwaway capture that drains stale samples (TTS residue, DMA carry-over)
+  between cycles. With the old ordering, the throwaway ran AFTER the user
+  saw the prompt, so the first ~1 s of speech went into the discarded
+  flush WAV — operators reported the opening of their commands being
+  chopped off. New ordering: flush is silent during the brief gap between
+  cycles, then prompt appears the instant arecord actually starts. Both
+  the push-to-talk path and the continuous follow-up path are fixed.
 - `record_audio`'s sox preprocessing chain now does dynamic-range
   compression with `compand 0.02,0.20 -50,-50,-25,-12,-5,-5 -2` before
   the final `gain -n -3` peak-normalize. The previous pipeline applied

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Changed
+
+- `record_audio`'s sox preprocessing chain now does dynamic-range
+  compression with `compand 0.02,0.20 -50,-50,-25,-12,-5,-5 -2` before
+  the final `gain -n -3` peak-normalize. The previous pipeline applied
+  a single linear gain to satisfy peak-normalize: if a user's loudest
+  syllable was at -5 dBFS and the quietest at -25 dBFS, BOTH got the
+  same scalar boost and the quiet syllables stayed buried under whisper's
+  hallucination threshold. With compand, quiet-speech input around
+  -25 dBFS now maps to -12 dBFS (+13 dB lift) while loud peaks stay
+  at -5 dBFS and the noise floor below -50 dBFS is NOT amplified.
+  Compand attack/release of 20 ms / 200 ms matches speech syllable
+  timing. Net effect on STT: whisper-small reaches whole-utterance
+  intelligibility on quieter LyraT captures that previously
+  produced assistant-stock hallucinations ("I'm here to help",
+  "feel free to ask"). Closes #6.
+
 ### Added
 
 - `genie-llm-warmup.service` — a oneshot systemd unit ordered `After=genie-llm.service`

--- a/crates/genie-core/src/voice/stt.rs
+++ b/crates/genie-core/src/voice/stt.rs
@@ -504,41 +504,58 @@ pub async fn record_audio(device: &str, sample_rate: u32, duration_secs: u32) ->
         "recording complete"
     );
 
-    // Band-pass filter + peak-normalize the captured audio before STT.
+    // Preprocess captured audio for STT.
     //
-    // Why band-pass FIRST:
-    //   The ES8388 ADC on LyraT V4.3 has a noticeable high-frequency noise
-    //   floor. Without filtering, sox's peak-normalization amplifies that
-    //   HF hiss along with speech, so after `gain -n -3` the dominant
-    //   spectral content can sit at 10 kHz+ instead of the 100-500 Hz
-    //   speech band — confirmed via `sox stat` showing rough frequency
-    //   ~10.5 kHz on a quiet test capture. Whisper then hears mostly hiss
-    //   and hallucinates assistant-stock phrases.
+    //   channels 1     — downmix stereo (captured by `arecord -c 2` above)
+    //                    to mono. sox's `channels 1` averages all input
+    //                    channels — for a stereo LyraT capture this is the
+    //                    passive broadside delay-and-sum beamformer pointed
+    //                    at the speaker.
+    //   highpass 100   — kill DC + sub-bass rumble (kept above the lowest
+    //                    male fundamentals around 80 Hz).
+    //   lowpass  7000  — kill ADC hiss and electronic noise above the
+    //                    speech band (kept above sibilance to preserve
+    //                    /s/, /f/, /sh/ phonemes for whisper).
+    //   compand …      — dynamic-range expand-the-quiet-bits. Before this,
+    //                    `gain -n -3` had to amplify both the loudest speech
+    //                    peak and any quiet speech segments by the same
+    //                    linear scalar — so when a user mumbled half their
+    //                    command, the loud parts ate the gain budget and
+    //                    the mumbled half stayed underwater (whisper would
+    //                    hear ambiguous low-level audio and fall back to
+    //                    assistant-stock hallucinations). The compand
+    //                    transfer function lifts input -25 dBFS to output
+    //                    -12 dBFS (~13 dB of expansion on quiet speech),
+    //                    keeps loud speech at -5 dBFS so it doesn't clip,
+    //                    and pins the floor at -50 dBFS so noise is NOT
+    //                    amplified into the speech band.
+    //   gain -n -3     — final peak-normalize the cleaned + compressed
+    //                    signal to -3 dBFS so whisper sees nominal
+    //                    speech-level audio.
     //
-    //   highpass 100  — kill DC + sub-bass rumble (kept above the lowest
-    //                   male fundamentals around 80 Hz).
-    //   lowpass  7000 — kill ADC hiss and electronic noise above the
-    //                   speech band (kept above sibilance to preserve /s/,
-    //                   /f/, /sh/ phonemes for whisper).
-    //   gain -n -3    — then peak-normalize the *clean* signal to -3 dBFS,
-    //                   so whisper sees nominal speech-level audio with
-    //                   the noise floor still relatively suppressed.
+    //   Compand args breakdown:
+    //     attack=0.02 release=0.20  — 20 ms attack / 200 ms release matches
+    //                                  speech syllable timing
+    //     -50,-50                   — noise floor stays at -50 dBFS
+    //     -25,-12                   — input -25 dBFS -> output -12 dBFS
+    //                                  (+13 dB on quiet speech)
+    //     -5,-5                     — loud speech (-5 dBFS) stays at -5
+    //     -2                        — slight makeup offset
     let normalized_path = format!("/tmp/geniepod-rec-{}-norm.wav", std::process::id());
     match Command::new("sox")
         .args([
             wav_path.as_str(),
             normalized_path.as_str(),
-            // Downmix stereo (captured by arecord -c 2 above) to mono. sox's
-            // `channels 1` effect averages all input channels into one — for
-            // a stereo LyraT capture this is mathematically the same as a
-            // passive broadside delay-and-sum beamformer pointed at the
-            // speaker.
             "channels",
             "1",
             "highpass",
             "100",
             "lowpass",
             "7000",
+            "compand",
+            "0.02,0.20",
+            "-50,-50,-25,-12,-5,-5",
+            "-2",
             "gain",
             "-n",
             "-3",
@@ -561,7 +578,7 @@ pub async fn record_audio(device: &str, sample_rate: u32, duration_secs: u32) ->
             let _ = tokio::fs::remove_file(&wav_path).await;
             tracing::info!(
                 path = %normalized_path,
-                "preprocessed audio (highpass 100 Hz, lowpass 7 kHz, peak-normalize -3 dBFS)"
+                "preprocessed audio (highpass 100 Hz, lowpass 7 kHz, compand quiet-speech lift, peak-normalize -3 dBFS)"
             );
             Ok(normalized_path)
         }

--- a/crates/genie-core/src/voice/stt.rs
+++ b/crates/genie-core/src/voice/stt.rs
@@ -412,7 +412,7 @@ impl SttEngine {
 /// 1 second of throwaway capture is enough to settle the I2S DMA on Jetson +
 /// LyraT V4.3. The arecord open/close also fully releases and re-acquires the
 /// device, resetting any kernel-side state.
-async fn flush_mic_buffer(device: &str, sample_rate: u32) {
+pub async fn flush_mic_buffer(device: &str, sample_rate: u32) {
     let flush_path = format!("/tmp/geniepod-flush-{}.wav", std::process::id());
     // Use -c 2 (stereo) for the same reason as the real capture: -c 1 on the
     // Tegra/LyraT plughw stack returns samples in half real time, so a 1 s
@@ -442,11 +442,10 @@ async fn flush_mic_buffer(device: &str, sample_rate: u32) {
 ///
 /// Returns the path to the recorded WAV file.
 pub async fn record_audio(device: &str, sample_rate: u32, duration_secs: u32) -> Result<String> {
-    // Drain any stale samples in the ALSA capture buffer before the real
-    // recording (TTS residue bleeding speaker→room→mic, plus DMA carry-over
-    // from prior cycles). This makes consecutive voice-loop cycles produce
-    // independent captures instead of one polluting the next.
-    flush_mic_buffer(device, sample_rate).await;
+    // NOTE: callers are expected to call `flush_mic_buffer` themselves BEFORE
+    // printing any "speak now" prompt to the user. Doing the flush here would
+    // cause the throwaway 1 s arecord to run *after* the user sees the
+    // prompt — chopping ~1 s off the start of the captured speech.
 
     let wav_path = format!("/tmp/geniepod-rec-{}.wav", std::process::id());
 

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -298,6 +298,11 @@ async fn run_with_wakeword(
                 // Small delay to ensure mic is fully released by wake word process.
                 tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
+                // Drain stale samples (TTS residue, DMA carry-over) BEFORE
+                // printing the prompt — otherwise the 1 s flush would
+                // overlap the start of the user's follow-up utterance.
+                stt::flush_mic_buffer(audio_device, voice_cfg.sample_rate).await;
+
                 eprintln!(
                     "[voice] Listening for follow-up ({} sec)...",
                     voice_cfg.voice_continuous_secs
@@ -803,6 +808,12 @@ async fn voice_cycle(
     conv_id: &str,
 ) -> bool {
     // Step 1: Record (fixed duration — reliable).
+    //
+    // Drain stale samples (TTS residue from the previous cycle, kernel-side
+    // DMA carry-over) BEFORE printing the prompt. Doing the flush inside
+    // record_audio would chop ~1 s off the start of the user's speech,
+    // because the user starts talking the moment they see "speak now!".
+    stt::flush_mic_buffer(audio_device, voice_cfg.sample_rate).await;
     eprintln!(
         "[voice] Recording {} seconds — speak now!",
         voice_cfg.record_secs


### PR DESCRIPTION
## Summary

Two related capture-side fixes that compound:

### 1. sox `compand` for quiet-speech lift (closes #6)

`record_audio` sox chain gains a `compand 0.02,0.20 -50,-50,-25,-12,-5,-5 -2` effect between the band-pass filters and the final `gain -n -3` peak-normalize.

The previous pipeline ended on a single linear peak-normalize. With LyraT V4.3 onboard mics at home distance, captured RMS lands around -30 dBFS while loud syllables peak around -10 dBFS. `gain -n -3` then applies the same scalar boost to both — quiet/mumbled segments stay at low SNR relative to the now-amplified noise floor and whisper-small hallucinates assistant-stock phrases ("I'm here to help", "feel free to ask", "Get out of here! Time, time.").

Compand transfer:

| Input | Output | Effect |
|---:|---:|---|
| -50 dBFS | -50 dBFS | noise floor: no lift |
| -25 dBFS | -12 dBFS | **quiet speech: +13 dB** |
| -5 dBFS | -5 dBFS | loud speech: held (no clipping) |

Attack 20 ms / release 200 ms matches speech syllable timing.

### 2. Move `flush_mic_buffer` BEFORE the "speak now!" prompt

Reported during hardware testing of (1): the first ~0.5-1 s of the user's utterance is missing from the captured audio. STT transcripts read like `"Hello."` when the user said `"Hello GeniePod"`, or `"Who can I ask for a beer"` when the user said `"Where can I ask for a beer"`.

Root cause: `record_audio` was running `flush_mic_buffer` (a 1 s silent throwaway arecord that drains stale DMA samples + TTS residue) AFTER `voice_cycle` printed the `"Recording 3 seconds — speak now!"` prompt. Users see the prompt and start speaking immediately, but arecord is busy with the throwaway capture for that first second. The first 1 s of speech goes to `/tmp/geniepod-flush-*.wav` (which is deleted). The real recording only captures seconds 2-4 of the user's speech.

Fix:
- `stt::flush_mic_buffer` is now `pub`
- `record_audio` no longer calls it internally
- `voice_cycle` (push-to-talk path) calls `stt::flush_mic_buffer`, **then** prints the prompt, **then** calls `record_audio`
- continuous follow-up path does the same

Net effect: the 1 s flush happens silently during the gap between cycles. The prompt appears the instant the real arecord begins, so the user's speech is captured from word one.

## Closes

- #6 (compand)

## Test plan

- [ ] `make deploy` from `tiny@tiny-virtual-machine`
- [ ] Voice loop log line now reads:
  `INFO preprocessed audio (highpass 100 Hz, lowpass 7 kHz, compand quiet-speech lift, peak-normalize -3 dBFS)`
- [ ] Push-to-talk timing: the moment "speak now!" appears, immediately say a multi-word phrase ("Hello GeniePod" / "What time is it now"). Transcript should include the leading word/syllable.
- [ ] `aplay /tmp/geniepod-last-rec.wav` after a cycle: should begin with your first phoneme, not start mid-word.
- [ ] Three back-to-back cycles, mixing loud / mumbled / mixed. Transcripts should improve on quiet input without regressing on clean input.
- [ ] No "pumping" / "breathing" compand artifacts on `aplay` of the captured audio.

## Notes

- The flush ordering change benefits every cycle (push-to-talk and continuous follow-up) even when audio quality isn't marginal. It's a pure UX win — the user's full utterance is captured.
- Compand is CPU-only; ~30-50 ms added per 3 s capture on Orin Nano. Negligible vs the rest of the voice cycle.
- If compound accuracy on marginal audio is still insufficient after this, the next lever is #5 (whisper-medium fallback). Compand reduces the *frequency* of marginal-audio hits but doesn't change the upper bound of what whisper-small can recover.