### PR TITLE
deploy+config: opt-in Qwen3-4B model download (#44, phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Added
 
+- Opt-in Qwen3-4B model download in `setup-jetson.sh` (issue #44, Phase 1).
+  `deploy/setup-jetson.sh --model qwen3-4b` fetches
+  `Qwen3-4B-Q4_K_M.gguf` from `Qwen/Qwen3-4B-GGUF` into
+  `/opt/geniepod/models/`. `--model phi-4-mini` is also accepted as an
+  explicit form of today's default. The flag only changes the download
+  target; it does not rewrite `llm_model_path` in
+  `/etc/geniepod/geniepod.toml`, so existing Phi-4-mini deployments stay
+  on Phi-4-mini until the operator flips the config line by hand. The
+  recommended pairing is Qwen3-4B + `genie-ai-runtime` once both are
+  installed — see the new "Recommended LLM Pairing" section in README.
+  `geniepod.toml` carries commented examples for both
+  `llm_model_name = "qwen"` and the matching `llm_model_path`. Regression
+  tests in `prompt.rs` lock the `Qwen3-4B-Q4_K_M.gguf` filename to
+  `ModelFamily::Qwen` so a future detector refactor cannot silently drop
+  it into the small-model prompt shape. The default flip ships in Phase 2
+  alongside the genie-ai-runtime default flip in issue #33.
 - `.github/workflows/ci.yml` — the fmt + clippy + test daily loop for
   issue #34 (PR #37). Runs `cargo fmt --all -- --check`,
   `cargo clippy --workspace --all-targets --locked -- -D warnings`, and

--- a/README.md
+++ b/README.md
@@ -289,6 +289,36 @@ The repo includes:
 - wake-word helper scripts
 - Docker support for local development
 
+### Recommended LLM Pairing
+
+The bundled default is **Phi-4-mini Q4_K_M** on llama.cpp. `setup-jetson.sh`
+auto-downloads it on first run.
+
+For deployments that want stronger reasoning, cleaner JSON tool calls, and
+better multilingual support (matching the per-language Piper voice models),
+the recommended pairing is **Qwen3-4B Q4_K_M** running on
+[`genie-ai-runtime`](https://github.com/GeniePod/genie-ai-runtime) once the
+runtime backend is enabled (`[services.llm].backend = "genie_ai_runtime"`).
+Qwen3-4B's slower per-token decode is exactly what genie-ai-runtime's
+prefill and TTFT improvements address.
+
+Phase 1 is opt-in only — Phi-4-mini remains the default:
+
+```bash
+# On the Jetson, after `make deploy`:
+sudo /opt/geniepod/setup-jetson.sh --model qwen3-4b
+
+# Then edit /etc/geniepod/geniepod.toml:
+#   llm_model_name = "qwen"
+#   llm_model_path = "/opt/geniepod/models/Qwen3-4B-Q4_K_M.gguf"
+# And update GENIEPOD_LLM_MODEL in /etc/systemd/system/genie-llm.service,
+# then: sudo systemctl restart genie-llm genie-core
+```
+
+See [issue #44](https://github.com/GeniePod/genie-claw/issues/44) for the
+full rollout plan; flipping the default ships in Phase 2 alongside
+[issue #33](https://github.com/GeniePod/genie-claw/issues/33).
+
 ## Design Principles
 
 - **Privacy and security over broad skills**: trust matters more than a giant extension catalog

--- a/crates/genie-core/src/prompt.rs
+++ b/crates/genie-core/src/prompt.rs
@@ -344,6 +344,41 @@ mod tests {
         ));
     }
 
+    // Issue #44: Qwen3-4B is the canonical opt-in alternative paired with
+    // genie-ai-runtime. Lock the exact filename setup-jetson.sh writes to
+    // disk so a future detector refactor cannot silently drop it back into
+    // ModelFamily::Generic (which would route through the small-model prompt
+    // shape and lose the JSON tool-call instructions).
+    #[test]
+    fn detect_qwen3_4b_canonical_filename() {
+        assert!(matches!(
+            ModelFamily::from_model_name("Qwen3-4B-Q4_K_M.gguf"),
+            ModelFamily::Qwen
+        ));
+        assert!(matches!(
+            ModelFamily::from_model_name("Qwen3-4B-Instruct-Q4_K_M.gguf"),
+            ModelFamily::Qwen
+        ));
+    }
+
+    #[test]
+    fn qwen3_4b_uses_capable_prompt_shape() {
+        let builder = PromptBuilder::from_model_name("Qwen3-4B-Q4_K_M.gguf");
+        let tools = vec![crate::tools::dispatch::ToolDef {
+            name: "get_time".into(),
+            description: "Get current time".into(),
+            parameters: serde_json::json!({"type": "object", "properties": {}}),
+        }];
+        let mem_path = std::env::temp_dir().join("prompt-test-qwen3-4b.db");
+        let _ = std::fs::remove_file(&mem_path);
+        let memory = Memory::open(&mem_path).unwrap();
+
+        let prompt = builder.build(&tools, &memory);
+        assert!(prompt.contains("ONLY a JSON object"));
+        assert!(prompt.contains("Do NOT wrap the JSON in markdown code blocks"));
+        assert!(!prompt.contains("EXAMPLES:"));
+    }
+
     #[test]
     fn detect_phi() {
         assert!(matches!(

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -8,6 +8,15 @@ port = 3000
 bind_host = "127.0.0.1"           # Safer default. Use "0.0.0.0" only behind a trusted gateway/firewall.
 ha_token = ""                     # Only needed when Home Assistant service is enabled below. Or set HA_TOKEN env var.
 llm_model_name = "phi"            # For prompt optimization. Options: nemotron-4b, tinyllama, llama, qwen, phi
+                                  # Opt-in Qwen3-4B alternative (issue #44):
+                                  #   1) deploy/setup-jetson.sh --model qwen3-4b
+                                  #   2) flip the two lines below:
+                                  #        llm_model_name = "qwen"
+                                  #        llm_model_path = "/opt/geniepod/models/Qwen3-4B-Q4_K_M.gguf"
+                                  #   3) update GENIEPOD_LLM_MODEL in genie-llm.service
+                                  #   4) sudo systemctl restart genie-llm genie-core
+                                  # Recommended pairing: Qwen3-4B + genie-ai-runtime
+                                  # (see ARCHITECTURE.md "Current Transitional Adapters").
 whisper_model = "/opt/geniepod/models/ggml-small.bin"   # alpha.5 default — with the
                                   # long-running whisper-server (genie-whisper.service)
                                   # this model stays resident in iGPU memory, so per-call
@@ -94,6 +103,8 @@ voice_record_secs = 3             # Seconds to record per voice interaction. Mos
 voice_continuous = true           # After response, auto-listen for follow-up without re-wake.
 voice_continuous_secs = 3         # Shorter recording for follow-up conversation.
 llm_model_path = "/opt/geniepod/models/phi-4-mini-instruct-q4_k_m.gguf"  # For GPU time-sharing in voice mode.
+                                  # Qwen3-4B alternative (issue #44, opt-in):
+                                  # llm_model_path = "/opt/geniepod/models/Qwen3-4B-Q4_K_M.gguf"
 wakeword_script = ""              # Empty = push-to-talk (alpha.5 default).
                                   # Set to "/opt/geniepod/bin/genie-wake-listen.py" once
                                   # wake-word detection is validated for your install.

--- a/deploy/setup-jetson.sh
+++ b/deploy/setup-jetson.sh
@@ -4,6 +4,15 @@
 #   ssh geniepod@<jetson-ip> 'bash /opt/geniepod/setup-jetson.sh'
 #
 # Flags:
+#   --model phi-4-mini           Explicit form of today's default
+#                                (Phi-4-mini Q4_K_M).
+#   --model qwen3-4b             Download Qwen3-4B Q4_K_M instead
+#                                (issue #44). Recommended pairing with
+#                                genie-ai-runtime once both are installed.
+#                                The flag only changes the download target;
+#                                it does NOT rewrite llm_model_path in
+#                                /etc/geniepod/geniepod.toml — flip that
+#                                line by hand once the new model is on disk.
 #   --runtime genie-ai-runtime   Build + install genie-ai-runtime v1.0.0
 #                                alongside the existing llama.cpp backend.
 #                                Does NOT modify /etc/geniepod/geniepod.toml
@@ -18,11 +27,39 @@ CONFIG_DIR="/etc/geniepod"
 MODEL_DIR="$GENIEPOD_DIR/models"
 DATA_DIR="$GENIEPOD_DIR/data"
 
+# Phi-4-mini Q4_K_M — the current default. Pinned to lmstudio-community's
+# GGUF mirror because that conversion has been verified end-to-end on this
+# repo's Tegra/aarch64 + llama.cpp + flash-attn stack.
+PHI_MODEL_FILENAME="phi-4-mini-instruct-q4_k_m.gguf"
+PHI_MODEL_URL="https://huggingface.co/lmstudio-community/Phi-4-mini-instruct-GGUF/resolve/main/Phi-4-mini-instruct-Q4_K_M.gguf"
+PHI_MODEL_LABEL="Phi-4-mini Q4_K_M (~2.4 GB)"
+
+# Qwen3-4B Q4_K_M — opt-in alternative (issue #44). Sourced from upstream
+# Qwen GGUF release. Stronger reasoning / multilingual / JSON tool-call
+# behavior than Phi-4-mini; per-token decode is slower, which is what
+# genie-ai-runtime is meant to address downstream.
+QWEN3_MODEL_FILENAME="Qwen3-4B-Q4_K_M.gguf"
+QWEN3_MODEL_URL="https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf"
+QWEN3_MODEL_LABEL="Qwen3-4B Q4_K_M (~2.5 GB)"
+
 # ── Argument parsing ────────────────────────────────────────────
+MODEL_CHOICE=""
 RUNTIME_TO_INSTALL=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
+        --model)
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --model requires a value (phi-4-mini | qwen3-4b)" >&2
+                exit 2
+            fi
+            MODEL_CHOICE="$2"
+            shift 2
+            ;;
+        --model=*)
+            MODEL_CHOICE="${1#--model=}"
+            shift
+            ;;
         --runtime)
             shift
             if [ $# -eq 0 ]; then
@@ -37,12 +74,12 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -h|--help)
-            sed -n '2,12p' "$0"
+            sed -n '2,21p' "$0"
             exit 0
             ;;
         *)
             echo "ERROR: unknown argument: $1" >&2
-            echo "Usage: $0 [--runtime genie-ai-runtime]" >&2
+            echo "Usage: $0 [--model phi-4-mini|qwen3-4b] [--runtime genie-ai-runtime]" >&2
             exit 2
             ;;
     esac
@@ -138,6 +175,9 @@ install_genie_ai_runtime() {
     echo "  systemctl status genie-ai-runtime.service"
 }
 
+# --runtime is install-only: do the build/install and exit before the
+# rest of the Jetson setup runs. Validation happens here so an unknown
+# value fails fast, before we resolve any model paths.
 if [ -n "$RUNTIME_TO_INSTALL" ]; then
     case "$RUNTIME_TO_INSTALL" in
         genie-ai-runtime)
@@ -152,7 +192,27 @@ if [ -n "$RUNTIME_TO_INSTALL" ]; then
     esac
 fi
 
+case "$MODEL_CHOICE" in
+    ""|phi-4-mini)
+        MODEL_FLAG_FILENAME="$PHI_MODEL_FILENAME"
+        MODEL_FLAG_URL="$PHI_MODEL_URL"
+        MODEL_FLAG_LABEL="$PHI_MODEL_LABEL"
+        ;;
+    qwen3-4b)
+        MODEL_FLAG_FILENAME="$QWEN3_MODEL_FILENAME"
+        MODEL_FLAG_URL="$QWEN3_MODEL_URL"
+        MODEL_FLAG_LABEL="$QWEN3_MODEL_LABEL"
+        ;;
+    *)
+        echo "ERROR: unknown --model '$MODEL_CHOICE'. Supported: phi-4-mini, qwen3-4b" >&2
+        exit 2
+        ;;
+esac
+
 echo "=== GeniePod Jetson Setup ==="
+if [ -n "$MODEL_CHOICE" ]; then
+    echo "Model selection: --model $MODEL_CHOICE ($MODEL_FLAG_LABEL)"
+fi
 echo ""
 
 # 1. Create directories.
@@ -203,28 +263,45 @@ else
 fi
 
 # 4. Ensure the configured LLM model exists.
+# Selection rules (issue #44):
+#   - Without --model: honor llm_model_path in geniepod.toml if set, else
+#     fall back to the Phi-4-mini default path. Auto-download only when
+#     the resolved path matches the default for the active model choice.
+#   - With --model <name>: download <name>'s canonical artifact to
+#     $MODEL_DIR/<filename>. Does NOT rewrite llm_model_path — operator
+#     flips that line by hand to switch the running LLM.
 echo "[4/6] Checking LLM model..."
-CONFIGURED_MODEL_PATH="$(awk -F'"' '/^llm_model_path = / {print $2; exit}' "$CONFIG_DIR/geniepod.toml" 2>/dev/null || true)"
-DEFAULT_PHI_MODEL="$MODEL_DIR/phi-4-mini-instruct-q4_k_m.gguf"
-GGUF="${CONFIGURED_MODEL_PATH:-$DEFAULT_PHI_MODEL}"
+DEFAULT_MODEL_PATH="$MODEL_DIR/$MODEL_FLAG_FILENAME"
+if [ -n "$MODEL_CHOICE" ]; then
+    GGUF="$DEFAULT_MODEL_PATH"
+else
+    CONFIGURED_MODEL_PATH="$(awk -F'"' '/^llm_model_path = / {print $2; exit}' "$CONFIG_DIR/geniepod.toml" 2>/dev/null || true)"
+    GGUF="${CONFIGURED_MODEL_PATH:-$DEFAULT_MODEL_PATH}"
+fi
 sudo mkdir -p "$(dirname "$GGUF")"
 
 if [ -f "$GGUF" ]; then
     echo "  OK: $(basename "$GGUF") ($(du -h "$GGUF" | cut -f1))"
 else
-    if [ "$GGUF" = "$DEFAULT_PHI_MODEL" ]; then
-        echo "  Downloading Phi-4-mini Q4_K_M (~2.4 GB)..."
-        if wget -q --show-progress -O "$GGUF" \
-            "https://huggingface.co/lmstudio-community/Phi-4-mini-instruct-GGUF/resolve/main/Phi-4-mini-instruct-Q4_K_M.gguf"
-        then
+    if [ "$GGUF" = "$DEFAULT_MODEL_PATH" ]; then
+        echo "  Downloading $MODEL_FLAG_LABEL..."
+        if wget -q --show-progress -O "$GGUF" "$MODEL_FLAG_URL"; then
             echo "  OK: downloaded $(du -h "$GGUF" | cut -f1)"
+            if [ -n "$MODEL_CHOICE" ] && [ "$MODEL_CHOICE" != "phi-4-mini" ]; then
+                echo ""
+                echo "  NOTE: $CONFIG_DIR/geniepod.toml was not modified."
+                echo "        To run with this model, set:"
+                echo "          llm_model_path = \"$GGUF\""
+                echo "          llm_model_name = \"qwen\"   # selects the Qwen prompt template"
+                echo "        then restart genie-llm + genie-core."
+            fi
         else
             rm -f "$GGUF"
-            echo "  FAILED: could not download Phi-4-mini automatically"
+            echo "  FAILED: could not download $MODEL_FLAG_LABEL automatically"
             echo "    Try manually from a dev machine:"
-            echo "      hf download lmstudio-community/Phi-4-mini-instruct-GGUF --include 'Phi-4-mini-instruct-Q4_K_M.gguf' --local-dir ."
-            echo "      scp Phi-4-mini-instruct-Q4_K_M.gguf $(whoami)@$(hostname -I | awk '{print $1}'):/tmp/"
-            echo "      sudo mv /tmp/Phi-4-mini-instruct-Q4_K_M.gguf $GGUF"
+            echo "      wget -O $MODEL_FLAG_FILENAME '$MODEL_FLAG_URL'"
+            echo "      scp $MODEL_FLAG_FILENAME $(whoami)@$(hostname -I | awk '{print $1}'):/tmp/"
+            echo "      sudo mv /tmp/$MODEL_FLAG_FILENAME $GGUF"
             exit 1
         fi
     else

--- a/deploy/setup-jetson.sh
+++ b/deploy/setup-jetson.sh
@@ -287,14 +287,6 @@ else
         echo "  Downloading $MODEL_FLAG_LABEL..."
         if wget -q --show-progress -O "$GGUF" "$MODEL_FLAG_URL"; then
             echo "  OK: downloaded $(du -h "$GGUF" | cut -f1)"
-            if [ -n "$MODEL_CHOICE" ] && [ "$MODEL_CHOICE" != "phi-4-mini" ]; then
-                echo ""
-                echo "  NOTE: $CONFIG_DIR/geniepod.toml was not modified."
-                echo "        To run with this model, set:"
-                echo "          llm_model_path = \"$GGUF\""
-                echo "          llm_model_name = \"qwen\"   # selects the Qwen prompt template"
-                echo "        then restart genie-llm + genie-core."
-            fi
         else
             rm -f "$GGUF"
             echo "  FAILED: could not download $MODEL_FLAG_LABEL automatically"
@@ -308,6 +300,25 @@ else
         echo "  MISSING: configured model $(basename "$GGUF")"
         echo "    Copy the model to: $GGUF"
         exit 1
+    fi
+fi
+
+# Cutover guidance for non-default --model selections (issue #44 review,
+# PR #46). Must run independent of the download branch above so that
+# re-runs against an already-on-disk model still surface the four manual
+# steps the operator needs to take. Suppressed once geniepod.toml's
+# llm_model_path already points at the downloaded model, on the
+# assumption that the operator has completed the cutover.
+if [ -n "$MODEL_CHOICE" ] && [ "$MODEL_CHOICE" != "phi-4-mini" ]; then
+    CUTOVER_CONFIGURED_PATH="$(awk -F'"' '/^llm_model_path = / {print $2; exit}' "$CONFIG_DIR/geniepod.toml" 2>/dev/null || true)"
+    if [ "$GGUF" != "$CUTOVER_CONFIGURED_PATH" ]; then
+        echo ""
+        echo "  NOTE: $CONFIG_DIR/geniepod.toml was not modified."
+        echo "        To run with this model, set:"
+        echo "          llm_model_path = \"$GGUF\""
+        echo "          llm_model_name = \"qwen\"   # selects the Qwen prompt template"
+        echo "        update GENIEPOD_LLM_MODEL in /etc/systemd/system/genie-llm.service,"
+        echo "        then: sudo systemctl restart genie-llm genie-core"
     fi
 fi
 


### PR DESCRIPTION
## Summary

- Phase 1 of #44: introduces `setup-jetson.sh --model qwen3-4b` as the canonical opt-in alternative to today's Phi-4-mini default. `--model phi-4-mini` is also accepted as an explicit form of the existing default.
- The flag **only** changes the download target — it does not rewrite `llm_model_path` in `/etc/geniepod/geniepod.toml`. Existing Phi-4-mini deployments stay on Phi-4-mini until the operator flips the config lines by hand. Backward-compatible per the issue's "no default change" acceptance criterion.
- `geniepod.toml` carries commented examples for `llm_model_name = "qwen"` and the matching `llm_model_path` next to the existing Phi defaults.
- `prompt.rs` picks up two regression tests locking the canonical `Qwen3-4B-Q4_K_M.gguf` filename to `ModelFamily::Qwen`, so a future detector refactor cannot silently drop it into the small-model prompt shape and lose the JSON tool-call instructions.
- README gets a "Recommended LLM Pairing" subsection under Deployment documenting the Qwen3-4B + `genie-ai-runtime` pairing and the manual flip steps.

Phase 2 (flip the bundled default, introduce the manifest layer, add a voice-cycle latency regression gate) is coupled to #33 and ships in a separate PR. Phase 3 (extract to a separate `genie-ai-model` repo) stays deferred.

## Implementation notes

- Qwen3-4B is sourced from the upstream `Qwen/Qwen3-4B-GGUF` HuggingFace release; chosen over community mirrors for provenance. Open to switching if there's a preferred mirror.
- A fourth hardcode site exists at `deploy/systemd/genie-llm.service:30` (`Environment=GENIEPOD_LLM_MODEL=…`). Phase 1 leaves it alone because flipping the default would break existing Phi-4-mini deployments. Phase 2 will need to address it alongside #33.
- The existing comment at `deploy/systemd/genie-llm.service:22-28` notes a Phi-3/Phi-4-specific `--cache-type-k q4_0 + flash-attn` crash on Tegra/aarch64. Worth a smoke test with Qwen3-4B on Jetson before Phase 2 flips the default; not blocking for the opt-in path here.

## Test plan

- [ ] CI: `cargo test --package genie-core --lib prompt::` — new `detect_qwen3_4b_canonical_filename` and `qwen3_4b_uses_capable_prompt_shape` tests pass.
- [ ] CI: `bash -n deploy/setup-jetson.sh` — syntax-clean (verified locally).
- [ ] Manual: on a Jetson with no existing model, `sudo /opt/geniepod/setup-jetson.sh --model qwen3-4b` downloads
  `Qwen3-4B-Q4_K_M.gguf` to `/opt/geniepod/models/` and prints the manual config-flip instructions.
- [ ] Manual: on a Jetson with the Phi-4-mini default, `sudo /opt/geniepod/setup-jetson.sh` (no flag) still finds the existing model
  and leaves `geniepod.toml` untouched.
- [ ] Manual: `sudo /opt/geniepod/setup-jetson.sh --model bogus` exits 2 with a useful error.

Closes #44 (Phase 1 only — issue stays open for Phases 2 and 3).
