### PR TITLE
Half-duplex post-TTS gate + stale AEC reference detection (#15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /target/
 /ROADMAP.md
 /VISION.md
+
+# macOS metadata
+.DS_Store
+**/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Added
 
+- Half-duplex post-TTS gate to suppress speaker→mic acoustic echo (issue #15).
+  `TtsEngine::speak()` now sleeps `post_tts_silence_ms` milliseconds after
+  `aplay` exits. The ALSA hardware playback buffer continues draining for
+  some time after `aplay` returns, and the room itself takes time to decay
+  below the whisper-server no-speech threshold. Without the gate, the next
+  cycle's mic capture picked up the assistant's own TTS and whisper happily
+  transcribed it as the next user utterance — confirmed in the #14 chase
+  on Jetson + LyraT + speakers in a shared room. Default 1500 ms; settable
+  via `[core].post_tts_silence_ms` in `geniepod.toml`. Headphone / headset
+  installs can drop it to 0.
+- `aec::process_aec` now discards stale echo references — any TTS reference
+  older than `TTS_duration + MAX_ECHO_TAIL_MS` (1.5 s) is dropped before
+  NLMS runs. Push-to-talk recordings that happen after the room reverb has
+  decayed should not be processed against an aged TTS reference; the
+  previous behavior would convolve fresh user speech with old TTS PCM and
+  introduce phantom artifacts.
 - DeepFilterNet capture-side denoiser as the alpha.7 default (issue #12).
   `record_audio` now branches on a new `audio_denoiser` config knob with
   three backends: `"deepfilternet"` (neural; new default), `"sox"` (the

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -133,6 +133,16 @@ pub struct CoreConfig {
     #[serde(default = "defaults::deep_filter_atten_lim_db")]
     pub deep_filter_atten_lim_db: f32,
 
+    /// Half-duplex gate (issue #15): milliseconds to wait after Piper's `aplay`
+    /// subprocess exits before allowing the next mic capture. Lets the ALSA
+    /// hardware buffer drain and the speaker/room reverb decay below the
+    /// whisper-server no-speech threshold. Without this, the next cycle's
+    /// recording contains the assistant's own TTS bleed and whisper
+    /// transcribes the assistant's voice instead of the user's. Set to 0
+    /// on installs with full physical isolation (headphones / headset).
+    #[serde(default = "defaults::post_tts_silence_ms")]
+    pub post_tts_silence_ms: u64,
+
     /// Enable voice mode (mic → STT → LLM → TTS → speaker loop).
     #[serde(default)]
     pub voice_enabled: bool,
@@ -197,6 +207,7 @@ impl Default for CoreConfig {
             audio_denoiser: defaults::audio_denoiser(),
             deep_filter_path: defaults::deep_filter_path(),
             deep_filter_atten_lim_db: defaults::deep_filter_atten_lim_db(),
+            post_tts_silence_ms: defaults::post_tts_silence_ms(),
             voice_enabled: false,
             voice_record_secs: defaults::voice_record_secs(),
             voice_continuous: true,
@@ -1239,6 +1250,13 @@ mod defaults {
     }
     pub fn deep_filter_path() -> PathBuf {
         PathBuf::from("/opt/geniepod/bin/deep-filter")
+    }
+    pub fn post_tts_silence_ms() -> u64 {
+        // 1500 ms: empirical default that lets ALSA's hardware playback buffer
+        // drain on Tegra HDA and the speaker/room decay fall below the
+        // whisper-server no-speech threshold. Set lower on headphone-only
+        // installs, higher on rooms with long reverberation.
+        1500
     }
     pub fn deep_filter_atten_lim_db() -> f32 {
         100.0

--- a/crates/genie-core/src/main.rs
+++ b/crates/genie-core/src/main.rs
@@ -193,6 +193,7 @@ async fn main() -> Result<()> {
             audio_denoiser: config.core.audio_denoiser.clone(),
             deep_filter_path: config.core.deep_filter_path.to_string_lossy().to_string(),
             deep_filter_atten_lim_db: config.core.deep_filter_atten_lim_db,
+            post_tts_silence_ms: config.core.post_tts_silence_ms,
             record_secs: config.core.voice_record_secs,
             llm_model_path: config.core.llm_model_path.to_string_lossy().to_string(),
             wakeword_script: config.core.wakeword_script.to_string_lossy().to_string(),

--- a/crates/genie-core/src/voice/aec.rs
+++ b/crates/genie-core/src/voice/aec.rs
@@ -29,6 +29,11 @@ struct EchoReference {
     play_start_ms: u64,
 }
 
+/// Maximum room/acoustic tail after TTS playback where the reference is still
+/// meaningful for echo cancellation. Push-to-talk recordings that happen after
+/// this window should not be processed against old TTS audio.
+const MAX_ECHO_TAIL_MS: u64 = 1_500;
+
 /// Store TTS output as echo reference for future AEC processing.
 ///
 /// Called by TTS speak() after Piper generates PCM, before sending to aplay.
@@ -149,8 +154,43 @@ pub fn cancel_echo(mic_samples: &mut [f32], mic_sample_rate: u32) {
 /// Reads the WAV, applies echo cancellation, writes back.
 /// Called from noise processing pipeline after recording.
 pub async fn process_aec(wav_path: &str, sample_rate: u32) {
-    // Check if we have an echo reference.
-    let has_ref = ECHO_REF.lock().map(|g| g.is_some()).unwrap_or(false);
+    // Check if we have a fresh echo reference. The current voice loop records
+    // after TTS playback, not during it. Applying an old TTS reference to the
+    // next push-to-talk capture corrupts real speech, so stale references are
+    // discarded before NLMS runs.
+    let has_ref = ECHO_REF
+        .lock()
+        .map(|mut guard| {
+            let Some(reference) = guard.as_ref() else {
+                return false;
+            };
+
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64;
+            let ref_duration_ms = if reference.sample_rate == 0 {
+                0
+            } else {
+                (reference.samples.len() as u64 * 1_000) / reference.sample_rate as u64
+            };
+            let age_ms = now_ms.saturating_sub(reference.play_start_ms);
+            let fresh_window_ms = ref_duration_ms.saturating_add(MAX_ECHO_TAIL_MS);
+
+            if age_ms > fresh_window_ms {
+                tracing::debug!(
+                    age_ms,
+                    ref_duration_ms,
+                    fresh_window_ms,
+                    "skipping stale echo reference"
+                );
+                *guard = None;
+                false
+            } else {
+                true
+            }
+        })
+        .unwrap_or(false);
 
     if !has_ref {
         return; // No echo reference — TTS wasn't playing during recording.
@@ -296,6 +336,63 @@ mod tests {
 
         let has_ref = ECHO_REF.lock().unwrap().is_some();
         assert!(!has_ref, "Reference should be cleared");
+    }
+
+    #[tokio::test]
+    async fn process_aec_skips_stale_reference() {
+        let _guard = TEST_LOCK.lock().unwrap();
+
+        let sample_rate = 16000;
+        let pcm = vec![0u8; 3200];
+        let path = format!("/tmp/geniepod-aec-stale-test-{}.wav", std::process::id());
+        let wav = test_wav(&pcm, sample_rate);
+        tokio::fs::write(&path, &wav).await.unwrap();
+
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        *ECHO_REF.lock().unwrap() = Some(EchoReference {
+            samples: vec![1000.0; 1600],
+            sample_rate,
+            play_start_ms: now_ms - 60_000,
+        });
+
+        process_aec(&path, sample_rate).await;
+
+        let after = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(after, wav, "stale AEC reference should not modify WAV");
+        assert!(
+            ECHO_REF.lock().unwrap().is_none(),
+            "stale reference should be cleared"
+        );
+
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    fn test_wav(pcm: &[u8], sample_rate: u32) -> Vec<u8> {
+        let channels = 1u16;
+        let bits_per_sample = 16u16;
+        let data_size = pcm.len() as u32;
+        let byte_rate = sample_rate * channels as u32 * bits_per_sample as u32 / 8;
+        let block_align = channels * bits_per_sample / 8;
+
+        let mut wav = Vec::with_capacity(44 + pcm.len());
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&(36 + data_size).to_le_bytes());
+        wav.extend_from_slice(b"WAVE");
+        wav.extend_from_slice(b"fmt ");
+        wav.extend_from_slice(&16u32.to_le_bytes());
+        wav.extend_from_slice(&1u16.to_le_bytes());
+        wav.extend_from_slice(&channels.to_le_bytes());
+        wav.extend_from_slice(&sample_rate.to_le_bytes());
+        wav.extend_from_slice(&byte_rate.to_le_bytes());
+        wav.extend_from_slice(&block_align.to_le_bytes());
+        wav.extend_from_slice(&bits_per_sample.to_le_bytes());
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&data_size.to_le_bytes());
+        wav.extend_from_slice(pcm);
+        wav
     }
 
     fn rms(samples: &[f32]) -> f32 {

--- a/crates/genie-core/src/voice/tts.rs
+++ b/crates/genie-core/src/voice/tts.rs
@@ -21,6 +21,12 @@ pub struct TtsEngine {
     pub sample_rate: u32,
     /// ALSA device for playback (e.g. "plughw:0,0").
     audio_device: String,
+    /// Half-duplex post-TTS silence (issue #15): milliseconds to sleep after
+    /// `aplay` exits before returning from speak(). Gives the ALSA hardware
+    /// playback buffer time to drain and the room reverb time to decay below
+    /// the whisper-server no-speech threshold, so the next mic capture does
+    /// not pick up the assistant's own TTS.
+    post_silence_ms: u64,
 }
 
 #[derive(Clone, Copy)]
@@ -41,6 +47,7 @@ impl TtsEngine {
             child: None,
             sample_rate: 22050,
             audio_device: String::new(),
+            post_silence_ms: 0,
         }
     }
 
@@ -53,6 +60,7 @@ impl TtsEngine {
             child: None,
             sample_rate: 22050,
             audio_device: String::new(),
+            post_silence_ms: 0,
         }
     }
 
@@ -74,7 +82,14 @@ impl TtsEngine {
             child: None,
             sample_rate: 22050,
             audio_device: audio_device.to_string(),
+            post_silence_ms: 0,
         }
+    }
+
+    /// Set the half-duplex post-TTS silence (ms) — see issue #15.
+    pub fn with_post_silence_ms(mut self, ms: u64) -> Self {
+        self.post_silence_ms = ms;
+        self
     }
 
     pub fn for_model(&self, model_path: &str) -> Self {
@@ -85,6 +100,7 @@ impl TtsEngine {
             child: None,
             sample_rate: self.sample_rate,
             audio_device: self.audio_device.clone(),
+            post_silence_ms: self.post_silence_ms,
         }
     }
 
@@ -192,6 +208,20 @@ impl TtsEngine {
         let aplay_output = aplay.wait().await?;
         if !aplay_output.success() {
             tracing::warn!("aplay exited with error");
+        }
+
+        // Half-duplex gate (issue #15): once aplay has exited, the ALSA
+        // hardware buffer may still be flushing the tail of the TTS PCM, and
+        // the room itself takes time to decay below the whisper-server
+        // no-speech threshold. Without this sleep, the next mic capture
+        // contains the assistant's own voice and whisper happily transcribes
+        // it as the next "user" utterance.
+        if self.post_silence_ms > 0 {
+            tracing::debug!(
+                post_silence_ms = self.post_silence_ms,
+                "half-duplex gate: sleeping for room decay"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(self.post_silence_ms)).await;
         }
 
         Ok(())

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -47,6 +47,10 @@ pub struct VoiceConfig {
     pub deep_filter_path: String,
     /// DeepFilterNet `--atten-lim` in dB. 100.0 = full denoising.
     pub deep_filter_atten_lim_db: f32,
+    /// Half-duplex gate: wait this long after aplay exits before recording.
+    /// See issue #15 — prevents the previous TTS from being captured as the
+    /// next utterance.
+    pub post_tts_silence_ms: u64,
     pub record_secs: u32,
     pub llm_model_path: String,
     pub wakeword_script: String,
@@ -622,6 +626,7 @@ fn clone_voice_config(cfg: &VoiceConfig) -> VoiceConfig {
         audio_denoiser: cfg.audio_denoiser.clone(),
         deep_filter_path: cfg.deep_filter_path.clone(),
         deep_filter_atten_lim_db: cfg.deep_filter_atten_lim_db,
+        post_tts_silence_ms: cfg.post_tts_silence_ms,
         record_secs: cfg.record_secs,
         llm_model_path: cfg.llm_model_path.clone(),
         wakeword_script: cfg.wakeword_script.clone(),
@@ -651,6 +656,7 @@ fn tts_engine_for_language(
         &voice_cfg.audio_output_device,
         voice_cfg.piper_pipe_mode,
     )
+    .with_post_silence_ms(voice_cfg.post_tts_silence_ms)
 }
 
 async fn handle_quick_tool_for_voice(

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -76,6 +76,15 @@ deep_filter_atten_lim_db = 100.0  # DeepFilterNet attenuation limit (--atten-lim
                                   # full denoising (upstream default). Lower values mix
                                   # the noisy signal back in — drop to ~30 if DFN
                                   # over-suppresses quiet phonemes.
+post_tts_silence_ms = 1500        # Half-duplex gate (issue #15): ms to wait after aplay
+                                  # exits before allowing the next mic capture. Lets the
+                                  # ALSA hardware playback buffer drain and the speaker/
+                                  # room reverb decay below the whisper-server no-speech
+                                  # threshold — without it the next cycle's recording
+                                  # picks up the assistant's own TTS and whisper
+                                  # transcribes the assistant's voice as the next "user"
+                                  # utterance. Set to 0 on installs with full physical
+                                  # isolation (headphones / headset).
 voice_enabled = true              # Voice mode on by default in alpha.5 (push-to-talk).
                                   # Set false on hosts without whisper/piper installed.
 voice_record_secs = 3             # Seconds to record per voice interaction. Most


### PR DESCRIPTION
## Summary

- Closes #15. Fixes the speaker→mic acoustic echo that the #14 chase eventually traced to: when playback and capture share a room, whisper transcribes the assistant's own TTS as the next "user" utterance.
- `TtsEngine::speak()` now sleeps `post_tts_silence_ms` (default 1500 ms, configurable in `geniepod.toml`) after `aplay` exits. Lets the ALSA hardware buffer drain and the room reverb decay below whisper-server's no-speech threshold.
- `aec::process_aec` now drops stale echo references — anything older than `TTS_duration + 1500 ms` is cleared before NLMS runs, so push-to-talk captures aren't corrupted by convolving fresh user speech with old TTS PCM.

## Why this and not full AEC?

The existing NLMS AEC in `aec.rs` is designed for **barge-in** (user speaks during TTS — mic captures both signals, AEC subtracts the time-aligned reference). The #14 case is **push-to-talk**: mic opens after TTS finished. NLMS has nothing to time-align against, so it can't help. The right primitive is a half-duplex gate.

Full barge-in AEC stays as future work — the NLMS code is left in place and benefits from the stale-reference detection added here.

## Config

| key | default | meaning |
| --- | --- | --- |
| `post_tts_silence_ms` | `1500` | ms to sleep after `aplay` before the next mic capture is allowed. Drop to `0` on headphone / headset installs. |

## Test plan

- [ ] `make deploy JETSON_HOST=192.168.55.1 JETSON_USER=aihpc`
- [ ] On Jetson: `sudo systemctl stop genie-core && sudo -E /opt/geniepod/bin/genie-core`
- [ ] With speaker UNMUTED (the failure case from #14): say "Hello, this is testing" for 5+ cycles. Verify all transcribe correctly — no "thank you for watching", no LLM-response bleed.
- [ ] Verify the gate timing in the log: there's a ~1.5 s pause between `Piper generated audio, playing...` (after aplay exits) and the next `Press Enter to speak >`.
- [ ] Edge case: set `post_tts_silence_ms = 0` in `/etc/geniepod/geniepod.toml`, restart, confirm gate is bypassed (and confirm the bug reproduces — proves the gate is what's helping).
- [ ] Unit tests: `cargo test -p genie-core voice::aec::` — 4 pass including the new `process_aec_skips_stale_reference`.

## Notes

- The stale-reference detection in `aec.rs` was already present in the working tree from earlier exploratory work; this PR commits it alongside the half-duplex change since the two complement each other (one prevents adding echo bleed at capture time, the other prevents AEC from making clean captures worse after the fact).
- `.gitignore` finally gets `.DS_Store` rules; macOS finder kept slipping the file in.