### PR TITLE
feat(telegram): voice-message ingestion via Whisper (issue #42 phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +854,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -846,6 +863,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1358,6 +1376,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -448,6 +448,43 @@ pub struct TelegramConfig {
     /// Bypass the allowlist and accept messages from any chat.
     #[serde(default)]
     pub allow_all_chats: bool,
+
+    /// Voice-message handling for the Telegram channel (issue #42).
+    #[serde(default)]
+    pub voice: TelegramVoiceConfig,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct TelegramVoiceConfig {
+    /// Enable voice-message ingestion. When false, voice messages get a polite
+    /// text reply explaining that voice is not enabled on this deployment.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Hard cap on accepted voice duration. Telegram includes a `duration`
+    /// field; anything longer is rejected before download.
+    #[serde(default = "defaults::telegram_voice_max_duration_secs")]
+    pub max_voice_duration_secs: u32,
+
+    /// Delete the downloaded `.ogg` and transcoded `.wav` after handling.
+    #[serde(default = "defaults::telegram_voice_delete_temp_audio")]
+    pub delete_temp_audio: bool,
+
+    /// Path to the `ffmpeg` binary used to transcode Telegram OGG/Opus to the
+    /// 16 kHz mono WAV that Whisper consumes.
+    #[serde(default = "defaults::telegram_voice_ffmpeg_path")]
+    pub ffmpeg_path: PathBuf,
+}
+
+impl Default for TelegramVoiceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_voice_duration_secs: defaults::telegram_voice_max_duration_secs(),
+            delete_temp_audio: defaults::telegram_voice_delete_temp_audio(),
+            ffmpeg_path: defaults::telegram_voice_ffmpeg_path(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -811,6 +848,7 @@ impl Default for TelegramConfig {
             poll_timeout_secs: defaults::telegram_poll_timeout_secs(),
             allowed_chat_ids: Vec::new(),
             allow_all_chats: false,
+            voice: TelegramVoiceConfig::default(),
         }
     }
 }
@@ -1426,6 +1464,15 @@ mod defaults {
     }
     pub fn telegram_poll_timeout_secs() -> u64 {
         30
+    }
+    pub fn telegram_voice_max_duration_secs() -> u32 {
+        60
+    }
+    pub fn telegram_voice_delete_temp_audio() -> bool {
+        true
+    }
+    pub fn telegram_voice_ffmpeg_path() -> PathBuf {
+        PathBuf::from("ffmpeg")
     }
     pub fn web_search_enabled() -> bool {
         true

--- a/crates/genie-core/Cargo.toml
+++ b/crates/genie-core/Cargo.toml
@@ -38,7 +38,7 @@ libloading = "0.8"
 toml = { workspace = true }
 genie-skill-sdk = { path = "../genie-skill-sdk" }
 async-trait = "0.1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 
 [dev-dependencies]
 toml = { workspace = true }

--- a/crates/genie-core/src/main.rs
+++ b/crates/genie-core/src/main.rs
@@ -272,6 +272,16 @@ async fn main() -> Result<()> {
                     poll_timeout_secs: config.telegram.poll_timeout_secs,
                     allowed_chat_ids: config.telegram.allowed_chat_ids.clone(),
                     allow_all_chats: config.telegram.allow_all_chats,
+                    voice: genie_core::telegram::TelegramVoiceRuntimeConfig {
+                        enabled: config.telegram.voice.enabled,
+                        max_voice_duration_secs: config.telegram.voice.max_voice_duration_secs,
+                        delete_temp_audio: config.telegram.voice.delete_temp_audio,
+                        ffmpeg_path: config.telegram.voice.ffmpeg_path.clone(),
+                        whisper_port: config.core.whisper_port,
+                        whisper_cli_path: config.core.whisper_cli_path.clone(),
+                        whisper_model: config.core.whisper_model.clone(),
+                        stt_language: config.core.stt_language.clone(),
+                    },
                 };
 
                 tracing::info!(

--- a/crates/genie-core/src/telegram.rs
+++ b/crates/genie-core/src/telegram.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use std::time::Duration;
+use tokio::process::Command;
 
 const TELEGRAM_MAX_MESSAGE_LEN: usize = 4096;
 
@@ -13,6 +15,25 @@ pub struct TelegramRuntimeConfig {
     pub poll_timeout_secs: u64,
     pub allowed_chat_ids: Vec<i64>,
     pub allow_all_chats: bool,
+    pub voice: TelegramVoiceRuntimeConfig,
+}
+
+/// Voice-message ingestion settings for the Telegram channel (issue #42).
+///
+/// The Telegram adapter stays out of process boundaries with `voice/*`
+/// modules — it speaks to Whisper directly via the same HTTP server or
+/// `whisper-cli` subprocess the on-device voice loop uses, so a chat-only
+/// deployment without ALSA still gets voice-in.
+#[derive(Debug, Clone)]
+pub struct TelegramVoiceRuntimeConfig {
+    pub enabled: bool,
+    pub max_voice_duration_secs: u32,
+    pub delete_temp_audio: bool,
+    pub ffmpeg_path: PathBuf,
+    pub whisper_port: u16,
+    pub whisper_cli_path: PathBuf,
+    pub whisper_model: PathBuf,
+    pub stt_language: String,
 }
 
 pub async fn run(config: TelegramRuntimeConfig) -> Result<()> {
@@ -148,6 +169,12 @@ impl TelegramApi {
             return Ok(());
         }
 
+        // Voice or audio messages (issue #42): download → transcode → STT →
+        // /api/chat → reply. The text path falls through below.
+        if let Some(voice) = message.voice.as_ref().or(message.audio.as_ref()) {
+            return self.handle_voice_message(chat_id, voice).await;
+        }
+
         let Some(text) = message
             .text
             .as_deref()
@@ -169,6 +196,294 @@ impl TelegramApi {
         let core_response = self.chat_core(chat_id, normalized).await?;
         self.send_text(chat_id, &core_response).await?;
         Ok(())
+    }
+
+    async fn handle_voice_message(
+        &self,
+        chat_id: i64,
+        voice: &TelegramVoice,
+    ) -> Result<()> {
+        let voice_cfg = &self.config.voice;
+
+        if !voice_cfg.enabled {
+            let _ = self
+                .send_text(
+                    chat_id,
+                    "Voice messages aren't enabled on this deployment.",
+                )
+                .await;
+            return Ok(());
+        }
+
+        if voice.duration > voice_cfg.max_voice_duration_secs {
+            let _ = self
+                .send_text(
+                    chat_id,
+                    &format!(
+                        "Voice message is too long ({}s); the limit is {}s.",
+                        voice.duration, voice_cfg.max_voice_duration_secs
+                    ),
+                )
+                .await;
+            return Ok(());
+        }
+
+        let pid = std::process::id();
+        let nonce: u32 = rand_nonce();
+        let ogg_path = format!("/tmp/geniepod-tg-voice-{pid}-{nonce}.ogg");
+        let wav_path = format!("/tmp/geniepod-tg-voice-{pid}-{nonce}.wav");
+
+        // RAII-style cleanup: drop guard removes both temp files on every exit
+        // path (success, error, panic during unwind).
+        let _cleanup = TempCleanup::new(
+            voice_cfg.delete_temp_audio,
+            ogg_path.clone(),
+            wav_path.clone(),
+        );
+
+        if let Err(e) = self.download_voice_file(&voice.file_id, &ogg_path).await {
+            tracing::warn!(error = %e, file_id = %voice.file_id, "telegram voice download failed");
+            let _ = self
+                .send_text(
+                    chat_id,
+                    "Sorry, I couldn't download that voice message from Telegram.",
+                )
+                .await;
+            return Ok(());
+        }
+
+        if let Err(e) = self.transcode_to_wav(&ogg_path, &wav_path).await {
+            tracing::warn!(error = %e, "telegram voice transcode failed");
+            let _ = self
+                .send_text(
+                    chat_id,
+                    "Sorry, I couldn't decode that voice message (ffmpeg failed).",
+                )
+                .await;
+            return Ok(());
+        }
+
+        let transcript = match self.transcribe_wav(&wav_path).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(error = %e, "telegram voice transcription failed");
+                let _ = self
+                    .send_text(
+                        chat_id,
+                        "Sorry, I couldn't transcribe that voice message.",
+                    )
+                    .await;
+                return Ok(());
+            }
+        };
+
+        let transcript = clean_transcript(&transcript);
+        if transcript.is_empty() {
+            // Whisper produced nothing useful — either silence, hallucination,
+            // or unrecognized speech. Mirror the intent gate's "blank audio"
+            // outcome from the on-device voice loop.
+            let _ = self
+                .send_text(
+                    chat_id,
+                    "I couldn't make out any speech in that voice message.",
+                )
+                .await;
+            return Ok(());
+        }
+
+        tracing::info!(
+            chat_id,
+            duration_secs = voice.duration,
+            transcript = %transcript,
+            "telegram voice message transcribed"
+        );
+
+        let core_response = self.chat_core(chat_id, &transcript).await?;
+        self.send_text(chat_id, &core_response).await?;
+        Ok(())
+    }
+
+    async fn download_voice_file(&self, file_id: &str, dest_path: &str) -> Result<()> {
+        // Telegram getFile → file_path, then GET the binary off the file CDN.
+        let payload = serde_json::json!({ "file_id": file_id });
+        let env: TelegramEnvelope<TelegramFile> = self
+            .client
+            .post(self.method_url("getFile"))
+            .json(&payload)
+            .send()
+            .await
+            .context("Telegram getFile request failed")?
+            .error_for_status()
+            .context("Telegram getFile HTTP error")?
+            .json()
+            .await
+            .context("Telegram getFile JSON decode failed")?;
+
+        if !env.ok {
+            anyhow::bail!(
+                "Telegram getFile API error: {}",
+                env.description.unwrap_or_else(|| "unknown error".into())
+            );
+        }
+
+        let file = env
+            .result
+            .context("Telegram getFile returned no result body")?;
+        let file_path = file
+            .file_path
+            .context("Telegram getFile returned no file_path")?;
+
+        let download_url = format!(
+            "{}/file/bot{}/{}",
+            self.config.api_base.trim_end_matches('/'),
+            self.config.bot_token,
+            file_path
+        );
+
+        let bytes = self
+            .client
+            .get(&download_url)
+            .send()
+            .await
+            .context("Telegram file download failed")?
+            .error_for_status()
+            .context("Telegram file download HTTP error")?
+            .bytes()
+            .await
+            .context("Telegram file body read failed")?;
+
+        tokio::fs::write(dest_path, &bytes)
+            .await
+            .with_context(|| format!("write temp ogg to {dest_path}"))?;
+        Ok(())
+    }
+
+    async fn transcode_to_wav(&self, ogg_path: &str, wav_path: &str) -> Result<()> {
+        let ffmpeg = &self.config.voice.ffmpeg_path;
+        let output = Command::new(ffmpeg)
+            .args([
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-i",
+                ogg_path,
+                "-ar",
+                "16000",
+                "-ac",
+                "1",
+                "-f",
+                "wav",
+                wav_path,
+            ])
+            .output()
+            .await
+            .with_context(|| format!("failed to spawn ffmpeg at {ffmpeg:?}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("ffmpeg transcode failed: {}", stderr.trim());
+        }
+
+        Ok(())
+    }
+
+    async fn transcribe_wav(&self, wav_path: &str) -> Result<String> {
+        let voice_cfg = &self.config.voice;
+        if voice_cfg.whisper_port > 0 {
+            self.transcribe_via_whisper_server(voice_cfg.whisper_port, wav_path)
+                .await
+        } else {
+            self.transcribe_via_whisper_cli(wav_path).await
+        }
+    }
+
+    async fn transcribe_via_whisper_server(&self, port: u16, wav_path: &str) -> Result<String> {
+        // Posts to whisper.cpp's /inference endpoint with the same form fields
+        // the on-device voice loop uses: explicit language, deterministic temp,
+        // JSON response, empty initial prompt. Lives parallel to
+        // `voice::stt::SttEngine::transcribe_via_server` rather than reusing
+        // it directly so the Telegram adapter stays callable from chat-only
+        // builds where the `voice` feature is off.
+        let wav_data = tokio::fs::read(wav_path)
+            .await
+            .with_context(|| format!("read wav {wav_path}"))?;
+
+        let language = configured_language(&self.config.voice.stt_language);
+
+        let mut form = reqwest::multipart::Form::new()
+            .text("temperature", "0.0")
+            .text("response_format", "json")
+            .text("prompt", "");
+
+        if let Some(lang) = language {
+            form = form.text("language", lang);
+        }
+
+        let file_part = reqwest::multipart::Part::bytes(wav_data)
+            .file_name("audio.wav")
+            .mime_str("audio/wav")
+            .context("invalid mime for whisper part")?;
+        form = form.part("file", file_part);
+
+        let url = format!("http://127.0.0.1:{port}/inference");
+        let resp: serde_json::Value = self
+            .client
+            .post(url)
+            .multipart(form)
+            .send()
+            .await
+            .context("whisper-server request failed")?
+            .error_for_status()
+            .context("whisper-server HTTP error")?
+            .json()
+            .await
+            .context("whisper-server JSON decode failed")?;
+
+        Ok(resp
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string())
+    }
+
+    async fn transcribe_via_whisper_cli(&self, wav_path: &str) -> Result<String> {
+        let voice_cfg = &self.config.voice;
+        let cli = &voice_cfg.whisper_cli_path;
+        let model = &voice_cfg.whisper_model;
+
+        let mut args: Vec<String> = vec![
+            "-m".into(),
+            model.to_string_lossy().into_owned(),
+            "-f".into(),
+            wav_path.into(),
+            "--no-timestamps".into(),
+            "--no-prints".into(),
+            "--threads".into(),
+            "4".into(),
+            "--suppress-nst".into(),
+            "--no-speech-thold".into(),
+            "0.8".into(),
+        ];
+
+        if let Some(lang) = configured_language(&voice_cfg.stt_language) {
+            args.push("--language".into());
+            args.push(lang);
+        }
+
+        let output = Command::new(cli)
+            .args(&args)
+            .output()
+            .await
+            .with_context(|| format!("failed to spawn whisper-cli at {cli:?}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("whisper-cli failed: {}", stderr.trim());
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
     async fn chat_core(&self, chat_id: i64, text: &str) -> Result<String> {
@@ -239,6 +554,82 @@ impl TelegramApi {
     }
 }
 
+/// Drop guard that removes Telegram voice temp files on every exit path.
+/// Honors `delete_temp_audio = false` for live debugging.
+struct TempCleanup {
+    delete: bool,
+    ogg: String,
+    wav: String,
+}
+
+impl TempCleanup {
+    fn new(delete: bool, ogg: String, wav: String) -> Self {
+        Self { delete, ogg, wav }
+    }
+}
+
+impl Drop for TempCleanup {
+    fn drop(&mut self) {
+        if !self.delete {
+            return;
+        }
+        let _ = std::fs::remove_file(&self.ogg);
+        let _ = std::fs::remove_file(&self.wav);
+    }
+}
+
+/// Cheap unique suffix to keep concurrent voice messages from colliding on
+/// `/tmp` paths when whisper-server allows parallel transcribes.
+fn rand_nonce() -> u32 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0)
+}
+
+/// Normalize the configured STT language ("auto", "" → None; everything else
+/// passed through trimmed). Mirrors `voice::language::configured_language`
+/// without requiring the `voice` feature to be on.
+fn configured_language(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("auto") {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Trim Whisper output and drop common no-speech / hallucination markers.
+/// A small, conservative subset of `voice::stt::SttEngine::clean_hallucinations`;
+/// the agent-side intent gate handles the rest once `/api/chat` runs.
+fn clean_transcript(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let lower = trimmed.to_lowercase();
+    const HALLUCINATIONS: &[&str] = &[
+        "[blank_audio]",
+        "[ blank_audio ]",
+        "(blank audio)",
+        "[silence]",
+        "(silence)",
+        "[music]",
+        "(music)",
+        "[applause]",
+        "(applause)",
+        "thank you.",
+        "thanks for watching.",
+        "you",
+    ];
+    if HALLUCINATIONS.iter().any(|h| lower == *h) {
+        return String::new();
+    }
+    trimmed.to_string()
+}
+
 fn strip_bot_mention(text: &str) -> String {
     text.split_whitespace()
         .filter(|part| !part.starts_with('@'))
@@ -303,6 +694,23 @@ struct TelegramMessage {
     from: Option<TelegramUser>,
     #[serde(default)]
     text: Option<String>,
+    #[serde(default)]
+    voice: Option<TelegramVoice>,
+    #[serde(default)]
+    audio: Option<TelegramVoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramVoice {
+    file_id: String,
+    #[serde(default)]
+    duration: u32,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct TelegramFile {
+    #[serde(default)]
+    file_path: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -330,7 +738,10 @@ struct CoreChatResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{TELEGRAM_MAX_MESSAGE_LEN, split_message, strip_bot_mention};
+    use super::{
+        TELEGRAM_MAX_MESSAGE_LEN, clean_transcript, configured_language, split_message,
+        strip_bot_mention,
+    };
 
     #[test]
     fn telegram_split_keeps_short_message() {
@@ -353,5 +764,43 @@ mod tests {
     #[test]
     fn telegram_strip_bot_mentions() {
         assert_eq!(strip_bot_mention("@geniebot hello there"), "hello there");
+    }
+
+    #[test]
+    fn configured_language_normalizes_auto_and_blank() {
+        assert_eq!(configured_language(""), None);
+        assert_eq!(configured_language("auto"), None);
+        assert_eq!(configured_language(" AUTO "), None);
+        assert_eq!(configured_language(" en "), Some("en".to_string()));
+    }
+
+    #[test]
+    fn clean_transcript_drops_whisper_hallucinations() {
+        assert_eq!(clean_transcript("[BLANK_AUDIO]"), "");
+        assert_eq!(clean_transcript(" Thank you. "), "");
+        assert_eq!(clean_transcript("(silence)"), "");
+        assert_eq!(clean_transcript("turn off the lights"), "turn off the lights");
+    }
+
+    #[test]
+    fn telegram_voice_message_deserializes() {
+        // Spot-check that the message struct accepts a real-looking voice
+        // update payload from Telegram getUpdates. This keeps the wire-format
+        // contract in the test suite rather than only in production traffic.
+        let raw = serde_json::json!({
+            "update_id": 1,
+            "message": {
+                "chat": { "id": 42 },
+                "from": { "is_bot": false },
+                "voice": { "file_id": "AwACAg...", "duration": 5 }
+            }
+        });
+        let parsed: super::TelegramUpdate = serde_json::from_value(raw).unwrap();
+        let msg = parsed.message.unwrap();
+        let voice = msg.voice.unwrap();
+        assert_eq!(voice.file_id, "AwACAg...");
+        assert_eq!(voice.duration, 5);
+        assert!(msg.audio.is_none());
+        assert!(msg.text.is_none());
     }
 }

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -164,6 +164,15 @@ alert_webhook_url = ""            # Optional local notifier endpoint.
 # poll_timeout_secs = 30
 # allowed_chat_ids = [123456789]   # Recommended allowlist for private use.
 # allow_all_chats = false
+#
+# Voice-message ingestion (issue #42). Reuses the configured whisper-server
+# (core.whisper_port > 0) or whisper-cli; needs `ffmpeg` on $PATH for the
+# OGG/Opus → 16 kHz mono WAV transcode.
+# [telegram.voice]
+# enabled = false                  # Off by default — opt-in.
+# max_voice_duration_secs = 60     # Hard limit; longer messages are rejected.
+# delete_temp_audio = true         # Remove /tmp/geniepod-tg-voice-*.{ogg,wav} after handling.
+# ffmpeg_path = "ffmpeg"           # Override if ffmpeg isn't on PATH.
 
 # Public web search tool. Default provider is DuckDuckGo Instant Answer, which needs no API key.
 # For a private/local path, run SearXNG and set provider = "searxng" with base_url.


### PR DESCRIPTION
Part of #42 (phase 1 only).

A Telegram user can send a voice message; the bot downloads it, transcodes
OGG/Opus → 16 kHz mono WAV with ffmpeg, transcribes via the same Whisper
server (`/inference`) or `whisper-cli` the on-device voice loop uses, then
routes the transcript through the existing `/api/chat` flow and replies as text.

## Design
- File-driven STT path; no `voice/*` runtime modules pulled in → works on
  chat-only deployments without ALSA.
- Hallucination filter + duration cap + RAII temp-file cleanup.
- Concurrent voice messages get unique `/tmp` paths (pid + nanos nonce).
- New config block `[telegram.voice]`; off by default.

## Test plan
- [x] `cargo check --workspace --all-targets` : clean.
- [x] `cargo test -p genie-core telegram::` : 6/6 passed.
- [x] `cargo test --workspace` — 388 passed; 2 pre-existing `memory::tests::promotion_*`
      flakes (parallel-mode SQLite/temp-path collision; pass with `--test-threads=1`).
- [ ] Manual end-to-end against a real Telegram bot + Jetson whisper-server.
- [ ] Integration test with mock Telegram API + ffmpeg fixture — deferred to follow-up.

## Deferred (phase 2 / 3 per issue)
- Piper TTS reply via `sendVoice`.
- Speaker identity from Telegram user_id.
- Group-chat voice handling.
