### PR TITLE
runtime: resolve llm service from config

### DIFF
--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -159,7 +159,7 @@ pub struct CoreConfig {
     #[serde(default = "defaults::voice_continuous_secs")]
     pub voice_continuous_secs: u32,
 
-    /// LLM model path (for GPU time-sharing — voice loop restarts llama-server).
+    /// LLM model path used when runtime tooling swaps the configured LLM service.
     #[serde(default = "defaults::llm_model_path")]
     pub llm_model_path: PathBuf,
 
@@ -594,10 +594,38 @@ impl Config {
     /// Whether the current deployment should manage a given service alias.
     pub fn manages_service_alias(&self, alias: &str) -> bool {
         match alias {
+            "core" | "genie-core" | "llm" | "genie-llm" => true,
             "homeassistant" => self.services.homeassistant.is_some(),
             "nextcloud" => self.services.nextcloud.is_some(),
             "jellyfin" => self.services.jellyfin.is_some(),
             _ => true,
+        }
+    }
+
+    /// Resolve a service alias used by runtime tooling to its configured
+    /// systemd unit. Optional services return `None` when they are not
+    /// configured for this deployment.
+    pub fn service_unit_for_alias(&self, alias: &str) -> Option<String> {
+        match alias {
+            "core" | "genie-core" => Some(self.services.core.systemd_unit.clone()),
+            "llm" | "genie-llm" => Some(self.services.llm.systemd_unit.clone()),
+            "homeassistant" => self
+                .services
+                .homeassistant
+                .as_ref()
+                .map(|service| service.systemd_unit.clone()),
+            "nextcloud" => self
+                .services
+                .nextcloud
+                .as_ref()
+                .map(|service| service.systemd_unit.clone()),
+            "jellyfin" => self
+                .services
+                .jellyfin
+                .as_ref()
+                .map(|service| service.systemd_unit.clone()),
+            _ if self.manages_service_alias(alias) => Some(alias.to_string()),
+            _ => None,
         }
     }
 
@@ -875,9 +903,38 @@ bind_host = "0.0.0.0"
         });
 
         assert!(config.manages_service_alias("genie-core"));
+        assert!(config.manages_service_alias("llm"));
         assert!(!config.manages_service_alias("homeassistant"));
         assert!(config.manages_service_alias("nextcloud"));
         assert!(!config.manages_service_alias("jellyfin"));
+    }
+
+    #[test]
+    fn service_unit_aliases_use_configured_units() {
+        let mut config = test_config();
+        config.services.llm.systemd_unit = "genie-ai-runtime.service".into();
+        config.services.nextcloud = Some(ServiceEndpoint {
+            url: "http://127.0.0.1:8180/status.php".into(),
+            systemd_unit: "nextcloud.service".into(),
+        });
+
+        assert_eq!(
+            config.service_unit_for_alias("core").as_deref(),
+            Some("genie-core.service")
+        );
+        assert_eq!(
+            config.service_unit_for_alias("llm").as_deref(),
+            Some("genie-ai-runtime.service")
+        );
+        assert_eq!(
+            config.service_unit_for_alias("genie-llm").as_deref(),
+            Some("genie-ai-runtime.service")
+        );
+        assert_eq!(
+            config.service_unit_for_alias("nextcloud").as_deref(),
+            Some("nextcloud.service")
+        );
+        assert_eq!(config.service_unit_for_alias("jellyfin"), None);
     }
 
     #[test]

--- a/crates/genie-common/src/mode.rs
+++ b/crates/genie-common/src/mode.rs
@@ -38,13 +38,13 @@ impl Mode {
             Mode::Day | Mode::NightA => &[
                 "genie-wakeword",
                 "genie-core",
-                "genie-llm",
+                "llm",
                 "genie-mqtt",
                 "homeassistant",
             ],
-            Mode::NightB => &["genie-wakeword", "genie-core", "genie-llm", "genie-mqtt"],
+            Mode::NightB => &["genie-wakeword", "genie-core", "llm", "genie-mqtt"],
             Mode::Media => &["genie-wakeword", "genie-core", "genie-mqtt"],
-            Mode::Pressure => &["genie-wakeword", "genie-core", "genie-llm", "genie-mqtt"],
+            Mode::Pressure => &["genie-wakeword", "genie-core", "llm", "genie-mqtt"],
         }
     }
 
@@ -53,7 +53,7 @@ impl Mode {
         match self {
             Mode::Day | Mode::NightA => &[],
             Mode::NightB => &["homeassistant", "nextcloud", "jellyfin"],
-            Mode::Media => &["genie-llm", "nextcloud", "jellyfin"],
+            Mode::Media => &["llm", "nextcloud", "jellyfin"],
             Mode::Pressure => &["nextcloud", "jellyfin"],
         }
     }

--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -989,14 +989,31 @@ async fn cmd_connectivity() -> Result<()> {
 }
 
 async fn cmd_health() -> Result<()> {
-    // Check each service.
+    let core_health = match http_get(CORE_URL, "/api/health").await {
+        Ok(body) => {
+            println!("  [OK]   genie-core");
+            serde_json::from_str::<serde_json::Value>(&body).ok()
+        }
+        Err(_) => {
+            println!("  [DOWN] genie-core");
+            None
+        }
+    };
+
+    if let Some(health) = &core_health {
+        let label = llm_service_label(health.get("llm_backend").and_then(|v| v.as_str()));
+        match health.get("llm").and_then(|v| v.as_str()) {
+            Some("connected") => println!("  [OK]   {}", label),
+            Some(_) => println!("  [DOWN] {}", label),
+            None => println!("  [DOWN] {}", label),
+        }
+    }
+
+    // Check each remaining HTTP service.
     let services = [
-        ("genie-core", CORE_URL, "/api/health"),
-        ("llama.cpp", "127.0.0.1:8080", "/health"),
         ("Home Assistant", "127.0.0.1:8123", "/api/"),
         ("genie-api", "127.0.0.1:3080", "/api/status"),
     ];
-
     for (name, addr, path) in &services {
         match http_get(addr, path).await {
             Ok(_) => println!("  [OK]   {}", name),
@@ -1115,7 +1132,6 @@ async fn cmd_diag() -> Result<()> {
     println!("\n[Services]");
     let services = [
         ("genie-core", CORE_URL, "/api/health"),
-        ("llama.cpp", "127.0.0.1:8080", "/health"),
         ("genie-api", "127.0.0.1:3080", "/api/status"),
         ("Home Assistant", "127.0.0.1:8123", "/api/"),
     ];
@@ -1156,6 +1172,9 @@ async fn cmd_diag() -> Result<()> {
         }
         if let Some(v) = data.get("llm").and_then(|v| v.as_str()) {
             println!("  LLM:           {}", v);
+        }
+        if let Some(v) = data.get("llm_backend").and_then(|v| v.as_str()) {
+            println!("  LLM Backend:   {}", v);
         }
         if let Some(v) = data.get("memories").and_then(|v| v.as_u64()) {
             println!("  Memories:      {}", v);
@@ -1228,6 +1247,7 @@ async fn cmd_diag() -> Result<()> {
         "genie-health",
         "genie-api",
         "llama-server",
+        "genie-ai-runtime",
     ] {
         let path = format!("{}/{}", bin_dir, name);
         if std::path::Path::new(&path).exists() {
@@ -1279,7 +1299,6 @@ async fn cmd_diag() -> Result<()> {
 async fn cmd_support_bundle(output_path: &Path) -> Result<()> {
     let services = [
         ("genie-core", CORE_URL, "/api/health"),
-        ("llama.cpp", "127.0.0.1:8080", "/health"),
         ("genie-api", "127.0.0.1:3080", "/api/status"),
         ("Home Assistant", "127.0.0.1:8123", "/api/"),
     ];
@@ -1363,6 +1382,13 @@ async fn http_json_value(addr: &str, path: &str) -> serde_json::Value {
     }
 }
 
+fn llm_service_label(backend: Option<&str>) -> String {
+    match backend.filter(|value| !value.trim().is_empty()) {
+        Some(backend) => format!("LLM ({backend})"),
+        None => "LLM".into(),
+    }
+}
+
 fn read_file_string(path: &str) -> Option<String> {
     std::fs::read_to_string(path)
         .ok()
@@ -1411,20 +1437,43 @@ async fn disk_summary(path: &str) -> serde_json::Value {
 }
 
 fn config_presence() -> Vec<serde_json::Value> {
-    [
+    let mut paths = vec![
         "/etc/geniepod/geniepod.toml",
         "/etc/geniepod/mosquitto.conf",
-        "/etc/systemd/system/genie-core.service",
-        "/etc/systemd/system/genie-llm.service",
     ]
     .into_iter()
-    .map(|path| {
-        serde_json::json!({
-            "path": path,
-            "present": Path::new(path).exists(),
+    .map(String::from)
+    .collect::<Vec<_>>();
+
+    match Config::load() {
+        Ok(config) => {
+            paths.push(systemd_unit_file_path(&config.services.core.systemd_unit));
+            paths.push(systemd_unit_file_path(&config.services.llm.systemd_unit));
+        }
+        Err(_) => {
+            paths.push(systemd_unit_file_path("genie-core.service"));
+            paths.push(systemd_unit_file_path("genie-llm.service"));
+        }
+    }
+
+    paths
+        .into_iter()
+        .map(|path| {
+            serde_json::json!({
+                "path": path,
+                "present": Path::new(&path).exists(),
+            })
         })
-    })
-    .collect()
+        .collect()
+}
+
+fn systemd_unit_file_path(unit: &str) -> String {
+    let unit = if unit.contains('.') {
+        unit.to_string()
+    } else {
+        format!("{unit}.service")
+    };
+    format!("/etc/systemd/system/{unit}")
 }
 
 fn binary_inventory() -> Vec<serde_json::Value> {
@@ -1435,6 +1484,7 @@ fn binary_inventory() -> Vec<serde_json::Value> {
         "genie-health",
         "genie-api",
         "llama-server",
+        "genie-ai-runtime",
     ]
     .into_iter()
     .map(|name| {
@@ -1742,6 +1792,27 @@ mod tests {
         let path = default_support_bundle_path();
         assert!(path.starts_with("/tmp"));
         assert_eq!(path.extension().and_then(|ext| ext.to_str()), Some("json"));
+    }
+
+    #[test]
+    fn llm_service_label_includes_backend_when_known() {
+        assert_eq!(
+            llm_service_label(Some("genie-ai-runtime")),
+            "LLM (genie-ai-runtime)"
+        );
+        assert_eq!(llm_service_label(None), "LLM");
+    }
+
+    #[test]
+    fn systemd_unit_file_path_normalizes_unit_name() {
+        assert_eq!(
+            systemd_unit_file_path("genie-ai-runtime"),
+            "/etc/systemd/system/genie-ai-runtime.service"
+        );
+        assert_eq!(
+            systemd_unit_file_path("genie-llm.service"),
+            "/etc/systemd/system/genie-llm.service"
+        );
     }
 
     #[test]

--- a/crates/genie-governor/src/governor.rs
+++ b/crates/genie-governor/src/governor.rs
@@ -187,47 +187,51 @@ impl Governor {
         tracing::info!(from = %from, to = %target, "mode transition");
 
         // Stop services not needed in target mode.
-        for unit in target.stopped_services() {
-            if !self.should_manage_service(unit) {
+        for alias in target.stopped_services() {
+            let Some(unit) = self.service_unit_for_alias(alias) else {
                 continue;
-            }
-            let _ = ServiceCtl::stop(unit).await;
+            };
+            let _ = ServiceCtl::stop(&unit).await;
         }
 
         // Handle LLM model swap.
         match (from, target) {
             (_, Mode::Media) => {
-                let _ = ServiceCtl::stop("genie-llm.service").await;
+                let unit = self.llm_service_unit();
+                let _ = ServiceCtl::stop(&unit).await;
             }
             (Mode::Media, _) => {
                 if let Some(model) = target.llm_model() {
                     let path = format!("/opt/geniepod/models/{}", model);
-                    let _ = ServiceCtl::swap_llm_model(&path).await;
+                    let unit = self.llm_service_unit();
+                    let _ = ServiceCtl::swap_llm_model(&unit, &path).await;
                 }
                 let _ = tokio::fs::remove_file("/run/geniepod/media_mode").await;
             }
             (Mode::Day | Mode::NightA, Mode::NightB) => {
                 if let Some(model) = Mode::NightB.llm_model() {
                     let path = format!("/opt/geniepod/models/{}", model);
-                    let _ = ServiceCtl::swap_llm_model(&path).await;
+                    let unit = self.llm_service_unit();
+                    let _ = ServiceCtl::swap_llm_model(&unit, &path).await;
                 }
             }
             (Mode::NightB, Mode::Day) => {
                 if let Some(model) = Mode::Day.llm_model() {
                     let path = format!("/opt/geniepod/models/{}", model);
-                    let _ = ServiceCtl::swap_llm_model(&path).await;
+                    let unit = self.llm_service_unit();
+                    let _ = ServiceCtl::swap_llm_model(&unit, &path).await;
                 }
             }
             _ => {}
         }
 
         // Start services required by target mode.
-        for unit in target.required_services() {
-            if !self.should_manage_service(unit) {
+        for alias in target.required_services() {
+            let Some(unit) = self.service_unit_for_alias(alias) else {
                 continue;
-            }
-            if !ServiceCtl::is_active(unit).await {
-                let _ = ServiceCtl::start(unit).await;
+            };
+            if !ServiceCtl::is_active(&unit).await {
+                let _ = ServiceCtl::start(&unit).await;
             }
         }
 
@@ -260,6 +264,16 @@ impl Governor {
 
     fn should_manage_service(&self, alias: &str) -> bool {
         self.config.manages_service_alias(alias)
+    }
+
+    fn service_unit_for_alias(&self, alias: &str) -> Option<String> {
+        self.config.service_unit_for_alias(alias)
+    }
+
+    fn llm_service_unit(&self) -> String {
+        self.config
+            .service_unit_for_alias("llm")
+            .unwrap_or_else(|| "genie-llm.service".into())
     }
 }
 
@@ -367,13 +381,13 @@ mod tests {
     fn mode_required_services() {
         let day_services = Mode::Day.required_services();
         assert!(day_services.contains(&"genie-core"));
-        assert!(day_services.contains(&"genie-llm"));
+        assert!(day_services.contains(&"llm"));
         assert!(day_services.contains(&"homeassistant"));
 
         let media_services = Mode::Media.required_services();
         assert!(media_services.contains(&"genie-wakeword"));
         assert!(media_services.contains(&"genie-core"));
-        assert!(!media_services.contains(&"genie-llm")); // LLM unloaded in media.
+        assert!(!media_services.contains(&"llm")); // LLM unloaded in media.
     }
 
     #[test]
@@ -381,6 +395,7 @@ mod tests {
         assert!(Mode::Day.stopped_services().is_empty());
         assert!(Mode::NightB.stopped_services().contains(&"homeassistant"));
         assert!(Mode::NightB.stopped_services().contains(&"nextcloud"));
+        assert!(Mode::Media.stopped_services().contains(&"llm"));
     }
 
     #[test]
@@ -425,8 +440,24 @@ mod tests {
         let gov = make_governor();
 
         assert!(gov.should_manage_service("genie-core"));
+        assert!(gov.should_manage_service("llm"));
         assert!(!gov.should_manage_service("homeassistant"));
         assert!(!gov.should_manage_service("nextcloud"));
         assert!(!gov.should_manage_service("jellyfin"));
+    }
+
+    #[test]
+    fn resolves_llm_alias_to_configured_service_unit() {
+        let mut config = test_config();
+        config.services.llm.systemd_unit = "genie-ai-runtime.service".into();
+        let db_path = std::env::temp_dir().join("geniepod-test-gov-llm-unit.db");
+        let store = Store::open(&db_path).unwrap();
+        let gov = Governor::new(config, store);
+
+        assert_eq!(
+            gov.service_unit_for_alias("llm").as_deref(),
+            Some("genie-ai-runtime.service")
+        );
+        assert_eq!(gov.llm_service_unit(), "genie-ai-runtime.service");
     }
 }

--- a/crates/genie-governor/src/service_ctl.rs
+++ b/crates/genie-governor/src/service_ctl.rs
@@ -86,14 +86,15 @@ impl ServiceCtl {
         Ok(())
     }
 
-    /// Reload llama.cpp server with a different model.
+    /// Reload the configured LLM service with a different model.
     /// Sends SIGHUP or restarts the service with new args.
-    pub async fn swap_llm_model(model_path: &str) -> Result<()> {
-        tracing::info!(model = model_path, "swapping LLM model");
+    pub async fn swap_llm_model(unit: &str, model_path: &str) -> Result<()> {
+        let unit = normalize_systemd_unit(unit);
+        tracing::info!(unit = %unit, model = model_path, "swapping LLM model");
 
         // Write the model path to the override config, then restart.
-        let override_dir = "/etc/systemd/system/genie-llm.service.d";
-        tokio::fs::create_dir_all(override_dir).await?;
+        let override_dir = llm_override_dir_for_unit(&unit);
+        tokio::fs::create_dir_all(&override_dir).await?;
 
         let override_content = format!(
             "[Service]\nEnvironment=\"GENIEPOD_LLM_MODEL={}\"\n",
@@ -112,7 +113,7 @@ impl ServiceCtl {
             .await?;
 
         Command::new("systemctl")
-            .args(["restart", "genie-llm.service"])
+            .args(["restart", &unit])
             .output()
             .await?;
 
@@ -137,5 +138,39 @@ impl ServiceCtl {
             tracing::warn!(%stderr, "zram setup may have partially failed");
         }
         Ok(())
+    }
+}
+
+fn normalize_systemd_unit(unit: &str) -> String {
+    if unit.contains('.') {
+        unit.to_string()
+    } else {
+        format!("{unit}.service")
+    }
+}
+
+fn llm_override_dir_for_unit(unit: &str) -> String {
+    format!("/etc/systemd/system/{}.d", normalize_systemd_unit(unit))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_systemd_unit_names() {
+        assert_eq!(normalize_systemd_unit("genie-llm"), "genie-llm.service");
+        assert_eq!(
+            normalize_systemd_unit("genie-ai-runtime.service"),
+            "genie-ai-runtime.service"
+        );
+    }
+
+    #[test]
+    fn llm_override_dir_uses_configured_unit() {
+        assert_eq!(
+            llm_override_dir_for_unit("genie-ai-runtime.service"),
+            "/etc/systemd/system/genie-ai-runtime.service.d"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Follow-up for the runtime/service-tooling part of the LLM backend abstraction work.
- Replaces governor mode hard-codes of `genie-llm` with a generic `llm` service alias.
- Resolves `llm` through `services.llm.systemd_unit`, so governor starts/stops/restarts the configured LLM service.
- Updates `genie-ctl health`, diagnostics, and support bundles to use core `/api/health` for backend-neutral LLM status instead of probing llama.cpp directly.
- Keeps `genie-health` on the existing config-driven `services.llm.url` path and verifies it still passes.

## Scope
This PR intentionally does not add `[services.llm].backend` config parsing or change the default backend. It only makes runtime/service tooling honor the existing configured LLM service unit and backend-neutral health reporting.

## Tests
- `cargo test -p genie-common config::tests::service_unit_aliases_use_configured_units`
- `cargo test -p genie-governor`
- `cargo test -p genie-ctl`
- `cargo test -p genie-health`
- `cargo check -p genie-common -p genie-governor -p genie-ctl -p genie-health`
- `git diff --check`