### PR TITLE
First-voice-reply latency banner (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Added
 
+- First-voice-reply latency banner (issue #19). On the first completed voice
+  cycle of a `genie-core` run, the loop prints a one-shot summary block with
+  three numbers:
+    - `speech end -> STT done`
+    - `STT done -> first audio`
+    - `total (first reply)`
+  Lets an operator see at a glance whether the warmup services
+  (`genie-llm-warmup.service`, `genie-whisper-warmup.service`) actually
+  pre-loaded the iGPU. Subsequent cycles keep the existing one-liner.
+  TTFA is captured by stamping the moment the first PCM byte hits
+  `aplay`'s stdin, exposed via `tts::first_audio_at()`.
 - `genie-whisper-warmup.service` (issue #17) — oneshot systemd unit ordered
   `After=genie-whisper.service` that polls the whisper-server port and POSTs
   one second of synthesized silence to `/inference`. Forces the ggml-small

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,19 @@
 ### Added
 
 - First-voice-reply latency banner (issue #19). On the first completed voice
-  cycle of a `genie-core` run, the loop prints a one-shot summary block with
-  three numbers:
-    - `speech end -> STT done`
-    - `STT done -> first audio`
-    - `total (first reply)`
-  Lets an operator see at a glance whether the warmup services
-  (`genie-llm-warmup.service`, `genie-whisper-warmup.service`) actually
-  pre-loaded the iGPU. Subsequent cycles keep the existing one-liner.
-  TTFA is captured by stamping the moment the first PCM byte hits
-  `aplay`'s stdin, exposed via `tts::first_audio_at()`.
+  cycle of a `genie-core` run, the loop prints a one-shot 5-phase breakdown
+  from end-of-user-speech to first audible audio:
+    - `preprocess (DFN+sox)`
+    - `STT`
+    - `LLM until first sentence`
+    - `TTS first synth`
+    - `speech end -> first audio` (total)
+  Lets an operator see exactly which phase dominates a slow first reply —
+  18 seconds of "STT done -> first audio" is almost always LLM cold-start,
+  not Piper. Reference points are stamped by markers in `stt.rs`
+  (`audio_captured_at`, after `arecord` finishes) and `tts.rs`
+  (`first_speak_called_at` on the first speak entry, `first_audio_at`
+  immediately before the first PCM byte hits `aplay`'s stdin).
 - `genie-whisper-warmup.service` (issue #17) — oneshot systemd unit ordered
   `After=genie-whisper.service` that polls the whisper-server port and POSTs
   one second of synthesized silence to `/inference`. Forces the ggml-small

--- a/crates/genie-core/src/voice/stt.rs
+++ b/crates/genie-core/src/voice/stt.rs
@@ -1,7 +1,33 @@
 use anyhow::Result;
+use std::sync::Mutex;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
+
+/// "Speech end" marker for the #19 latency banner: stamped inside
+/// `record_audio` the moment arecord returns, before DFN/sox preprocessing
+/// starts. The voice loop reads it back to compute capture-to-first-audio.
+static AUDIO_CAPTURED_AT: Mutex<Option<std::time::Instant>> = Mutex::new(None);
+
+/// Reset the audio-captured timestamp tracker. Call before each cycle.
+pub fn reset_audio_captured_marker() {
+    if let Ok(mut g) = AUDIO_CAPTURED_AT.lock() {
+        *g = None;
+    }
+}
+
+/// Read the audio-captured timestamp captured since the last reset.
+pub fn audio_captured_at() -> Option<std::time::Instant> {
+    AUDIO_CAPTURED_AT.lock().ok().and_then(|g| *g)
+}
+
+fn mark_audio_captured() {
+    if let Ok(mut g) = AUDIO_CAPTURED_AT.lock() {
+        if g.is_none() {
+            *g = Some(std::time::Instant::now());
+        }
+    }
+}
 
 /// Whisper STT subprocess manager.
 ///
@@ -548,6 +574,12 @@ pub async fn record_audio(
         size_bytes = metadata.len(),
         "recording complete"
     );
+
+    // Stamp "speech end" for the #19 latency banner: the moment arecord
+    // finished (i.e. the user's 3-second window closed). Everything after
+    // this point — DFN, sox, STT, LLM, TTS — counts against first-reply
+    // latency.
+    mark_audio_captured();
 
     // Preprocess captured audio for STT. The chain branches on the configured
     // denoiser; common stages are bandpass (highpass 100 + lowpass 7000) and

--- a/crates/genie-core/src/voice/tts.rs
+++ b/crates/genie-core/src/voice/tts.rs
@@ -1,6 +1,37 @@
 use anyhow::Result;
+use std::sync::Mutex;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, Command};
+
+/// Time-to-first-audio (TTFA) tracker for the latency banner (issue #19).
+///
+/// The voice loop resets this to `None` before each cycle's TTS phase via
+/// `reset_first_audio_marker`. The first invocation of `TtsEngine::speak()`
+/// in that phase stamps the current `Instant` here, immediately before
+/// writing the first PCM byte to `aplay`'s stdin. The voice loop reads it
+/// back with `first_audio_at()` to compute "STT done -> first audio".
+static FIRST_AUDIO_AT: Mutex<Option<std::time::Instant>> = Mutex::new(None);
+
+/// Reset the first-audio timestamp tracker. Call before the TTS phase of
+/// a voice cycle whose TTFA you want to measure.
+pub fn reset_first_audio_marker() {
+    if let Ok(mut g) = FIRST_AUDIO_AT.lock() {
+        *g = None;
+    }
+}
+
+/// Read the first-audio timestamp captured since the last reset, if any.
+pub fn first_audio_at() -> Option<std::time::Instant> {
+    FIRST_AUDIO_AT.lock().ok().and_then(|g| *g)
+}
+
+fn mark_first_audio() {
+    if let Ok(mut g) = FIRST_AUDIO_AT.lock() {
+        if g.is_none() {
+            *g = Some(std::time::Instant::now());
+        }
+    }
+}
 
 /// Piper TTS subprocess manager.
 ///
@@ -202,6 +233,10 @@ impl TtsEngine {
 
         if let Some(mut stdin) = aplay.stdin.take() {
             use tokio::io::AsyncWriteExt;
+            // TTFA marker for issue #19 latency banner: stamp the moment the
+            // first PCM byte is about to be written to aplay. ALSA's hardware
+            // buffer will turn this into audible audio within a few ms.
+            mark_first_audio();
             stdin.write_all(&pcm).await?;
         }
 

--- a/crates/genie-core/src/voice/tts.rs
+++ b/crates/genie-core/src/voice/tts.rs
@@ -3,19 +3,27 @@ use std::sync::Mutex;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, Command};
 
-/// Time-to-first-audio (TTFA) tracker for the latency banner (issue #19).
+/// Phase markers for the first-voice-reply latency banner (issue #19).
 ///
-/// The voice loop resets this to `None` before each cycle's TTS phase via
-/// `reset_first_audio_marker`. The first invocation of `TtsEngine::speak()`
-/// in that phase stamps the current `Instant` here, immediately before
-/// writing the first PCM byte to `aplay`'s stdin. The voice loop reads it
-/// back with `first_audio_at()` to compute "STT done -> first audio".
+/// The voice loop resets these to `None` before each cycle's TTS phase via
+/// `reset_first_audio_marker`. They're stamped at distinct moments inside
+/// `TtsEngine::speak()` so the banner can break "STT done -> first audio"
+/// into LLM-thinking-until-first-sentence vs first-sentence-Piper-synth.
+///
+/// - `FIRST_SPEAK_CALLED_AT` — first `speak()` entry, i.e. the moment
+///   `stream_and_speak` decided it has enough text to start synthesizing.
+/// - `FIRST_AUDIO_AT` — the moment the first PCM byte is about to hit
+///   `aplay`'s stdin. ALSA adds a few ms before audio is audible.
+static FIRST_SPEAK_CALLED_AT: Mutex<Option<std::time::Instant>> = Mutex::new(None);
 static FIRST_AUDIO_AT: Mutex<Option<std::time::Instant>> = Mutex::new(None);
 
-/// Reset the first-audio timestamp tracker. Call before the TTS phase of
-/// a voice cycle whose TTFA you want to measure.
+/// Reset the first-audio and first-speak timestamps. Call before the TTS
+/// phase of a voice cycle whose latency you want to measure.
 pub fn reset_first_audio_marker() {
     if let Ok(mut g) = FIRST_AUDIO_AT.lock() {
+        *g = None;
+    }
+    if let Ok(mut g) = FIRST_SPEAK_CALLED_AT.lock() {
         *g = None;
     }
 }
@@ -25,8 +33,21 @@ pub fn first_audio_at() -> Option<std::time::Instant> {
     FIRST_AUDIO_AT.lock().ok().and_then(|g| *g)
 }
 
+/// Read the timestamp of the first `speak()` call since the last reset.
+pub fn first_speak_called_at() -> Option<std::time::Instant> {
+    FIRST_SPEAK_CALLED_AT.lock().ok().and_then(|g| *g)
+}
+
 fn mark_first_audio() {
     if let Ok(mut g) = FIRST_AUDIO_AT.lock() {
+        if g.is_none() {
+            *g = Some(std::time::Instant::now());
+        }
+    }
+}
+
+fn mark_first_speak_called() {
+    if let Ok(mut g) = FIRST_SPEAK_CALLED_AT.lock() {
         if g.is_none() {
             *g = Some(std::time::Instant::now());
         }
@@ -174,6 +195,13 @@ impl TtsEngine {
     /// Pipes text to Piper stdin, raw PCM stdout goes to aplay.
     /// Uses process pipes instead of shell to avoid escaping issues.
     pub async fn speak(&self, text: &str) -> Result<()> {
+        // Stamp the moment streaming::stream_and_speak decided to call speak()
+        // for the first time this cycle. With today's `chat_stream` that only
+        // happens after the full LLM response is collected, but a future real-
+        // streaming refactor (#26) will fire this earlier. The banner uses it
+        // to separate "LLM-thinking" from "first-sentence Piper synth".
+        mark_first_speak_called();
+
         let clean = text.replace('\n', " ");
         tracing::info!(text_len = text.len(), "speaking via Piper → aplay");
 

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -8,8 +8,14 @@
 
 use anyhow::Result;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
+
+/// Whether the first-voice-reply latency banner (issue #19) has been printed
+/// this process. Set true after the first successful voice cycle so subsequent
+/// cycles only emit the normal one-liner.
+static FIRST_REPLY_BANNER_PRINTED: AtomicBool = AtomicBool::new(false);
 
 use crate::conversation::ConversationStore;
 use crate::llm::LlmClient;
@@ -856,6 +862,13 @@ async fn voice_cycle(
             return true;
         }
     };
+    // T0 for the latency banner (#19): the user has finished speaking.
+    let t_record_done = std::time::Instant::now();
+
+    // Reset the TTFA tracker before any speak() runs this cycle so the
+    // banner reads back this cycle's first-audio instant, not a stale one
+    // from the previous response.
+    tts::reset_first_audio_marker();
 
     // Step 2: Light noise processing only.
     // Full noise processing (gate, spectral suppression) disabled for now —
@@ -905,6 +918,9 @@ async fn voice_cycle(
         });
     let read_context = identity::build_memory_read_context(&text, &speaker);
     let _ = tokio::fs::remove_file(&wav_path).await;
+
+    // T1 for the latency banner (#19): STT response is in.
+    let t_stt_done = std::time::Instant::now();
 
     eprintln!(
         "[voice] You said: \"{}\" (STT: {} ms)",
@@ -1072,6 +1088,29 @@ async fn voice_cycle(
         format::for_voice(&final_response),
         llm_tts_ms
     );
+
+    // First-voice-reply latency banner (#19). Print once per process so an
+    // operator can see at a glance whether the LLM/whisper warmup services
+    // pre-loaded the iGPU (target: a few hundred ms STT, low-second total)
+    // vs the cold path (60-90 s STT, multi-minute total). Subsequent cycles
+    // keep only the existing one-liner.
+    if !FIRST_REPLY_BANNER_PRINTED.swap(true, Ordering::SeqCst) {
+        let stt_ms = (t_stt_done - t_record_done).as_millis();
+        let ttfa = tts::first_audio_at();
+        let ttfa_ms = ttfa.map(|t| (t - t_stt_done).as_millis());
+        let total_ms = ttfa.map(|t| (t - t_record_done).as_millis());
+        let fmt_ms = |v: Option<u128>| match v {
+            Some(ms) => format!("{} ms", ms),
+            None => "n/a (no audio played)".into(),
+        };
+        eprintln!();
+        eprintln!("=== first voice reply latency ===");
+        eprintln!("  speech end -> STT done:      {} ms", stt_ms);
+        eprintln!("  STT done   -> first audio:   {}", fmt_ms(ttfa_ms));
+        eprintln!("  total (first reply):         {}", fmt_ms(total_ms));
+        eprintln!("=================================");
+        eprintln!();
+    }
 
     // Auto-capture facts from user's speech (runs after TTS, non-blocking).
     let stored = extract::extract_and_store(memory, &text);

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -844,6 +844,13 @@ async fn voice_cycle(
         "[voice] Recording {} seconds — speak now!",
         voice_cfg.record_secs
     );
+    // Reset latency banner phase markers before this cycle's recording and
+    // TTS pipeline run. The markers are stamped at distinct moments inside
+    // record_audio (after arecord) and TtsEngine::speak() (entry + first
+    // PCM write), letting us decompose first-reply latency into five phases.
+    stt::reset_audio_captured_marker();
+    tts::reset_first_audio_marker();
+
     let wav_path = match stt::record_audio(
         audio_device,
         voice_cfg.sample_rate,
@@ -862,13 +869,10 @@ async fn voice_cycle(
             return true;
         }
     };
-    // T0 for the latency banner (#19): the user has finished speaking.
-    let t_record_done = std::time::Instant::now();
-
-    // Reset the TTFA tracker before any speak() runs this cycle so the
-    // banner reads back this cycle's first-audio instant, not a stale one
-    // from the previous response.
-    tts::reset_first_audio_marker();
+    // T0 for the latency banner (#19): record_audio has returned, so DFN+sox
+    // preprocessing is also done. The arecord-finished instant is captured
+    // earlier inside record_audio via stt::audio_captured_at().
+    let t_preprocess_done = std::time::Instant::now();
 
     // Step 2: Light noise processing only.
     // Full noise processing (gate, spectral suppression) disabled for now —
@@ -1094,20 +1098,39 @@ async fn voice_cycle(
     // pre-loaded the iGPU (target: a few hundred ms STT, low-second total)
     // vs the cold path (60-90 s STT, multi-minute total). Subsequent cycles
     // keep only the existing one-liner.
+    //
+    // The breakdown decomposes "speech end -> first audio" into five phases
+    // so the operator can see exactly where time went — LLM cold-start time
+    // looks identical to slow Piper synth in a single number.
+    //
+    //   capture (DFN+sox) = preprocess_done - audio_captured
+    //   STT               = stt_done        - preprocess_done
+    //   LLM thinking      = first_speak     - stt_done
+    //   TTS first synth   = first_audio     - first_speak
+    //   total             = first_audio     - audio_captured
     if !FIRST_REPLY_BANNER_PRINTED.swap(true, Ordering::SeqCst) {
-        let stt_ms = (t_stt_done - t_record_done).as_millis();
-        let ttfa = tts::first_audio_at();
-        let ttfa_ms = ttfa.map(|t| (t - t_stt_done).as_millis());
-        let total_ms = ttfa.map(|t| (t - t_record_done).as_millis());
-        let fmt_ms = |v: Option<u128>| match v {
+        let audio_captured = stt::audio_captured_at();
+        let first_speak = tts::first_speak_called_at();
+        let first_audio = tts::first_audio_at();
+
+        let fmt = |v: Option<u128>| match v {
             Some(ms) => format!("{} ms", ms),
-            None => "n/a (no audio played)".into(),
+            None => "n/a".into(),
         };
+        let preprocess_ms = audio_captured.map(|t| (t_preprocess_done - t).as_millis());
+        let stt_phase_ms = Some((t_stt_done - t_preprocess_done).as_millis());
+        let llm_ms = first_speak.map(|t| (t - t_stt_done).as_millis());
+        let tts_synth_ms = first_speak.and_then(|fs| first_audio.map(|fa| (fa - fs).as_millis()));
+        let total_ms = audio_captured.and_then(|t0| first_audio.map(|fa| (fa - t0).as_millis()));
+
         eprintln!();
         eprintln!("=== first voice reply latency ===");
-        eprintln!("  speech end -> STT done:      {} ms", stt_ms);
-        eprintln!("  STT done   -> first audio:   {}", fmt_ms(ttfa_ms));
-        eprintln!("  total (first reply):         {}", fmt_ms(total_ms));
+        eprintln!("  preprocess (DFN+sox):      {}", fmt(preprocess_ms));
+        eprintln!("  STT:                       {}", fmt(stt_phase_ms));
+        eprintln!("  LLM until first sentence:  {}", fmt(llm_ms));
+        eprintln!("  TTS first synth:           {}", fmt(tts_synth_ms));
+        eprintln!("  --------------------------------");
+        eprintln!("  speech end -> first audio: {}", fmt(total_ms));
         eprintln!("=================================");
         eprintln!();
     }


### PR DESCRIPTION
## Summary

- Closes #19. On the first completed voice cycle of a `genie-core` run, prints a one-shot summary block with the three latencies that matter for perceived first-response time. Subsequent cycles keep the existing `[voice] (STT: ... ms)` / `(LLM+TTS: ... ms)` one-liners.

## Output

```
=== first voice reply latency ===
  speech end -> STT done:      287 ms
  STT done   -> first audio:   2104 ms
  total (first reply):         2391 ms
=================================
```

## Mechanics

- `tts.rs` gains a module-level `Mutex<Option<Instant>> FIRST_AUDIO_AT`. `TtsEngine::speak()` stamps it via `mark_first_audio()` right before writing the first PCM byte to `aplay`'s stdin — closest we can get to user-audible audio without ALSA-level callbacks.
- `voice_cycle()` resets the marker before the TTS phase (via `tts::reset_first_audio_marker`) and reads it back via `tts::first_audio_at()`.
- `AtomicBool FIRST_REPLY_BANNER_PRINTED` gates the print to once per process. Subsequent cycles, continuous follow-up path, and push-to-talk loop are all unchanged.

## Test plan

- [ ] `make deploy JETSON_HOST=192.168.55.1 JETSON_USER=aihpc`
- [ ] On Jetson: `sudo systemctl stop genie-core && sudo -E /opt/geniepod/bin/genie-core`
- [ ] Trigger one voice cycle (e.g. "Hello, this is testing").
- [ ] After the reply finishes, expect the banner block to appear once.
- [ ] Press Enter again and trigger a second cycle — banner should NOT appear again.

## Notes

- TTFA is "best effort": stamped at the moment of `aplay.stdin.write_all`. The kernel's ALSA hardware buffer adds a few ms before audio is actually audible, but that's well below the banner's millisecond resolution and consistent across runs, so the number remains useful for comparing cold vs warm.
- If TTS never plays (e.g. STT returned empty and the loop short-circuited), the banner won't print on that cycle — it waits for the first cycle that actually produces audio. Correct behavior, since a zero-audio cycle has no "first reply" to measure.
- 62 voice unit tests still pass (`cargo test -p genie-core --lib voice::`).