### PR TITLE
Add genie-whisper-warmup.service to eliminate first-STT cold path (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+- `genie-whisper-warmup.service` (issue #17) — oneshot systemd unit ordered
+  `After=genie-whisper.service` that polls the whisper-server port and POSTs
+  one second of synthesized silence to `/inference`. Forces the ggml-small
+  weights and CUDA kernels into iGPU memory before the first user-visible
+  voice cycle, eliminating the 60-90 s first-STT cold path observed on
+  Orin Nano. Mirrors the existing `genie-llm-warmup.service` design from
+  PR #7. Wired into `setup-jetson.sh`'s enable loop; failures are non-fatal
+  (`|| true`) so a broken whisper does not block boot. Skips cleanly on
+  hosts without `sox` or `whisper-server`.
 - Half-duplex post-TTS gate to suppress speaker→mic acoustic echo (issue #15).
   `TtsEngine::speak()` now sleeps `post_tts_silence_ms` milliseconds after
   `aplay` exits. The ALSA hardware playback buffer continues draining for

--- a/deploy/setup-jetson.sh
+++ b/deploy/setup-jetson.sh
@@ -306,7 +306,7 @@ fi
 
 # Enable core services. genie-audio runs the I2S/AHUB route setup at boot
 # (no-op if /opt/geniepod/bin/genie-audio-init is missing, see ConditionPathExists).
-for svc in homeassistant genie-audio genie-whisper genie-llm genie-llm-warmup genie-core genie-governor genie-health genie-api genie-mqtt; do
+for svc in homeassistant genie-audio genie-whisper genie-whisper-warmup genie-llm genie-llm-warmup genie-core genie-governor genie-health genie-api genie-mqtt; do
     if sudo systemctl enable "$svc.service" 2>/dev/null; then
         echo "  Enabled: $svc"
     else

--- a/deploy/systemd/genie-whisper-warmup.service
+++ b/deploy/systemd/genie-whisper-warmup.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=GeniePod Whisper Warmup (force ggml-small into iGPU before first voice cycle)
+Documentation=https://github.com/GeniePod/genie-claw/issues/17
+After=genie-whisper.service
+Wants=genie-whisper.service
+ConditionPathExists=/opt/geniepod/bin/whisper-server
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Mirrors genie-llm-warmup.service (issue #3, PR #7): wait for the
+# whisper-server TCP port to open, then send one tiny /inference request
+# to force the ggml model load + CUDA kernels into iGPU memory. Without
+# this, the first user-visible voice cycle's STT can take 60-90 s on
+# Orin Nano while the model warms up in-band.
+#
+# The reference audio is 1 second of synthesized silence — whisper-server
+# decodes it (returns empty / "[BLANK_AUDIO]"), which is enough to load
+# weights and warm the kernels.
+#
+# Failures are non-fatal (|| true) so a broken whisper does not block boot.
+ExecStart=/bin/sh -c '\
+    for i in $(seq 1 90); do \
+        if nc -z 127.0.0.1 8178; then break; fi; \
+        sleep 1; \
+    done; \
+    if ! command -v sox > /dev/null 2>&1; then \
+        echo "[genie-whisper-warmup] sox not installed; skipping"; \
+        exit 0; \
+    fi; \
+    WAV=$(mktemp /tmp/whisper-warmup.XXXXXX.wav); \
+    sox -n -r 16000 -c 1 "$WAV" trim 0.0 1.0 2>/dev/null || { rm -f "$WAV"; echo "[genie-whisper-warmup] sox synth failed"; exit 0; }; \
+    curl -sf -X POST http://127.0.0.1:8178/inference \
+        -F "file=@$WAV" \
+        -F "language=en" \
+        -F "temperature=0.0" \
+        -F "response_format=json" > /dev/null || true; \
+    rm -f "$WAV"; \
+    echo "[genie-whisper-warmup] done"'
+TimeoutStartSec=180
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=geniepod.target


### PR DESCRIPTION
## Summary

- Closes #17. First voice cycle's STT was taking 60-90 s on Orin Nano because the whisper-server binary was up but the ggml-small weights weren't loaded into iGPU until the first `/inference` call.
- Mirrors PR #7's `genie-llm-warmup.service` design: a oneshot systemd unit ordered `After=genie-whisper.service` that polls the port, generates 1 s of silence via `sox`, and POSTs it to `/inference` to force the model + CUDA kernels into iGPU memory.
- Wired into `setup-jetson.sh`'s enable loop so `make deploy` + reboot ends with both LLM and whisper pre-loaded.

## Why generate silence inline instead of bundling a WAV?

No new asset to ship or version. `sox -n -r 16000 -c 1 ... trim 0.0 1.0` produces a valid 1 s silent mono WAV in <50 ms. If `sox` is missing, the unit no-ops with a journal message — same fallback pattern as the existing noise-profile capture in `setup-jetson.sh [5f/6]`.

## Test plan

- [ ] `make deploy JETSON_HOST=192.168.55.1 JETSON_USER=aihpc`
- [ ] On Jetson: `bash /opt/geniepod/setup-jetson.sh` — verify `Enabled: genie-whisper-warmup` in the `[6/6]` block.
- [ ] `sudo reboot`
- [ ] After reboot, before any voice activity: `journalctl -u genie-whisper-warmup -n 20` — expect `[genie-whisper-warmup] done` within ~10-30 s of boot.
- [ ] First voice cycle's STT should now be ~270-500 ms (warm), not 60-90 s.
- [ ] Smoke-test: `sudo systemctl stop genie-whisper && sudo systemctl restart genie-whisper-warmup` — should retry the warmup against the restarted server.

## Notes

- The unit POSTs with `language=en` to match the production decoder path (forces the English-only decoder weights, not just the multilingual model).
- TimeoutStartSec=180 covers up to 90 s of TCP-readiness polling plus the synthesized request itself. The whisper-server's own `TimeoutStartSec=120` (in `genie-whisper.service`) means the readiness poll usually succeeds within seconds.