### PR TITLE
llm: introduce backend facade

### DIFF
--- a/crates/genie-core/src/llm/genie_ai_runtime.rs
+++ b/crates/genie-core/src/llm/genie_ai_runtime.rs
@@ -1,0 +1,55 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::openai_compat::OpenAiCompatClient;
+use super::{LlmBackendClient, Message, ResponseFormat};
+
+/// Adapter for the `genie-ai-runtime` OpenAI-compatible chat API surface.
+pub struct GenieAiRuntimeBackend {
+    inner: OpenAiCompatClient,
+}
+
+impl GenieAiRuntimeBackend {
+    pub fn new(host: &str, port: u16) -> Self {
+        Self {
+            inner: OpenAiCompatClient::new("genie-ai-runtime", host, port),
+        }
+    }
+
+    pub fn from_url(url: &str) -> Self {
+        Self {
+            inner: OpenAiCompatClient::from_url("genie-ai-runtime", url),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmBackendClient for GenieAiRuntimeBackend {
+    fn backend_name(&self) -> &str {
+        self.inner.backend_name()
+    }
+
+    async fn health(&self) -> bool {
+        self.inner.health().await
+    }
+
+    async fn chat_with_format(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+    ) -> Result<String> {
+        self.inner
+            .chat_with_format(messages, max_tokens, response_format)
+            .await
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String> {
+        self.inner.chat_stream(messages, max_tokens, on_token).await
+    }
+}

--- a/crates/genie-core/src/llm/llama_cpp.rs
+++ b/crates/genie-core/src/llm/llama_cpp.rs
@@ -1,0 +1,55 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::openai_compat::OpenAiCompatClient;
+use super::{LlmBackendClient, Message, ResponseFormat};
+
+/// llama.cpp `--server` adapter for the OpenAI-compatible chat API.
+pub struct LlamaCppBackend {
+    inner: OpenAiCompatClient,
+}
+
+impl LlamaCppBackend {
+    pub fn new(host: &str, port: u16) -> Self {
+        Self {
+            inner: OpenAiCompatClient::new("llama.cpp", host, port),
+        }
+    }
+
+    pub fn from_url(url: &str) -> Self {
+        Self {
+            inner: OpenAiCompatClient::from_url("llama.cpp", url),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmBackendClient for LlamaCppBackend {
+    fn backend_name(&self) -> &str {
+        self.inner.backend_name()
+    }
+
+    async fn health(&self) -> bool {
+        self.inner.health().await
+    }
+
+    async fn chat_with_format(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+    ) -> Result<String> {
+        self.inner
+            .chat_with_format(messages, max_tokens, response_format)
+            .await
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String> {
+        self.inner.chat_stream(messages, max_tokens, on_token).await
+    }
+}

--- a/crates/genie-core/src/llm/mod.rs
+++ b/crates/genie-core/src/llm/mod.rs
@@ -1,6 +1,136 @@
-mod client;
+mod genie_ai_runtime;
+mod llama_cpp;
+mod openai_compat;
 mod retry;
 
-pub use client::{LlmClient, Message};
+use anyhow::Result;
+use async_trait::async_trait;
+
+pub use genie_ai_runtime::GenieAiRuntimeBackend;
+pub use llama_cpp::LlamaCppBackend;
+pub use openai_compat::{Message, ResponseFormat};
 #[allow(unused_imports)]
 pub use retry::RetryLlmClient;
+
+#[async_trait]
+pub trait LlmBackendClient: Send + Sync {
+    fn backend_name(&self) -> &str;
+
+    async fn health(&self) -> bool;
+
+    async fn chat_with_format(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+    ) -> Result<String>;
+
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String>;
+}
+
+/// LLM client facade used by agent orchestration.
+///
+/// The public constructors preserve the legacy llama.cpp default. Backend
+/// selection and config plumbing will be layered on top of this facade in a
+/// follow-up PR.
+pub struct LlmClient {
+    backend: Box<dyn LlmBackendClient>,
+}
+
+impl LlmClient {
+    pub fn new(host: &str, port: u16) -> Self {
+        Self::llama_cpp(host, port)
+    }
+
+    pub fn from_url(url: &str) -> Self {
+        Self::from_llama_cpp_url(url)
+    }
+
+    pub fn llama_cpp(host: &str, port: u16) -> Self {
+        Self {
+            backend: Box::new(LlamaCppBackend::new(host, port)),
+        }
+    }
+
+    pub fn from_llama_cpp_url(url: &str) -> Self {
+        Self {
+            backend: Box::new(LlamaCppBackend::from_url(url)),
+        }
+    }
+
+    pub fn genie_ai_runtime(host: &str, port: u16) -> Self {
+        Self {
+            backend: Box::new(GenieAiRuntimeBackend::new(host, port)),
+        }
+    }
+
+    pub fn from_genie_ai_runtime_url(url: &str) -> Self {
+        Self {
+            backend: Box::new(GenieAiRuntimeBackend::from_url(url)),
+        }
+    }
+
+    pub fn backend_name(&self) -> &str {
+        self.backend.backend_name()
+    }
+
+    pub async fn health(&self) -> bool {
+        self.backend.health().await
+    }
+
+    pub async fn chat(&self, messages: &[Message], max_tokens: Option<u32>) -> Result<String> {
+        self.chat_with_format(messages, max_tokens, None).await
+    }
+
+    pub async fn chat_json(&self, messages: &[Message], max_tokens: Option<u32>) -> Result<String> {
+        self.chat_with_format(messages, max_tokens, Some(ResponseFormat::json()))
+            .await
+    }
+
+    pub async fn chat_with_format(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+    ) -> Result<String> {
+        self.backend
+            .chat_with_format(messages, max_tokens, response_format)
+            .await
+    }
+
+    pub async fn chat_stream<F>(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        mut on_token: F,
+    ) -> Result<String>
+    where
+        F: FnMut(&str) + Send,
+    {
+        self.backend
+            .chat_stream(messages, max_tokens, &mut on_token)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_constructor_keeps_llama_cpp_default() {
+        let client = LlmClient::from_url("http://127.0.0.1:8080/health");
+        assert_eq!(client.backend_name(), "llama.cpp");
+    }
+
+    #[test]
+    fn can_construct_genie_ai_runtime_client() {
+        let client = LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:8080/health");
+        assert_eq!(client.backend_name(), "genie-ai-runtime");
+    }
+}

--- a/crates/genie-core/src/llm/openai_compat.rs
+++ b/crates/genie-core/src/llm/openai_compat.rs
@@ -3,29 +3,29 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
-/// Client for llama.cpp `--server` OpenAI-compatible API.
+/// Raw HTTP client for local OpenAI-compatible chat completion backends.
 ///
 /// Supports both blocking completion and streaming (SSE).
 /// No reqwest/hyper — raw HTTP over TCP to localhost.
-pub struct LlmClient {
+pub struct OpenAiCompatClient {
+    backend_name: &'static str,
     host: String,
     port: u16,
 }
 
 #[derive(Debug, Serialize)]
-pub struct ChatRequest {
-    pub model: String,
-    pub messages: Vec<Message>,
+pub(crate) struct ChatRequest {
+    pub(crate) model: String,
+    pub(crate) messages: Vec<Message>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tokens: Option<u32>,
+    pub(crate) max_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub temperature: Option<f32>,
-    pub stream: bool,
-    /// JSON schema constraint — forces the LLM to output valid JSON matching this schema.
-    /// Supported by llama.cpp `--server` via the `response_format` parameter.
-    /// When set, eliminates tool-calling parsing failures.
+    pub(crate) temperature: Option<f32>,
+    pub(crate) stream: bool,
+    /// JSON schema constraint for backends that support OpenAI-compatible
+    /// `response_format`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_format: Option<ResponseFormat>,
+    pub(crate) response_format: Option<ResponseFormat>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -61,20 +61,20 @@ pub struct Message {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct ChatResponse {
-    pub choices: Vec<Choice>,
+pub(crate) struct ChatResponse {
+    pub(crate) choices: Vec<Choice>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Choice {
-    pub message: Option<Message>,
-    pub delta: Option<Delta>,
-    pub finish_reason: Option<String>,
+pub(crate) struct Choice {
+    pub(crate) message: Option<Message>,
+    pub(crate) delta: Option<Delta>,
+    pub(crate) finish_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Delta {
-    pub content: Option<String>,
+pub(crate) struct Delta {
+    pub(crate) content: Option<String>,
 }
 
 #[derive(Debug)]
@@ -83,23 +83,29 @@ struct HttpResponse {
     body: String,
 }
 
-impl LlmClient {
-    pub fn new(host: &str, port: u16) -> Self {
+impl OpenAiCompatClient {
+    pub fn new(backend_name: &'static str, host: &str, port: u16) -> Self {
         Self {
+            backend_name,
             host: host.to_string(),
             port,
         }
     }
 
-    pub fn from_url(url: &str) -> Self {
+    pub fn from_url(backend_name: &'static str, url: &str) -> Self {
         let stripped = url.strip_prefix("http://").unwrap_or(url);
         let (host_port, _) = stripped.split_once('/').unwrap_or((stripped, ""));
         let (host, port_str) = host_port.split_once(':').unwrap_or((host_port, "8080"));
         let port = port_str.parse().unwrap_or(8080);
         Self {
+            backend_name,
             host: host.to_string(),
             port,
         }
+    }
+
+    pub fn backend_name(&self) -> &str {
+        self.backend_name
     }
 
     /// Send a chat completion request, return the full response.
@@ -108,7 +114,7 @@ impl LlmClient {
     }
 
     /// Send a chat request forcing JSON output.
-    /// Uses llama.cpp's grammar constraint to guarantee valid JSON.
+    /// Uses backend response-format support when available.
     /// Eliminates tool-calling parsing failures.
     pub async fn chat_json(&self, messages: &[Message], max_tokens: Option<u32>) -> Result<String> {
         self.chat_with_format(messages, max_tokens, Some(ResponseFormat::json()))
@@ -155,15 +161,17 @@ impl LlmClient {
         let response = self.http_post("/v1/chat/completions", &body).await?;
         if response.status != 200 {
             anyhow::bail!(
-                "llama.cpp {}: {}",
+                "{} {}: {}",
+                self.backend_name,
                 response.status,
-                llama_error_message(&response.body)
+                backend_error_message(&response.body)
             );
         }
 
         let chat_resp: ChatResponse = serde_json::from_str(&response.body).map_err(|e| {
             anyhow::anyhow!(
-                "failed to parse llama.cpp response: {}; body: {}",
+                "failed to parse {} response: {}; body: {}",
+                self.backend_name,
                 e,
                 truncate_body(&response.body)
             )
@@ -180,15 +188,12 @@ impl LlmClient {
 
     /// Send a streaming chat request. Calls `on_token` for each token as it arrives.
     /// Returns the full assembled response.
-    pub async fn chat_stream<F>(
+    pub async fn chat_stream(
         &self,
         messages: &[Message],
         max_tokens: Option<u32>,
-        mut on_token: F,
-    ) -> Result<String>
-    where
-        F: FnMut(&str),
-    {
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String> {
         let request = ChatRequest {
             model: "default".into(),
             messages: messages.to_vec(),
@@ -231,7 +236,12 @@ impl LlmClient {
                         while let Some(line) = lines.next_line().await? {
                             error_body.push_str(&line);
                         }
-                        anyhow::bail!("llama.cpp {}: {}", status, llama_error_message(&error_body));
+                        anyhow::bail!(
+                            "{} {}: {}",
+                            self.backend_name,
+                            status,
+                            backend_error_message(&error_body)
+                        );
                     }
                 }
                 continue;
@@ -416,7 +426,7 @@ fn flatten_system_into_first_user(messages: &[Message]) -> Vec<Message> {
     flattened
 }
 
-fn llama_error_message(body: &str) -> String {
+fn backend_error_message(body: &str) -> String {
     serde_json::from_str::<serde_json::Value>(body)
         .ok()
         .and_then(|json| {
@@ -449,7 +459,7 @@ mod tests {
 
     #[test]
     fn parse_url() {
-        let client = LlmClient::from_url("http://127.0.0.1:8080/v1");
+        let client = OpenAiCompatClient::from_url("test-backend", "http://127.0.0.1:8080/v1");
         assert_eq!(client.host, "127.0.0.1");
         assert_eq!(client.port, 8080);
     }

--- a/crates/genie-core/src/llm/retry.rs
+++ b/crates/genie-core/src/llm/retry.rs
@@ -2,12 +2,12 @@ use std::time::Duration;
 
 use anyhow::Result;
 
-use super::client::{LlmClient, Message};
+use super::{LlmClient, Message};
 
 /// LLM client with retry logic and graceful degradation.
 ///
 /// Wraps LlmClient to handle:
-/// - Connection failures (llama.cpp restarting during governor mode switch)
+/// - Connection failures (backend restarting during governor mode switch)
 /// - Timeout on slow responses (large context, cold model)
 /// - Graceful fallback messages when LLM is completely unavailable
 pub struct RetryLlmClient {
@@ -87,14 +87,14 @@ impl RetryLlmClient {
         &self,
         messages: &[Message],
         max_tokens: Option<u32>,
-        on_token: F,
+        mut on_token: F,
     ) -> String
     where
-        F: FnMut(&str),
+        F: FnMut(&str) + Send,
     {
         match tokio::time::timeout(
             self.timeout,
-            self.inner.chat_stream(messages, max_tokens, on_token),
+            self.inner.chat_stream(messages, max_tokens, &mut on_token),
         )
         .await
         {


### PR DESCRIPTION
## Summary
- First slice for #32, intentionally limited to `crates/genie-core/src/llm/`.
- Preserves the public `LlmClient` API and keeps `llama.cpp` as the default path.
- Extracts the raw OpenAI-compatible HTTP/SSE client behind a backend facade.
- Adds `llama_cpp` and `genie_ai_runtime` backend adapters without wiring config yet.
- Widens the `chat_stream` stream error object with `Send` so backend implementations satisfy the async trait boundary.

## Split plan
This PR is a preparatory slice and does not close #32 by itself. I opened it from `carlos4s:issue-32-llm-backend-abstraction` so the maintainer can review/merge the LLM-module boundary first.

Follow-up PRs can layer on:
- `services.llm.backend` config parsing and legacy default behavior.
- Startup/governor/service-unit plumbing for backend selection.
- Docs and CI/backend matrix updates.

## Tests
- `cargo check -p genie-core`
- `cargo test -p genie-core llm::`
- `cargo test -p genie-core`

Note: one unrelated memory-promotion test failed on the first full run, then passed when rerun directly and the second full `cargo test -p genie-core` run passed cleanly.