### PR TITLE
ci: add cargo-audit + cargo-deny supply-chain workflow (issue #34)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,50 @@
+name: Audit
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/audit.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/audit.yml"
+  schedule:
+    # Weekly: Mondays at 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-audit:
+    name: cargo audit (security advisories)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  cargo-deny:
+    name: cargo deny (licenses + bans + sources + advisories)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+          log-level: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- `.github/workflows/audit.yml` and `deny.toml` — supply-chain audit
+  workflow for issue #34. Runs `rustsec/audit-check` plus
+  `EmbarkStudios/cargo-deny-action` on every `Cargo.{toml,lock}` /
+  `deny.toml` / workflow change and on a Monday-06:00-UTC cron.
+  `deny.toml` codifies the project's license policy
+  (`AGPL-3.0-only` for genie-claw itself; the standard permissive
+  set plus `CDLA-Permissive-2.0` for webpki-roots and `OpenSSL` for
+  ring on the dependency side), pins all packages to crates.io as the
+  only allowed source so a future git dep requires an explicit policy
+  update, and currently runs `wildcards = "allow"` because workspace
+  path-deps would otherwise trip the public-crate exemption logic.
+  Audit badge added at the top of the README.
 - `.github/workflows/cross.yml` — aarch64 Jetson cross-compile workflow
   for issue #34. Installs `gcc-aarch64-linux-gnu` /
   `g++-aarch64-linux-gnu`, adds the `aarch64-unknown-linux-gnu` Rust

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/GeniePod/genie-claw/actions/workflows/ci.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/ci.yml)
 [![Jetson cross-compile](https://github.com/GeniePod/genie-claw/actions/workflows/cross.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/cross.yml)
+[![Audit](https://github.com/GeniePod/genie-claw/actions/workflows/audit.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/audit.yml)
 
 **A private, always-on AI for your home. Runs entirely on a Jetson Orin Nano.
 Voice in, voice out, controls Home Assistant, no cloud.**

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,85 @@
+# cargo-deny configuration for genie-claw.
+#
+# Run locally with:
+#   cargo install --locked cargo-deny
+#   cargo deny check
+#
+# Layout follows the cargo-deny 0.14+ schema (sections: graph, advisories,
+# licenses, bans, sources). The CI workflow uses the action's defaults plus
+# the rules in this file.
+
+[graph]
+all-features = true
+# Skip dev-dependencies for license / ban evaluation — they don't ship in
+# the Jetson binaries.
+exclude-dev = true
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+]
+
+# ── Security advisories ───────────────────────────────────────────
+# Fail on any unpatched RustSec advisory affecting our dependency tree.
+[advisories]
+version = 2
+yanked = "warn"
+ignore = []
+
+# ── Licenses ──────────────────────────────────────────────────────
+# genie-claw itself is AGPL-3.0-only. Allow the common permissive
+# licenses that AGPL-3.0 is one-way-compatible with for upstream deps.
+[licenses]
+version = 2
+confidence-threshold = 0.93
+unused-allowed-license = "allow"
+allow = [
+    "AGPL-3.0-only",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "CC0-1.0",
+    "MPL-2.0",
+    "OpenSSL",
+    # webpki-roots ships the Mozilla CA bundle under CDLA-Permissive-2.0,
+    # which is a permissive data-license (no copyleft / no patent terms).
+    "CDLA-Permissive-2.0",
+]
+
+# Permit ring's BoringSSL-derived license bundle.
+[[licenses.clarify]]
+crate = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+# ── Bans ──────────────────────────────────────────────────────────
+[bans]
+multiple-versions = "warn"
+# genie-claw's workspace crates depend on each other via `path = "..."`
+# entries without explicit versions. cargo-deny treats those as wildcard
+# *version* deps unless the crate is marked private (publish = false),
+# but the workspace crates currently carry publishable metadata even
+# though nothing is shipped to crates.io. Until that is reconciled, allow
+# wildcards globally — path deps are resolved locally and aren't a
+# supply-chain risk.
+wildcards = "allow"
+highlight = "all"
+# Crates we explicitly want banned would go here (e.g. yanked impls,
+# known-unmaintained shims). Empty for now.
+deny = []
+skip = []
+skip-tree = []
+
+# ── Sources ───────────────────────────────────────────────────────
+# Only allow dependencies from crates.io. Git deps must be added here
+# explicitly so a supply-chain swap shows up as a CI failure.
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
> 🛡️ **Supply-chain guard.** Catches RustSec advisories and license / source policy violations on every dep change, plus a weekly cron so quiet weeks don't hide new advisories.

Fourth slice of issue #34's CI pipeline (after #36 lint cleanup, #37 ci.yml + rustls-webpki bump, and the cross-compile PR).

> ⚠️ **Depends on #37.** This branch was built on top of the `rustls-webpki 0.103.13` bump in #37 because `cargo-audit` fails against the previous lockfile (RUSTSEC-2026-0104). GitHub will show the rustls-webpki commit in the diff until #37 merges; after that the visible diff collapses to just `audit.yml` + `deny.toml` + README badge + CHANGELOG.

## The two jobs

| Job | Action | Catches |
| :--- | :--- | :--- |
| `cargo-audit` | [`rustsec/audit-check@v2.0.0`](https://github.com/rustsec/audit-check) | RustSec advisories |
| `cargo-deny` | [`EmbarkStudios/cargo-deny-action@v2`](https://github.com/EmbarkStudios/cargo-deny-action) | License / ban / source policy via `deny.toml` |

## When it runs

- 🔄 **On `pull_request` and `push` to `main`** — only when `Cargo.{toml,lock}`, `deny.toml`, or the workflow itself changes. Rust-only diffs don't trigger the job, keeping CI minutes lean.
- ⏰ **Weekly cron** at `0 6 * * 1` (Mondays 06:00 UTC). Catches advisories that ship in quiet weeks where no dep changes.
- 🖱️ **`workflow_dispatch`** for manual reruns.

## What `deny.toml` codifies

cargo-deny v2 schema. `all-features = true`, `exclude-dev = true`, two target triples: `x86_64-unknown-linux-gnu` (host) and `aarch64-unknown-linux-gnu` (Jetson).

<details>
<summary><b><code>[advisories]</code></b></summary>

```toml
version = 2
yanked = "warn"
ignore = []
```

`yanked = "warn"` means a yanked crate surfaces as a CI warning but doesn't fail the build — giving the team a heads-up window to update without blocking unrelated PRs. No ignore list today.

</details>

<details>
<summary><b><code>[licenses]</code></b></summary>

| License | Why it's allowed |
| :--- | :--- |
| `AGPL-3.0-only` | The genie-claw workspace crates themselves |
| `Apache-2.0`, `Apache-2.0 WITH LLVM-exception`, `MIT`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `Unicode-3.0`, `Unicode-DFS-2016`, `Zlib`, `CC0-1.0`, `MPL-2.0` | Standard permissive bundle, AGPL-3.0-compatible upstream |
| `OpenSSL` | `ring`'s BoringSSL-derived bundle |
| `CDLA-Permissive-2.0` | `webpki-roots` ships the Mozilla CA bundle under this — permissive data license, no copyleft / no patent terms |

`unused-allowed-license = "allow"` so the policy can list defensive entries (e.g. `OpenSSL`, `MPL-2.0`) without warning when no current dep matches. A `[[licenses.clarify]]` block normalizes `ring`'s `MIT AND ISC AND OpenSSL` bundle.

</details>

<details>
<summary><b><code>[bans]</code></b></summary>

- `multiple-versions = "warn"` — the current lockfile has one duplicate (`hashbrown 0.14.5` from `rusqlite/hashlink` vs `hashbrown 0.16.1` from `toml_edit/indexmap`). Warning, not error, so this surfaces but doesn't block.
- `wildcards = "allow"` with an inline comment: workspace path-deps trip cargo-deny's public-crate exemption logic because the workspace metadata is publishable-looking even though nothing ships to crates.io. This can tighten to `"deny"` later if the workspace metadata is reconciled (e.g. `publish = false` on each crate).

</details>

<details>
<summary><b><code>[sources]</code></b></summary>

```toml
unknown-registry = "deny"
unknown-git = "deny"
allow-registry = ["https://github.com/rust-lang/crates.io-index"]
allow-git = []
```

A future git dep — or a typosquat registry — will surface as a CI failure with an explanation, instead of silently entering the dependency graph.

</details>

## Local verification

```
$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok
```

- [x] `cargo deny check` passes on the current lockfile (with #37 applied)
- [x] `cargo audit` — 0 vulnerabilities (with #37 applied)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/audit.yml'))"` — valid YAML

## README

Added an Audit badge at the top of `README.md`.

---

Refs #34.
