### PR TITLE
ci: add shellcheck + ruff workflow for shell / Python scripts (issue #34)

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,0 +1,68 @@
+name: Scripts
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.sh"
+      - "**.py"
+      - ".github/workflows/scripts.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**.sh"
+      - "**.py"
+      - ".github/workflows/scripts.yml"
+
+concurrency:
+  group: scripts-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends shellcheck
+      - name: Run shellcheck on all .sh files
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files '*.sh')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "no shell scripts to check"
+            exit 0
+          fi
+          printf '%s\n' "${files[@]}"
+          shellcheck --severity=warning "${files[@]}"
+
+  ruff:
+    name: ruff
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: pip install --no-cache-dir 'ruff==0.6.*'
+      - name: Discover Python files
+        id: discover
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files '*.py')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "no python files to check"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\n' "${files[@]}"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+      - name: ruff check
+        if: steps.discover.outputs.found == 'true'
+        run: ruff check --output-format=github .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- `.github/workflows/scripts.yml` and `ruff.toml` — shellcheck + ruff
+  workflow for the stretch slice of issue #34. Discovers all
+  tracked `*.sh` and `*.py` files via `git ls-files`, then runs
+  `shellcheck --severity=warning` and `ruff check
+  --output-format=github`. `ruff.toml` pins `target-version = "py310"`
+  (Jetson Ubuntu 22.04) and ignores E402, with an inline comment
+  explaining why: `deploy/scripts/genie-wake-listen.py` and
+  `genie-wakeword.py` legitimately import after redirecting ALSA stderr
+  to `/dev/null` so the C-level diagnostic noise from PyAudio doesn't
+  leak into the protocol stdout. Trigger paths are scoped to `**.sh` /
+  `**.py` / the workflow file itself so Rust-only changes don't spin up
+  this job.
 - First-voice-reply latency banner (issue #19). On the first completed voice
   cycle of a `genie-core` run, the loop prints a one-shot 5-phase breakdown
   from end-of-user-speech to first audible audio:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+# Ruff config for genie-claw's helper Python scripts under deploy/scripts/.
+# These scripts target the Python that ships with Jetson's Ubuntu 22.04 image.
+
+target-version = "py310"
+line-length = 100
+
+[lint]
+# E402 (module-level import not at top of file) is intentionally allowed:
+# the wakeword scripts have to suppress ALSA stderr and silence scipy/numpy
+# warnings *before* importing pyaudio / openwakeword, otherwise the C-level
+# diagnostics leak into the protocol stdout.
+ignore = ["E402"]


### PR DESCRIPTION
> 🧪 **The stretch goal from #34.** Lints every tracked shell script and Python script in the repo. Won't run on Rust-only diffs.

Closes the stretch slice of issue #34. **Independent** — no dependency on the other CI PRs in the series.

## Why a separate workflow?

The shell scripts under `deploy/` are critical to Jetson deployment (`setup-jetson.sh`, `detect-audio-device.sh`, `genie-restart-all.sh`). The Python scripts (`genie-wake-listen.py`, `genie-wakeword.py`) drive the wake-word detection that fronts the entire voice loop. A subtle bug in either is hard to catch by code review alone, and the Rust CI pipeline doesn't cover them. This workflow closes that gap.

## The two jobs

| Job | What it runs |
| :--- | :--- |
| `shellcheck` | `apt-get install shellcheck`, then discover via `git ls-files '*.sh'`, then `shellcheck --severity=warning` over the list |
| `ruff` | `actions/setup-python@v5` (3.12), `pip install 'ruff==0.6.*'`, discover via `git ls-files '*.py'`, then `ruff check --output-format=github` |

Both jobs **exit cleanly when discovery returns no files**, so a future cleanup pass that removes every shell or Python script doesn't break CI.

Triggers are scoped to `**.sh` / `**.py` / the workflow file itself — Rust-only diffs never spin this up.

## Why `ruff.toml` and not stricter ruff defaults?

```toml
target-version = "py310"
line-length = 100

[lint]
ignore = ["E402"]
```

`E402` (*module-level import not at top of file*) is intentionally allowed because the wakeword scripts under `deploy/scripts/` **must** run code before importing PyAudio:

```python
import warnings
warnings.filterwarnings("ignore")     # Silence scipy/numpy version warnings

import os, sys
_stderr_fd = os.dup(2)
_devnull = os.open(os.devnull, os.O_WRONLY)
os.dup2(_devnull, 2)                  # Redirect stderr → /dev/null

import argparse
import numpy as np
import pyaudio                        # ← E402 fires here without the ignore
from scipy.signal import resample
from openwakeword.model import Model

os.dup2(_stderr_fd, 2)                # Restore stderr
```

Without the redirect, ALSA / PortAudio dump C-level diagnostics on stderr that pollute the protocol stdout the scripts use to talk to genie-core. The ordering is load-bearing. The `ruff.toml` comment documents this so a future contributor doesn't "fix" it.

`py310` matches the Python that ships with Jetson Ubuntu 22.04 (the deploy target).

## Local verification

Reproduced both CI jobs on this branch:

- [x] **shellcheck `--severity=warning`** — clean on:
  - `deploy/setup-jetson.sh`
  - `deploy/scripts/detect-audio-device.sh`
  - `deploy/scripts/genie-restart-all.sh`
- [x] **`ruff check`** with the new config — clean on:
  - `deploy/scripts/genie-wake-listen.py`
  - `deploy/scripts/genie-wakeword.py`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scripts.yml'))"` — valid YAML

---

Refs #34.
