### PR TITLE
chore: fix fmt + clippy drift in genie-core/voice (issue #34 prep)

### DIFF
--- a/crates/genie-core/src/voice/aec.rs
+++ b/crates/genie-core/src/voice/aec.rs
@@ -338,6 +338,10 @@ mod tests {
         assert!(!has_ref, "Reference should be cleared");
     }
 
+    // TEST_LOCK serializes tests that touch the global ECHO_REF; the guard is
+    // intentionally held across awaits because it only gates other tests in
+    // this module, never production code.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn process_aec_skips_stale_reference() {
         let _guard = TEST_LOCK.lock().unwrap();

--- a/crates/genie-core/src/voice/stt.rs
+++ b/crates/genie-core/src/voice/stt.rs
@@ -22,10 +22,10 @@ pub fn audio_captured_at() -> Option<std::time::Instant> {
 }
 
 fn mark_audio_captured() {
-    if let Ok(mut g) = AUDIO_CAPTURED_AT.lock() {
-        if g.is_none() {
-            *g = Some(std::time::Instant::now());
-        }
+    if let Ok(mut g) = AUDIO_CAPTURED_AT.lock()
+        && g.is_none()
+    {
+        *g = Some(std::time::Instant::now());
     }
 }
 
@@ -213,8 +213,7 @@ impl SttEngine {
         );
         let body_end = format!("\r\n--{boundary}--\r\n");
 
-        let content_length =
-            text_parts.len() + file_part.len() + wav_data.len() + body_end.len();
+        let content_length = text_parts.len() + file_part.len() + wav_data.len() + body_end.len();
 
         let stream = tokio::net::TcpStream::connect(&addr).await?;
         let (reader, mut writer) = stream.into_split();
@@ -469,10 +468,10 @@ pub async fn flush_mic_buffer(device: &str, sample_rate: u32) {
 /// Variants in increasing strength / latency:
 /// - `None`        — bandpass + peak-normalize only (debug / no-denoise A/B)
 /// - `Sox`         — sox `noisered` spectral subtraction against a per-host
-///                   noise profile (alpha.6 baseline, see PR #11)
+///   noise profile (alpha.6 baseline, see PR #11)
 /// - `DeepFilterNet` — neural denoiser via the `deep-filter` subprocess
-///                   (alpha.7, see issue #12). Handles non-stationary noise
-///                   without a noise profile.
+///   (alpha.7, see issue #12). Handles non-stationary noise
+///   without a noise profile.
 #[derive(Debug, Clone)]
 pub enum Denoiser {
     None,
@@ -487,11 +486,7 @@ pub enum Denoiser {
 
 impl Denoiser {
     /// Build from VoiceConfig strings. Unknown values default to `None`.
-    pub fn from_config(
-        kind: &str,
-        deep_filter_path: &str,
-        deep_filter_atten_lim_db: f32,
-    ) -> Self {
+    pub fn from_config(kind: &str, deep_filter_path: &str, deep_filter_atten_lim_db: f32) -> Self {
         match kind {
             "deepfilternet" | "deep_filter" | "dfn" => Denoiser::DeepFilterNet {
                 binary_path: deep_filter_path.to_string(),
@@ -619,11 +614,14 @@ async fn preprocess_capture(wav_path: &str, denoiser: &Denoiser) -> Result<Strin
         Denoiser::DeepFilterNet {
             binary_path,
             atten_lim_db,
-        } => {
-            run_deepfilternet_chain(wav_path, &normalized_path, binary_path, *atten_lim_db).await
-        }
+        } => run_deepfilternet_chain(wav_path, &normalized_path, binary_path, *atten_lim_db).await,
         Denoiser::Sox { noise_profile_path } => {
-            run_sox_chain(wav_path, &normalized_path, Some(noise_profile_path.as_str())).await
+            run_sox_chain(
+                wav_path,
+                &normalized_path,
+                Some(noise_profile_path.as_str()),
+            )
+            .await
         }
         Denoiser::None => run_sox_chain(wav_path, &normalized_path, None).await,
     }
@@ -658,12 +656,7 @@ async fn run_sox_chain(
     // compand: 20 ms attack / 200 ms release, floor at -50 dBFS, +13 dB lift on
     // quiet speech (-25 -> -12), loud speech (-5) held to avoid clip, -2 dB
     // makeup offset.
-    sox_cmd.args([
-        "compand",
-        "0.02,0.20",
-        "-50,-50,-25,-12,-5,-5",
-        "-2",
-    ]);
+    sox_cmd.args(["compand", "0.02,0.20", "-50,-50,-25,-12,-5,-5", "-2"]);
     sox_cmd.args(["gain", "-n", "-3"]);
 
     match sox_cmd.output().await {
@@ -756,7 +749,10 @@ async fn run_deepfilternet_chain(
     if !stage1_ok {
         if let Ok(o) = stage1 {
             tracing::warn!(
-                stderr = String::from_utf8_lossy(&o.stderr).lines().next().unwrap_or(""),
+                stderr = String::from_utf8_lossy(&o.stderr)
+                    .lines()
+                    .next()
+                    .unwrap_or(""),
                 "sox stage 1 (downmix+bandpass) failed; falling back to sox chain"
             );
         }
@@ -783,7 +779,10 @@ async fn run_deepfilternet_chain(
     if !dfn_ok {
         if let Ok(o) = dfn_res {
             tracing::warn!(
-                stderr = String::from_utf8_lossy(&o.stderr).lines().next().unwrap_or(""),
+                stderr = String::from_utf8_lossy(&o.stderr)
+                    .lines()
+                    .next()
+                    .unwrap_or(""),
                 "deep-filter run failed; falling back to sox chain"
             );
         } else if let Err(ref e) = dfn_res {
@@ -812,7 +811,10 @@ async fn run_deepfilternet_chain(
     if !stage3_ok {
         if let Ok(o) = stage3 {
             tracing::warn!(
-                stderr = String::from_utf8_lossy(&o.stderr).lines().next().unwrap_or(""),
+                stderr = String::from_utf8_lossy(&o.stderr)
+                    .lines()
+                    .next()
+                    .unwrap_or(""),
                 "sox stage 3 (peak-normalize) failed; falling back to sox chain"
             );
         }

--- a/crates/genie-core/src/voice/tts.rs
+++ b/crates/genie-core/src/voice/tts.rs
@@ -39,18 +39,18 @@ pub fn first_speak_called_at() -> Option<std::time::Instant> {
 }
 
 fn mark_first_audio() {
-    if let Ok(mut g) = FIRST_AUDIO_AT.lock() {
-        if g.is_none() {
-            *g = Some(std::time::Instant::now());
-        }
+    if let Ok(mut g) = FIRST_AUDIO_AT.lock()
+        && g.is_none()
+    {
+        *g = Some(std::time::Instant::now());
     }
 }
 
 fn mark_first_speak_called() {
-    if let Ok(mut g) = FIRST_SPEAK_CALLED_AT.lock() {
-        if g.is_none() {
-            *g = Some(std::time::Instant::now());
-        }
+    if let Ok(mut g) = FIRST_SPEAK_CALLED_AT.lock()
+        && g.is_none()
+    {
+        *g = Some(std::time::Instant::now());
     }
 }
 

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -98,22 +98,21 @@ pub async fn run(
     // Auto-detect playback device. Uses a separate helper-script invocation
     // with output=1 so it prefers USB audio (headphone/headset) over the
     // capture-only LyraT I2S path.
-    let audio_output_device = if voice_cfg.audio_output_device.is_empty()
-        || voice_cfg.audio_output_device == "auto"
-    {
-        match detect_audio_output_device().await {
-            Some(dev) => {
-                tracing::info!(device = %dev, "auto-detected playback device");
-                dev
+    let audio_output_device =
+        if voice_cfg.audio_output_device.is_empty() || voice_cfg.audio_output_device == "auto" {
+            match detect_audio_output_device().await {
+                Some(dev) => {
+                    tracing::info!(device = %dev, "auto-detected playback device");
+                    dev
+                }
+                None => {
+                    tracing::warn!("no playback device found, falling back to 'default'");
+                    "default".to_string()
+                }
             }
-            None => {
-                tracing::warn!("no playback device found, falling back to 'default'");
-                "default".to_string()
-            }
-        }
-    } else {
-        voice_cfg.audio_output_device.clone()
-    };
+        } else {
+            voice_cfg.audio_output_device.clone()
+        };
 
     eprintln!(
         "[voice] Capture device: {}  |  Playback device: {}",


### PR DESCRIPTION
Preparation work for issue #34 (CI pipeline). On `rustc 1.95` the current `main` has small fmt and clippy drift that the new `cargo fmt --check` + `cargo clippy -- -D warnings` jobs would block on. This PR is the minimal, mechanical cleanup to make the tree green so the CI workflows in the follow-up PRs pass on day 1.

## Changes

- **`voice/stt.rs`, `voice/tts.rs`** — collapse three `if let Ok(_) { if … }` chains into the `if let Ok(_) && …` let-chain form (`clippy::collapsible_if`).
- **`voice/stt.rs`** — fix doc-list indentation on the `Denoiser` enum docs (`clippy::doc_list_item_overindented`).
- **`voice/aec.rs`** — annotate `process_aec_skips_stale_reference` with `#[allow(clippy::await_holding_lock)]` plus a comment explaining the test-serialization role. The std `TEST_LOCK` Mutex serializes ECHO_REF tests; holding it across awaits is safe because it gates only sibling tests in this module, never production code.
- **`voice_loop.rs`** — apply rustfmt's preferred line-wrapping for the `audio_output_device` if/else (cosmetic, no behavior change).

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked --all-targets` — 457 tests pass

No public API changes. No runtime behavior changes.

Refs #34.
