### PR TITLE
ci: add aarch64 Jetson cross-compile workflow (issue #34, 2/4)

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -1,0 +1,75 @@
+name: Cross-compile (aarch64 / Jetson)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  AARCH64_TARGET: aarch64-unknown-linux-gnu
+
+concurrency:
+  group: cross-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  jetson:
+    name: aarch64-unknown-linux-gnu release build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install aarch64 cross toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            gcc-aarch64-linux-gnu \
+            g++-aarch64-linux-gnu
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cross-jetson
+          key: ${{ env.AARCH64_TARGET }}
+
+      - name: cargo build --release (Jetson target)
+        env:
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
+        run: |
+          cargo build --release --locked --target ${AARCH64_TARGET} \
+            -p genie-core
+          cargo build --release --locked --target ${AARCH64_TARGET} \
+            -p genie-ctl -p genie-governor -p genie-health -p genie-api
+
+      - name: Verify all 5 Jetson binaries built
+        run: |
+          set -euo pipefail
+          out="target/${AARCH64_TARGET}/release"
+          for bin in genie-core genie-ctl genie-governor genie-health genie-api; do
+            test -f "$out/$bin" || { echo "missing: $out/$bin"; exit 1; }
+            file "$out/$bin" | grep -q "ARM aarch64" \
+              || { echo "$bin is not an aarch64 ELF"; exit 1; }
+          done
+          ls -lh "$out"/genie-core "$out"/genie-ctl "$out"/genie-governor \
+                 "$out"/genie-health "$out"/genie-api
+
+      - name: Upload Jetson binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: genie-jetson-aarch64-${{ github.sha }}
+          path: |
+            target/aarch64-unknown-linux-gnu/release/genie-core
+            target/aarch64-unknown-linux-gnu/release/genie-ctl
+            target/aarch64-unknown-linux-gnu/release/genie-governor
+            target/aarch64-unknown-linux-gnu/release/genie-health
+            target/aarch64-unknown-linux-gnu/release/genie-api
+          if-no-files-found: error
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Added
 
+- `.github/workflows/cross.yml` — aarch64 Jetson cross-compile workflow
+  for issue #34. Installs `gcc-aarch64-linux-gnu` /
+  `g++-aarch64-linux-gnu`, adds the `aarch64-unknown-linux-gnu` Rust
+  target, then runs the same two-step `cargo build --release --locked
+  --target aarch64-unknown-linux-gnu` recipe `make jetson` uses (with
+  `CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc` and the matching
+  `AR_` override) to produce `genie-core`, `genie-ctl`, `genie-governor`,
+  `genie-health`, and `genie-api`. A post-build verify step asserts
+  each binary is in fact an ELF tagged `ARM aarch64` before uploading
+  them as the `genie-jetson-aarch64-${{ github.sha }}` artifact with a
+  14-day retention. Catches the cross-compile breakage that previously
+  only surfaced at `make jetson` / `make deploy` time. Jetson badge added
+  at the top of the README.
 - Opt-in Qwen3-4B model download in `setup-jetson.sh` (issue #44, Phase 1).
   `deploy/setup-jetson.sh --model qwen3-4b` fetches
   `Qwen3-4B-Q4_K_M.gguf` from `Qwen/Qwen3-4B-GGUF` into

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GenieClaw
 
 [![CI](https://github.com/GeniePod/genie-claw/actions/workflows/ci.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/ci.yml)
+[![Jetson cross-compile](https://github.com/GeniePod/genie-claw/actions/workflows/cross.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/cross.yml)
 
 **A private, always-on AI for your home. Runs entirely on a Jetson Orin Nano.
 Voice in, voice out, controls Home Assistant, no cloud.**


### PR DESCRIPTION
> 🤖 **Catches the workflow most likely to silently rot.** Cross-compile breakage previously only surfaced at `make jetson` / `make deploy` time — now it surfaces on every PR.

Third slice of issue #34's CI pipeline (after the fmt/clippy cleanup landed in #36 and the daily-loop workflow + RUSTSEC bump landed in #37). **Independent** — no dependency on either of those PRs.

## Why this matters

GenieClaw ships to a Jetson Orin Nano. The repo's `Makefile` already has a working `make jetson` recipe, but it's only ever run when someone manually deploys. If a transitive dependency drops `aarch64` support, or a new crate brings in build-script C code that the cross-toolchain can't handle, the failure stays invisible until release time. This workflow surfaces the breakage **the same day** a regressing PR is opened.

## What the workflow does

| # | Step | Detail |
| :-: | :--- | :--- |
| 1 | Install cross toolchain | `apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu` |
| 2 | Install Rust target | `dtolnay/rust-toolchain@stable` + `targets: aarch64-unknown-linux-gnu` |
| 3 | Cache | `Swatinem/rust-cache@v2` keyed `cross-jetson` / aarch64 |
| 4 | Build `genie-core` | `cargo build --release --locked --target aarch64-unknown-linux-gnu -p genie-core` |
| 5 | Build the rest | same flags, `-p genie-ctl -p genie-governor -p genie-health -p genie-api` |
| 6 | Verify | shell step asserts all 5 outputs exist **and** `file` reports `ARM aarch64` |
| 7 | Upload artifact | `genie-jetson-aarch64-${{ github.sha }}`, 14-day retention, `if-no-files-found: error` |

The env vars (`CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc`, matching `AR_`) mirror the existing `Makefile` exactly, so the CI recipe and the local recipe stay in lock-step. Any future change to `make jetson` should be reflected here in the same PR.

## The verify step matters

```bash
for bin in genie-core genie-ctl genie-governor genie-health genie-api; do
  test -f "$out/$bin" || { echo "missing: $out/$bin"; exit 1; }
  file "$out/$bin" | grep -q "ARM aarch64" \
    || { echo "$bin is not an aarch64 ELF"; exit 1; }
done
```

Without it, a future misconfiguration could silently produce **x86_64** binaries that pass `cargo build` but bomb out on the Jetson. The `file` check catches that.

## Local verification

Installed `gcc-aarch64-linux-gnu g++-aarch64-linux-gnu` and `rustup target add aarch64-unknown-linux-gnu`, then ran the workflow's commands verbatim:

| Binary | Size | `file` output |
| :--- | ---: | :--- |
| `genie-core` | 4.3 MB | `ELF 64-bit LSB pie executable, ARM aarch64, …, stripped` |
| `genie-api` | 2.3 MB | `ELF 64-bit LSB pie executable, ARM aarch64, …, stripped` |
| `genie-governor` | 2.3 MB | `ELF 64-bit LSB pie executable, ARM aarch64, …, stripped` |
| `genie-health` | 2.2 MB | `ELF 64-bit LSB pie executable, ARM aarch64, …, stripped` |
| `genie-ctl` | 965 KB | `ELF 64-bit LSB pie executable, ARM aarch64, …, stripped` |

- [x] All 5 binaries produced
- [x] All 5 `file`-verified as `ARM aarch64`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cross.yml'))"` — valid YAML

## README

Added a "Jetson cross-compile" badge at the top.

---

Refs #34.
