### PR TITLE
llm: select backend from config

### DIFF
--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -556,6 +556,20 @@ pub struct Esp32C6UartConfig {
 pub struct ServiceEndpoint {
     pub url: String,
     pub systemd_unit: String,
+    /// LLM backend selector. Only meaningful for `services.llm`; defaults
+    /// preserve the legacy llama.cpp path for existing configs.
+    #[serde(default)]
+    pub backend: LlmBackendKind,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmBackendKind {
+    #[default]
+    #[serde(alias = "llama-cpp")]
+    LlamaCpp,
+    #[serde(alias = "genie-ai-runtime")]
+    GenieAiRuntime,
 }
 
 impl Config {
@@ -774,10 +788,12 @@ impl Default for ServicesConfig {
             core: ServiceEndpoint {
                 url: "http://127.0.0.1:3000/api/health".into(),
                 systemd_unit: "genie-core.service".into(),
+                backend: LlmBackendKind::default(),
             },
             llm: ServiceEndpoint {
                 url: "http://127.0.0.1:8080/health".into(),
                 systemd_unit: "genie-llm.service".into(),
+                backend: LlmBackendKind::LlamaCpp,
             },
             homeassistant: None,
             nextcloud: None,
@@ -900,6 +916,7 @@ bind_host = "0.0.0.0"
         config.services.nextcloud = Some(ServiceEndpoint {
             url: "http://127.0.0.1:8180/status.php".into(),
             systemd_unit: "nextcloud.service".into(),
+            backend: LlmBackendKind::default(),
         });
 
         assert!(config.manages_service_alias("genie-core"));
@@ -916,6 +933,7 @@ bind_host = "0.0.0.0"
         config.services.nextcloud = Some(ServiceEndpoint {
             url: "http://127.0.0.1:8180/status.php".into(),
             systemd_unit: "nextcloud.service".into(),
+            backend: LlmBackendKind::default(),
         });
 
         assert_eq!(
@@ -935,6 +953,33 @@ bind_host = "0.0.0.0"
             Some("nextcloud.service")
         );
         assert_eq!(config.service_unit_for_alias("jellyfin"), None);
+    }
+
+    #[test]
+    fn llm_service_backend_defaults_to_llama_cpp() {
+        let service: ServiceEndpoint = toml::from_str(
+            r#"
+url = "http://127.0.0.1:8080/health"
+systemd_unit = "genie-llm.service"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(service.backend, LlmBackendKind::LlamaCpp);
+    }
+
+    #[test]
+    fn llm_service_backend_accepts_genie_ai_runtime() {
+        let service: ServiceEndpoint = toml::from_str(
+            r#"
+url = "http://127.0.0.1:8080/health"
+systemd_unit = "genie-ai-runtime.service"
+backend = "genie_ai_runtime"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(service.backend, LlmBackendKind::GenieAiRuntime);
     }
 
     #[test]

--- a/crates/genie-core/src/llm/mod.rs
+++ b/crates/genie-core/src/llm/mod.rs
@@ -5,6 +5,7 @@ mod retry;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use genie_common::config::{LlmBackendKind, ServiceEndpoint};
 
 pub use genie_ai_runtime::GenieAiRuntimeBackend;
 pub use llama_cpp::LlamaCppBackend;
@@ -36,8 +37,7 @@ pub trait LlmBackendClient: Send + Sync {
 /// LLM client facade used by agent orchestration.
 ///
 /// The public constructors preserve the legacy llama.cpp default. Backend
-/// selection and config plumbing will be layered on top of this facade in a
-/// follow-up PR.
+/// selection from config is available through [`LlmClient::from_service_config`].
 pub struct LlmClient {
     backend: Box<dyn LlmBackendClient>,
 }
@@ -49,6 +49,13 @@ impl LlmClient {
 
     pub fn from_url(url: &str) -> Self {
         Self::from_llama_cpp_url(url)
+    }
+
+    pub fn from_service_config(service: &ServiceEndpoint) -> Self {
+        match service.backend {
+            LlmBackendKind::LlamaCpp => Self::from_llama_cpp_url(&service.url),
+            LlmBackendKind::GenieAiRuntime => Self::from_genie_ai_runtime_url(&service.url),
+        }
     }
 
     pub fn llama_cpp(host: &str, port: u16) -> Self {
@@ -131,6 +138,17 @@ mod tests {
     #[test]
     fn can_construct_genie_ai_runtime_client() {
         let client = LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:8080/health");
+        assert_eq!(client.backend_name(), "genie-ai-runtime");
+    }
+
+    #[test]
+    fn service_config_selects_genie_ai_runtime_backend() {
+        let client = LlmClient::from_service_config(&ServiceEndpoint {
+            url: "http://127.0.0.1:8080/health".into(),
+            systemd_unit: "genie-ai-runtime.service".into(),
+            backend: LlmBackendKind::GenieAiRuntime,
+        });
+
         assert_eq!(client.backend_name(), "genie-ai-runtime");
     }
 }

--- a/crates/genie-core/src/main.rs
+++ b/crates/genie-core/src/main.rs
@@ -43,8 +43,7 @@ async fn main() -> Result<()> {
     }
 
     // Build shared components.
-    let llm_url = &config.services.llm.url;
-    let llm = llm::LlmClient::from_url(llm_url);
+    let llm = llm::LlmClient::from_service_config(&config.services.llm);
     tracing::info!(backend = %llm.backend_name(), "LLM backend configured");
 
     let ha = ha::provider_from_config(&config);

--- a/crates/genie-core/src/voice/mod.rs
+++ b/crates/genie-core/src/voice/mod.rs
@@ -41,8 +41,7 @@ pub struct VoiceOrchestrator {
 
 impl VoiceOrchestrator {
     pub async fn new(config: Config) -> Result<Self> {
-        let llm_url = &config.services.llm.url;
-        let llm = LlmClient::from_url(llm_url);
+        let llm = LlmClient::from_service_config(&config.services.llm);
 
         let ha = crate::ha::provider_from_config(&config);
         let skill_loader = crate::skills::load_all_with_policy(


### PR DESCRIPTION
## Summary
- Adds `backend` parsing on service endpoints, defaulting to `llama_cpp` for legacy configs.
- Supports `backend = "genie_ai_runtime"` on `[services.llm]`.
- Builds the core `LlmClient` from `services.llm.backend` instead of always using the llama.cpp constructor.
- Applies the same config-based construction in the voice orchestrator path.
- Adds focused tests for legacy default parsing and `genie_ai_runtime` selection.

## Scope
This is the config-selection slice only. It does not change the default backend, add deploy TOML examples, update docs, or introduce Cargo feature gates.

## Tests
- `cargo test -p genie-common llm_service_backend`
- `cargo test -p genie-core llm::tests`
- `cargo test -p genie-common`
- `cargo check -p genie-common -p genie-core -p genie-health -p genie-governor -p genie-ctl`
- `git diff --check`