### PR TITLE
feat(deploy): genie-ai-runtime v1.0.0 build+install pipeline (issue #54)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 # genie-core — Build, Test, Cross-Compile, Deploy
 #
 # Usage:
-#   make              Build debug binaries (x86_64)
-#   make test         Run all tests
-#   make release      Build optimized x86_64 binaries
-#   make jetson       Cross-compile release for aarch64 (Jetson)
-#   make deploy       Deploy to Jetson devkit via SSH
-#   make clean        Remove build artifacts
+#   make                       Build debug binaries (x86_64)
+#   make test                  Run all tests
+#   make release               Build optimized x86_64 binaries
+#   make jetson                Cross-compile release for aarch64 (Jetson)
+#   make deploy                Deploy to Jetson devkit via SSH
+#   make jetson-ai-runtime     Build + install genie-ai-runtime v1.0.0 on the
+#                              Jetson alongside llama.cpp (issue #54). Install-
+#                              only — does not flip the backend config or stop
+#                              genie-llm.service.
+#   make clean                 Remove build artifacts
 #
 # Configuration:
 #   JETSON_HOST       SSH target (default: geniepod.local)
@@ -25,7 +29,7 @@ RELEASE_DIR = target/release
 CROSS_DIR = target/$(AARCH64)/release
 INSTALL_DIR = /opt/geniepod
 
-.PHONY: all build test release jetson deploy deploy-config deploy-systemd clean check fmt
+.PHONY: all build test release jetson deploy deploy-config deploy-systemd clean check fmt jetson-ai-runtime
 
 # ── Development ─────────────────────────────────────────────────
 
@@ -120,6 +124,25 @@ deploy-setup:
 		sudo mkdir -p $(INSTALL_DIR)/bin && \
 		sudo cp /tmp/genie-wake-listen.py /tmp/genie-wakeword.py /tmp/detect-audio-device.sh /tmp/genie-restart-all.sh /tmp/genie-audio-init $(INSTALL_DIR)/bin/ && \
 		sudo chmod +x $(INSTALL_DIR)/bin/genie-wake-listen.py $(INSTALL_DIR)/bin/genie-wakeword.py $(INSTALL_DIR)/bin/detect-audio-device.sh $(INSTALL_DIR)/bin/genie-restart-all.sh $(INSTALL_DIR)/bin/genie-audio-init'
+
+# ── Alternate LLM runtime: genie-ai-runtime (issue #54) ─────────
+#
+# Builds genie-ai-runtime v1.0.0 from source on the Jetson and installs the
+# binaries alongside the existing llama.cpp setup. The config switch
+# ([services.llm].backend / .systemd_unit) is intentionally left for the
+# operator to make by hand — this target is install-only, mirroring the
+# `--model qwen3-4b` safety property from PR #46.
+#
+# Prereq: `make deploy` (or at least deploy-systemd + deploy-setup) has run
+# at least once so the new units and the updated setup-jetson.sh are on the
+# target. We re-run those two sub-targets here for a self-contained flow.
+
+jetson-ai-runtime: deploy-systemd deploy-setup
+	@echo ""
+	@echo "=== Building + installing genie-ai-runtime v1.0.0 on $(JETSON_TARGET) ==="
+	@echo "    (this takes 10-20 min on Orin Nano while CMake compiles CUDA)"
+	@echo ""
+	ssh $(JETSON_TARGET) 'bash $(INSTALL_DIR)/setup-jetson.sh --runtime genie-ai-runtime'
 
 # ── Docker (HA + opt-in services) ───────────────────────────────
 

--- a/deploy/setup-jetson.sh
+++ b/deploy/setup-jetson.sh
@@ -2,6 +2,14 @@
 # GeniePod — Jetson first-time setup script
 # Run this on the Jetson after make deploy:
 #   ssh geniepod@<jetson-ip> 'bash /opt/geniepod/setup-jetson.sh'
+#
+# Flags:
+#   --runtime genie-ai-runtime   Build + install genie-ai-runtime v1.0.0
+#                                alongside the existing llama.cpp backend.
+#                                Does NOT modify /etc/geniepod/geniepod.toml
+#                                and does NOT stop any running service —
+#                                operator does the cutover by hand per the
+#                                instructions printed at the end. (issue #54)
 
 set -euo pipefail
 
@@ -9,6 +17,140 @@ GENIEPOD_DIR="/opt/geniepod"
 CONFIG_DIR="/etc/geniepod"
 MODEL_DIR="$GENIEPOD_DIR/models"
 DATA_DIR="$GENIEPOD_DIR/data"
+
+# ── Argument parsing ────────────────────────────────────────────
+RUNTIME_TO_INSTALL=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --runtime)
+            shift
+            if [ $# -eq 0 ]; then
+                echo "ERROR: --runtime requires an argument (e.g. genie-ai-runtime)" >&2
+                exit 2
+            fi
+            RUNTIME_TO_INSTALL="$1"
+            shift
+            ;;
+        --runtime=*)
+            RUNTIME_TO_INSTALL="${1#--runtime=}"
+            shift
+            ;;
+        -h|--help)
+            sed -n '2,12p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo "Usage: $0 [--runtime genie-ai-runtime]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ── --runtime mode: install an alternate LLM backend only ───────
+install_genie_ai_runtime() {
+    local build_dir="$GENIEPOD_DIR/src/genie-ai-runtime"
+    local repo_url="https://github.com/GeniePod/genie-ai-runtime.git"
+    local tag="v1.0.0"
+
+    echo "=== GeniePod: install genie-ai-runtime $tag ==="
+    echo ""
+
+    # 1. Verify prerequisites.
+    echo "[1/4] Checking build prerequisites..."
+    for pkg in cmake g++; do
+        if ! command -v "$pkg" > /dev/null 2>&1; then
+            echo "  Installing $pkg via apt..."
+            sudo apt-get update -qq
+            sudo apt-get install -y "$pkg"
+        fi
+        echo "  OK: $pkg ($("$pkg" --version 2>/dev/null | head -1))"
+    done
+    if ! command -v nvcc > /dev/null 2>&1 && [ ! -d /usr/local/cuda/include ]; then
+        echo "  WARN: CUDA toolkit not detected — JetPack normally ships it."
+        echo "        If the build fails on missing cuBLAS / cuda_runtime.h, install:"
+        echo "          sudo apt-get install -y nvidia-cuda-toolkit"
+    fi
+
+    # 2. Clone the pinned release.
+    echo "[2/4] Fetching $repo_url @ $tag ..."
+    sudo mkdir -p "$(dirname "$build_dir")"
+    sudo chown -R "$(whoami):$(whoami)" "$(dirname "$build_dir")"
+    if [ -d "$build_dir/.git" ]; then
+        echo "  Existing checkout found — fetching $tag and resetting."
+        git -C "$build_dir" fetch --tags --depth 1 origin "$tag"
+        git -C "$build_dir" checkout --quiet "tags/$tag"
+        git -C "$build_dir" clean -fdx
+    else
+        rm -rf "$build_dir"
+        git clone --branch "$tag" --depth 1 "$repo_url" "$build_dir"
+    fi
+
+    # 3. Build (10-20 min on Orin Nano).
+    echo "[3/4] Building (Release, $(nproc) jobs — this takes 10-20 min on Orin Nano)..."
+    cd "$build_dir"
+    cmake -B build -DCMAKE_BUILD_TYPE=Release
+    cmake --build build -j"$(nproc)"
+
+    # 4. Install binaries. Refuse to overwrite if something looks wrong.
+    echo "[4/4] Installing binaries to $GENIEPOD_DIR/bin/ ..."
+    for bin in jetson-llm-server jetson-llm; do
+        if [ ! -f "build/$bin" ]; then
+            echo "  ERROR: build/$bin not produced — build output unexpected." >&2
+            exit 1
+        fi
+        sudo install -Dm755 "build/$bin" "$GENIEPOD_DIR/bin/$bin"
+        echo "  OK: $bin ($(du -h "$GENIEPOD_DIR/bin/$bin" | cut -f1))"
+    done
+
+    echo ""
+    echo "=== genie-ai-runtime $tag installed ==="
+    echo ""
+    echo "NOTE: jetson-llm-server installed but not yet selected as the LLM backend."
+    echo "      Your existing llama.cpp setup is unchanged."
+    echo ""
+    echo "To run genie-ai-runtime instead of llama.cpp:"
+    echo "  1. Stop the current llama.cpp backend:"
+    echo "       sudo systemctl stop genie-llm"
+    echo "  2. Edit /etc/geniepod/geniepod.toml:"
+    echo "       [services.llm]"
+    echo "       backend      = \"genie_ai_runtime\""
+    echo "       systemd_unit = \"genie-ai-runtime.service\""
+    echo "  3. Start the new backend:"
+    echo "       sudo systemctl daemon-reload"
+    echo "       sudo systemctl enable --now genie-ai-runtime.service"
+    echo "       sudo systemctl enable --now genie-ai-runtime-warmup.service"
+    echo "  4. Restart genie-core to pick up the config change:"
+    echo "       sudo systemctl restart genie-core"
+    echo ""
+    echo "To roll back to llama.cpp:"
+    echo "  1. sudo systemctl stop genie-ai-runtime genie-ai-runtime-warmup"
+    echo "  2. Edit /etc/geniepod/geniepod.toml:"
+    echo "       [services.llm]"
+    echo "       backend      = \"llama_cpp\""
+    echo "       systemd_unit = \"genie-llm.service\""
+    echo "  3. sudo systemctl start genie-llm"
+    echo "  4. sudo systemctl restart genie-core"
+    echo ""
+    echo "Verify:"
+    echo "  genie-ctl status            # should report llm_backend"
+    echo "  systemctl status genie-ai-runtime.service"
+}
+
+if [ -n "$RUNTIME_TO_INSTALL" ]; then
+    case "$RUNTIME_TO_INSTALL" in
+        genie-ai-runtime)
+            install_genie_ai_runtime
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown runtime: $RUNTIME_TO_INSTALL" >&2
+            echo "Supported: genie-ai-runtime" >&2
+            exit 2
+            ;;
+    esac
+fi
 
 echo "=== GeniePod Jetson Setup ==="
 echo ""

--- a/deploy/systemd/genie-ai-runtime-warmup.service
+++ b/deploy/systemd/genie-ai-runtime-warmup.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=GeniePod AI Runtime Warmup (force Qwen 3 4B into iGPU before first voice cycle)
+Documentation=https://github.com/GeniePod/genie-claw/issues/54
+After=genie-ai-runtime.service
+Wants=genie-ai-runtime.service
+ConditionPathExists=/opt/geniepod/bin/jetson-llm-server
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Poll /health for up to 120 s while jetson-llm-server boots and compiles
+# CUDA kernels on first run, then send one tiny /completion request to force
+# the model load into iGPU memory. Without this, the first user-visible
+# voice cycle either blocks on the cold load or times out with 503 / connect-
+# refused. Failures are non-fatal (|| true) so a broken LLM does not block boot.
+ExecStart=/bin/sh -c '\
+    for i in $(seq 1 120); do \
+        if curl -sf -o /dev/null http://127.0.0.1:8080/health; then break; fi; \
+        sleep 1; \
+    done; \
+    curl -sf -X POST http://127.0.0.1:8080/v1/chat/completions \
+        -H "Content-Type: application/json" \
+        -d "{\"model\":\"jetson-llm\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1}" > /dev/null || true; \
+    echo "[genie-ai-runtime-warmup] done"'
+TimeoutStartSec=240
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=geniepod.target

--- a/deploy/systemd/genie-ai-runtime.service
+++ b/deploy/systemd/genie-ai-runtime.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=GeniePod AI Runtime (Jetson-tuned LLM, OpenAI-compatible)
+Documentation=https://github.com/GeniePod/genie-ai-runtime
+After=network.target
+ConditionPathExists=/opt/geniepod/bin/jetson-llm-server
+# Conflicts with genie-llm.service: both bind :8080. systemd will refuse
+# to start the second one while the first is running, so a misconfigured
+# [services.llm] block fails loudly instead of silently double-binding.
+Conflicts=genie-llm.service
+
+[Service]
+Type=simple
+# Drop page cache before loading model — Jetson NvMap needs contiguous blocks.
+ExecStartPre=/bin/sh -c 'sync && echo 3 > /proc/sys/vm/drop_caches'
+# v1.0.0 only accepts `-m <model> -p <port>`. Any llama.cpp-style flags
+# (--n-gpu-layers, --flash-attn, --ctx-size, --threads) are intentionally
+# absent — the runtime hard-codes its own Jetson-tuned defaults.
+ExecStart=/opt/geniepod/bin/jetson-llm-server \
+    -m ${GENIEPOD_LLM_MODEL} \
+    -p 8080
+Environment=GENIEPOD_LLM_MODEL=/opt/geniepod/models/Qwen3-4B-Q4_K_M.gguf
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=120
+
+# GPU needs full system access
+ProtectSystem=no
+SupplementaryGroups=video render
+
+[Install]
+WantedBy=geniepod.target


### PR DESCRIPTION
Closes #54

Adds the enabling infrastructure to install `genie-ai-runtime` v1.0.0
alongside the existing llama.cpp setup. Install-only — does NOT change
the running backend; operator does the cutover by hand per the printed
instructions (mirrors the `--model qwen3-4b` safety pattern from PR #46).

## What lands
- `deploy/systemd/genie-ai-runtime.service` — `Conflicts=genie-llm.service`
  so the :8080 binding-conflict is loud rather than silent.
- `deploy/systemd/genie-ai-runtime-warmup.service` — 120 s `/health` poll +
  one tiny `/v1/chat/completions` to force model load + CUDA kernel compile.
- `deploy/setup-jetson.sh --runtime genie-ai-runtime` — clone v1.0.0,
  `cmake --build`, install `jetson-llm-server` + `jetson-llm` to
  `/opt/geniepod/bin/`, print cutover + rollback instructions. No-flag
  path is unchanged.
- `make jetson-ai-runtime JETSON_HOST=<ip> JETSON_USER=<user>` — composes
  `deploy-systemd + deploy-setup + ssh setup-jetson.sh --runtime`.

## Out of scope (deliberate)
- Default-backend flip in `geniepod.toml` → #52.
- Qwen 3 4B auto-download → PR #46.
- CHANGELOG entry → done at release-cut time.
- CI build of genie-ai-runtime → would need self-hosted Jetson runner.

## Test plan
- [x] `bash -n` syntax clean.
- [x] `--help`, `--runtime` (no arg), `--runtime bogus`, `--unknown-flag`
      all behave correctly (exit 2 + clear error).
- [x] `make -n jetson-ai-runtime` shows the expected SSH command sequence.
- [x] `make -n jetson` / `make -n deploy` unchanged.
- [ ] **Manual Jetson run:** `make jetson-ai-runtime` against a real Orin Nano,
      verify build completes in <25 min and binaries land.
- [ ] **Manual cutover:** flip `[services.llm]` to `genie_ai_runtime`,
      restart genie-core, confirm `genie-ctl status` reports the new backend.
- [ ] **Manual rollback:** symmetric flip back to `llama_cpp`, confirm
      llama.cpp resumes serving.
