### PR TITLE
core: expose configured llm backend

### DIFF
--- a/crates/genie-core/src/main.rs
+++ b/crates/genie-core/src/main.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<()> {
     // Build shared components.
     let llm_url = &config.services.llm.url;
     let llm = llm::LlmClient::from_url(llm_url);
+    tracing::info!(backend = %llm.backend_name(), "LLM backend configured");
 
     let ha = ha::provider_from_config(&config);
 

--- a/crates/genie-core/src/server.rs
+++ b/crates/genie-core/src/server.rs
@@ -972,6 +972,7 @@ async fn handle_health(
     let resp = serde_json::json!({
         "status": status,
         "llm": if llm_ok { "connected" } else { "offline" },
+        "llm_backend": llm.backend_name(),
         "memories": mem_count,
         "conversations": conv_count,
         "mem_available_mb": mem_avail,
@@ -1745,7 +1746,7 @@ fn status_text(code: u16) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        ConnectivityState, StreamMode, detect_stream_mode, handle_actuation_actions,
+        ConnectivityState, StreamMode, detect_stream_mode, handle_actuation_actions, handle_health,
         handle_runtime_contract, handle_web_search, handle_web_search_status,
         overall_health_status, should_summarize_tool_result,
     };
@@ -1828,6 +1829,50 @@ mod tests {
             overall_health_status(true, ConnectivityState::Offline),
             "degraded"
         );
+    }
+
+    #[tokio::test]
+    async fn health_endpoint_reports_llm_backend() {
+        let unique = format!(
+            "genie-health-backend-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let temp = std::env::temp_dir();
+        let memory_path = temp.join(format!("{unique}-memory.db"));
+        let conversations_path = temp.join(format!("{unique}-conversations.db"));
+        let _ = std::fs::remove_file(&memory_path);
+        let _ = std::fs::remove_file(&conversations_path);
+
+        let llm = crate::llm::LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:1/health");
+        let tools = ToolDispatcher::new(None);
+        let connectivity = NullConnectivityController::from_config(&ConnectivityConfig::default());
+        let memory = Memory::open(&memory_path).unwrap();
+        let conversations = ConversationStore::open(&conversations_path).unwrap();
+
+        let (status, _, body) = handle_health(
+            &llm,
+            &tools,
+            &connectivity,
+            &memory,
+            &conversations,
+            "system prompt",
+            12,
+            ModelFamily::Phi,
+            "",
+        )
+        .await;
+
+        assert_eq!(status, 200);
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["llm"], "offline");
+        assert_eq!(parsed["llm_backend"], "genie-ai-runtime");
+
+        let _ = std::fs::remove_file(&memory_path);
+        let _ = std::fs::remove_file(&conversations_path);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Follow-up backend-abstraction slice after #35 and #38.
- Keeps scope inside `crates/genie-core/src` only.
- Logs the configured `LlmClient` backend at core startup.
- Adds `llm_backend` to `/api/health` while preserving the existing `llm` connected/offline field.
- Adds regression coverage with a `genie-ai-runtime` facade client.

## Scope
This intentionally does not add config parsing or change the default backend. It only surfaces the backend identity that the `LlmClient` facade already knows.

## Tests
- `cargo check -p genie-core`
- `cargo test -p genie-core server::tests::health_endpoint_reports_llm_backend`
- `cargo test -p genie-core server::tests`
- `git diff --check`