### PR TITLE
voice: report configured llm backend

### DIFF
--- a/crates/genie-core/src/voice/mod.rs
+++ b/crates/genie-core/src/voice/mod.rs
@@ -103,10 +103,14 @@ impl VoiceOrchestrator {
         tracing::info!("GeniePod core ready — type a message (or Ctrl+C to quit)");
 
         // Check LLM health.
+        let backend_name = self.llm.backend_name();
         if self.llm.health().await {
-            tracing::info!("LLM server connected");
+            tracing::info!(backend = %backend_name, "LLM backend connected");
         } else {
-            tracing::warn!("LLM server not reachable — will retry on first request");
+            tracing::warn!(
+                backend = %backend_name,
+                "LLM backend not reachable; will retry on first request"
+            );
         }
 
         let stdin = tokio::io::BufReader::new(tokio::io::stdin());

--- a/crates/genie-core/src/voice/pipeline.rs
+++ b/crates/genie-core/src/voice/pipeline.rs
@@ -127,7 +127,11 @@ impl VoicePipeline {
         let response = match stream_result {
             Ok(r) => r,
             Err(e) => {
-                tracing::error!(error = %e, "LLM error");
+                tracing::error!(
+                    error = %e,
+                    backend = %self.llm.backend_name(),
+                    "LLM backend error"
+                );
                 return Ok(("Sorry, I couldn't process that.".into(), None));
             }
         };

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -149,9 +149,9 @@ pub async fn run(
     tracing::info!(conv_id = %conv_id, "voice conversation started");
 
     if llm.health().await {
-        eprintln!("[voice] LLM server connected");
+        eprintln!("{}", llm_connected_message(llm.backend_name()));
     } else {
-        eprintln!("[voice] WARNING: LLM not reachable — start llama-server first!");
+        eprintln!("{}", llm_unreachable_message(llm.backend_name()));
     }
 
     let use_wakeword = !voice_cfg.wakeword_script.is_empty()
@@ -428,7 +428,11 @@ async fn run_with_wakeword(
                                     eprintln!("[voice] GeniePod: {}", format::for_voice(&response));
                                 }
                                 Err(e) => {
-                                    eprintln!("[voice] Follow-up LLM error: {}", e);
+                                    eprintln!(
+                                        "[voice] Follow-up LLM backend error ({}): {}",
+                                        llm.backend_name(),
+                                        e
+                                    );
                                 }
                             }
 
@@ -991,7 +995,11 @@ async fn voice_cycle(
         Ok(r) => r,
         Err(e) => {
             // Fallback: try non-streaming if streaming fails.
-            eprintln!("[voice] Streaming failed ({}), trying blocking...", e);
+            eprintln!(
+                "[voice] Streaming failed for {} backend ({}), trying blocking...",
+                llm.backend_name(),
+                e
+            );
             match llm.chat(&messages, Some(256)).await {
                 Ok(r) => {
                     let voice_text = format::for_voice(&r);
@@ -1001,7 +1009,7 @@ async fn voice_cycle(
                     r
                 }
                 Err(e2) => {
-                    eprintln!("[voice] LLM error: {}", e2);
+                    eprintln!("[voice] LLM backend error ({}): {}", llm.backend_name(), e2);
                     return true;
                 }
             }
@@ -1145,4 +1153,36 @@ async fn voice_cycle(
     }
 
     true
+}
+
+fn llm_connected_message(backend_name: &str) -> String {
+    format!("[voice] LLM backend connected ({backend_name})")
+}
+
+fn llm_unreachable_message(backend_name: &str) -> String {
+    format!(
+        "[voice] WARNING: LLM backend not reachable ({backend_name}) - check configured service"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn llm_status_messages_include_backend_name() {
+        let connected = llm_connected_message("genie-ai-runtime");
+        let unreachable = llm_unreachable_message("genie-ai-runtime");
+
+        assert!(connected.contains("genie-ai-runtime"));
+        assert!(unreachable.contains("genie-ai-runtime"));
+    }
+
+    #[test]
+    fn llm_unreachable_message_is_backend_neutral() {
+        let unreachable = llm_unreachable_message("genie-ai-runtime");
+
+        assert!(!unreachable.contains("llama-server"));
+        assert!(!unreachable.contains("llama.cpp"));
+    }
 }


### PR DESCRIPTION
## Summary
- Voice-only follow-up after #35 landed the LLM backend facade.
- Reports the configured backend name in voice health and LLM error paths.
- Removes the remaining voice-mode operator hint that hard-coded `llama-server`.
- Adds regression coverage for backend-neutral voice LLM status messages.

## Scope
This intentionally only touches `crates/genie-core/src/voice*` paths. It does not add `[services.llm].backend` config plumbing or change the default backend; those can stay as separate follow-up PRs if the maintainer wants smaller slices.

## Tests
- `cargo check -p genie-core`
- `cargo test -p genie-core voice_loop::tests`
- `cargo test -p genie-core voice::`
- `git diff --check`