### PR TITLE
ci: add --no-default-features axis for chat-only builds (#59)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,36 @@ jobs:
         run: cargo test --workspace --locked --all-targets
       - name: cargo test --doc
         run: cargo test --workspace --locked --doc
+
+  # Chat-only build axis (issue #59 / closes acceptance criterion #8 from
+  # #41 + #57). Guards `cargo {clippy,test} --no-default-features` on
+  # genie-core + genie-ctl so the voice-gated cfgs (and the latent
+  # telegram-gated cleanups from #57) don't silently bit-rot on the
+  # macOS / Windows / chat-bot deployment path. Scoped to the two crates
+  # that declare a `voice` feature; running --workspace would just
+  # duplicate the existing --workspace job. Distinct rust-cache shared-key
+  # because the feature-set produces a different target/ graph than the
+  # default --workspace axis.
+  no-default-features:
+    name: cargo clippy + test (--no-default-features)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-nodefault
+      - name: cargo clippy --no-default-features
+        run: |
+          cargo clippy \
+            -p genie-core -p genie-ctl \
+            --no-default-features --all-targets --locked \
+            -- -D warnings
+      - name: cargo test --no-default-features
+        run: |
+          cargo test \
+            -p genie-core -p genie-ctl \
+            --no-default-features --all-targets --locked


### PR DESCRIPTION
Closes #59.

## Summary

Adds a `no-default-features` job to `.github/workflows/ci.yml` that runs `cargo clippy` and `cargo test` for `-p genie-core -p genie-ctl --no-default-features --all-targets --locked` with `-D warnings` on every push to `main` and every PR.

This closes acceptance criterion #8 of #41 that PR #57 explicitly deferred ("`.github/` doesn't exist on `main` yet"). `ci.yml` landed in PR #37, so the deferral premise no longer holds and the chat-only build path can finally be guarded in CI.

## Why

PR #57 made `voice` an opt-out Cargo feature on `genie-core` and `genie-ctl`. With `--no-default-features` (the chat-only shape used by Telegram / Slack / Discord bots, remote-LLM nodes with no microphone, and macOS / Windows dev hosts), the build skips ~6 kLoC of ALSA-coupled voice / wakeword / STT / TTS / AEC code. Today, nothing in CI exercises that
axis — every `#[cfg(feature = "voice")]` (and the latent `#[cfg(feature = "telegram")]` cleanups from #57) is one stray `use` statement away from silently bit-rotting until the next time someone actually runs `cargo build --no-default-features` on a Mac.

This PR closes that loop.

## What changed

One new job in `.github/workflows/ci.yml`, parallel to the existing `fmt` / `clippy` / `test` jobs:

- `cargo clippy -p genie-core -p genie-ctl --no-default-features
  --all-targets --locked -- -D warnings`
- `cargo test -p genie-core -p genie-ctl --no-default-features
  --all-targets --locked`

Implementation notes that match the issue:

- **Scoped to `genie-core` + `genie-ctl`** — the only two crates that  declare a `voice` feature. `--workspace --no-default-features` would  just duplicate the existing `--workspace` job for feature-less crates.
- **`clippy` + `test` only, no `fmt`** — formatting doesn't depend on  features.
- **Distinct `Swatinem/rust-cache` `shared-key: ci-nodefault`** — a  different feature-set means a different `target/` graph; sharing  `ci-clippy` / `ci-test` would thrash both caches.
- **`-D warnings`** matches the rest of `ci.yml` (already enforced via  `RUSTFLAGS` at the workflow level).
- **15-minute timeout** matches the existing `clippy` job's budget.

## Local verification

`rustc 1.95.0 / cargo 1.95.0` on x86_64-linux:

- `cargo clippy -p genie-core -p genie-ctl --no-default-features
  --all-targets --locked -- -D warnings` → clean, no warnings.
- `cargo test   -p genie-core -p genie-ctl --no-default-features
  --all-targets --locked` → **355 passed, 0 failed, 0 ignored**.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → OK.

So the new job should land green on its first run — this is a guardrail,
not a remediation.

## Acceptance criteria

- [x] `.github/workflows/ci.yml` grows a `no-default-features` job that
      runs `cargo clippy` + `cargo test` for `-p genie-core -p genie-ctl
      --no-default-features --all-targets --locked` with `-D warnings`.
- [x] Uses a distinct `Swatinem/rust-cache` `shared-key` (`ci-nodefault`)
      so it doesn't thrash `ci-clippy` / `ci-test`.
- [x] First run on `main` should be green (verified locally above).
