### PR TITLE
feat(telegram): phase 2 voice replies via Piper + sendVoice (#42)

### DIFF
--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -474,6 +474,22 @@ pub struct TelegramVoiceConfig {
     /// 16 kHz mono WAV that Whisper consumes.
     #[serde(default = "defaults::telegram_voice_ffmpeg_path")]
     pub ffmpeg_path: PathBuf,
+
+    /// Reply to incoming voice messages with a synthesized voice message
+    /// instead of (or in addition to) text. Phase 2 of issue #42: Piper
+    /// synthesizes WAV, ffmpeg encodes it as OGG/Opus, the bot uploads via
+    /// the Telegram `sendVoice` endpoint. Falls back to text on any failure
+    /// (Piper missing, ffmpeg missing, sendVoice error, etc.) so no reply is
+    /// ever silently dropped.
+    #[serde(default)]
+    pub reply_as_voice: bool,
+
+    /// Hard cap on the assistant text fed to Piper. Long-form responses
+    /// produce long voice messages that hit Telegram's 1 MB sendVoice limit;
+    /// when the text is over this length the bot falls back to text reply.
+    /// Tuned for the 60–90 s of OGG/Opus that comfortably fits under 1 MB.
+    #[serde(default = "defaults::telegram_voice_max_reply_chars")]
+    pub max_reply_chars: usize,
 }
 
 impl Default for TelegramVoiceConfig {
@@ -483,6 +499,8 @@ impl Default for TelegramVoiceConfig {
             max_voice_duration_secs: defaults::telegram_voice_max_duration_secs(),
             delete_temp_audio: defaults::telegram_voice_delete_temp_audio(),
             ffmpeg_path: defaults::telegram_voice_ffmpeg_path(),
+            reply_as_voice: false,
+            max_reply_chars: defaults::telegram_voice_max_reply_chars(),
         }
     }
 }
@@ -1472,6 +1490,12 @@ mod defaults {
     }
     pub fn telegram_voice_ffmpeg_path() -> PathBuf {
         PathBuf::from("ffmpeg")
+    }
+    pub fn telegram_voice_max_reply_chars() -> usize {
+        // Roughly the upper bound that comfortably encodes under Telegram's
+        // 1 MB sendVoice limit at Piper's typical OGG/Opus output rate.
+        // Long-form replies fall back to text.
+        800
     }
     pub fn web_search_enabled() -> bool {
         true

--- a/crates/genie-core/src/main.rs
+++ b/crates/genie-core/src/main.rs
@@ -308,6 +308,10 @@ async fn main() -> Result<()> {
                         whisper_cli_path: config.core.whisper_cli_path.clone(),
                         whisper_model: config.core.whisper_model.clone(),
                         stt_language: config.core.stt_language.clone(),
+                        reply_as_voice: config.telegram.voice.reply_as_voice,
+                        max_reply_chars: config.telegram.voice.max_reply_chars,
+                        piper_path: config.core.piper_path.clone(),
+                        piper_model: config.core.piper_model.clone(),
                     },
                 };
 

--- a/crates/genie-core/src/telegram.rs
+++ b/crates/genie-core/src/telegram.rs
@@ -21,9 +21,10 @@ pub struct TelegramRuntimeConfig {
 /// Voice-message ingestion settings for the Telegram channel (issue #42).
 ///
 /// The Telegram adapter stays out of process boundaries with `voice/*`
-/// modules — it speaks to Whisper directly via the same HTTP server or
-/// `whisper-cli` subprocess the on-device voice loop uses, so a chat-only
-/// deployment without ALSA still gets voice-in.
+/// modules — it speaks to Whisper / Piper directly via subprocess + HTTP,
+/// the same way the on-device voice loop drives them, so a chat-only
+/// deployment without ALSA still gets voice-in (phase 1) and voice-out
+/// (phase 2).
 #[derive(Debug, Clone)]
 pub struct TelegramVoiceRuntimeConfig {
     pub enabled: bool,
@@ -34,6 +35,11 @@ pub struct TelegramVoiceRuntimeConfig {
     pub whisper_cli_path: PathBuf,
     pub whisper_model: PathBuf,
     pub stt_language: String,
+    // Phase 2 (issue #42): voice reply via Piper → ffmpeg → sendVoice.
+    pub reply_as_voice: bool,
+    pub max_reply_chars: usize,
+    pub piper_path: PathBuf,
+    pub piper_model: PathBuf,
 }
 
 pub async fn run(config: TelegramRuntimeConfig) -> Result<()> {
@@ -289,7 +295,176 @@ impl TelegramApi {
         );
 
         let core_response = self.chat_core(chat_id, &transcript).await?;
-        self.send_text(chat_id, &core_response).await?;
+        self.send_reply(chat_id, &core_response).await?;
+        Ok(())
+    }
+
+    /// Phase 2 of issue #42: route an assistant reply through the
+    /// voice-out path when `reply_as_voice = true` and the conditions
+    /// are met. Falls back to plain `send_text` on any failure so the
+    /// user is never left without a reply.
+    async fn send_reply(&self, chat_id: i64, text: &str) -> Result<()> {
+        let voice_cfg = &self.config.voice;
+
+        match voice_reply_gate(text, voice_cfg.reply_as_voice, voice_cfg.max_reply_chars) {
+            VoiceReplyGate::Text => return self.send_text(chat_id, text).await,
+            VoiceReplyGate::SkipOverLength { chars } => {
+                tracing::info!(
+                    chat_id,
+                    reply_chars = chars,
+                    cap = voice_cfg.max_reply_chars,
+                    "telegram voice reply skipped: reply over max_reply_chars; sending text"
+                );
+                return self.send_text(chat_id, text).await;
+            }
+            VoiceReplyGate::Voice => {}
+        }
+
+        let trimmed = text.trim();
+        let pid = std::process::id();
+        let nonce = rand_nonce();
+        let wav_path = format!("/tmp/geniepod-tg-reply-{pid}-{nonce}.wav");
+        let ogg_path = format!("/tmp/geniepod-tg-reply-{pid}-{nonce}.ogg");
+
+        let _cleanup = TempCleanup::new(
+            voice_cfg.delete_temp_audio,
+            ogg_path.clone(),
+            wav_path.clone(),
+        );
+
+        if let Err(e) = self.synthesize_reply_to_wav(trimmed, &wav_path).await {
+            tracing::warn!(error = %e, "telegram voice reply: piper synth failed; falling back to text");
+            return self.send_text(chat_id, text).await;
+        }
+
+        if let Err(e) = self.wav_to_ogg_opus(&wav_path, &ogg_path).await {
+            tracing::warn!(error = %e, "telegram voice reply: ffmpeg ogg encode failed; falling back to text");
+            return self.send_text(chat_id, text).await;
+        }
+
+        if let Err(e) = self.send_voice(chat_id, &ogg_path).await {
+            tracing::warn!(error = %e, "telegram voice reply: sendVoice failed; falling back to text");
+            return self.send_text(chat_id, text).await;
+        }
+
+        tracing::info!(chat_id, "telegram voice reply sent");
+        Ok(())
+    }
+
+    async fn synthesize_reply_to_wav(&self, text: &str, wav_path: &str) -> Result<()> {
+        // Piper reads text from stdin, writes WAV to --output_file. Matches
+        // the file-mode invocation in voice/tts.rs but kept inline so the
+        // adapter doesn't pull in the `voice` Cargo feature.
+        let voice_cfg = &self.config.voice;
+        let mut piper = Command::new(&voice_cfg.piper_path)
+            .args([
+                "--model",
+                &voice_cfg.piper_model.to_string_lossy(),
+                "--output_file",
+                wav_path,
+            ])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to spawn piper at {:?}", voice_cfg.piper_path))?;
+
+        // Newlines confuse Piper; collapse to spaces like voice/tts.rs does.
+        let one_line = text.replace('\n', " ");
+        if let Some(mut stdin) = piper.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            stdin
+                .write_all(one_line.as_bytes())
+                .await
+                .context("write piper stdin")?;
+            stdin.write_all(b"\n").await.context("write piper stdin")?;
+        }
+
+        let output = piper.wait_with_output().await.context("await piper")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("piper failed: {}", stderr.trim());
+        }
+
+        // Empty WAV = nothing useful synthesized; treat as failure so the
+        // caller falls back to text.
+        let meta = tokio::fs::metadata(wav_path)
+            .await
+            .with_context(|| format!("stat {wav_path}"))?;
+        if meta.len() < 128 {
+            anyhow::bail!("piper produced empty/undersized WAV ({} bytes)", meta.len());
+        }
+        Ok(())
+    }
+
+    async fn wav_to_ogg_opus(&self, wav_path: &str, ogg_path: &str) -> Result<()> {
+        // ffmpeg ships with libopus in all standard distros and on JetPack.
+        // The format Telegram's sendVoice expects is OGG/Opus; the explicit
+        // container + codec args here let ffmpeg pick conservative bitrate
+        // defaults that comfortably fit voice-message reads under the
+        // sendVoice 1 MB cap for typical Piper output lengths.
+        let voice_cfg = &self.config.voice;
+        let output = Command::new(&voice_cfg.ffmpeg_path)
+            .args([
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-i",
+                wav_path,
+                "-c:a",
+                "libopus",
+                "-b:a",
+                "24k",
+                "-ac",
+                "1",
+                "-f",
+                "ogg",
+                ogg_path,
+            ])
+            .output()
+            .await
+            .with_context(|| format!("failed to spawn ffmpeg at {:?}", voice_cfg.ffmpeg_path))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("ffmpeg ogg/opus encode failed: {}", stderr.trim());
+        }
+        Ok(())
+    }
+
+    async fn send_voice(&self, chat_id: i64, ogg_path: &str) -> Result<()> {
+        let bytes = tokio::fs::read(ogg_path)
+            .await
+            .with_context(|| format!("read ogg {ogg_path}"))?;
+
+        let file_part = reqwest::multipart::Part::bytes(bytes)
+            .file_name("reply.ogg")
+            .mime_str("audio/ogg")
+            .context("invalid mime for voice part")?;
+        let form = reqwest::multipart::Form::new()
+            .text("chat_id", chat_id.to_string())
+            .part("voice", file_part);
+
+        let resp: TelegramEnvelope<serde_json::Value> = self
+            .client
+            .post(self.method_url("sendVoice"))
+            .multipart(form)
+            .send()
+            .await
+            .context("Telegram sendVoice request failed")?
+            .error_for_status()
+            .context("Telegram sendVoice HTTP error")?
+            .json()
+            .await
+            .context("Telegram sendVoice JSON decode failed")?;
+
+        if !resp.ok {
+            anyhow::bail!(
+                "Telegram sendVoice API error: {}",
+                resp.description.unwrap_or_else(|| "unknown error".into())
+            );
+        }
         Ok(())
     }
 
@@ -620,6 +795,30 @@ fn clean_transcript(raw: &str) -> String {
     trimmed.to_string()
 }
 
+/// Pure decision for the voice-reply gate. Extracted from `send_reply` so
+/// the policy can be unit-tested without spinning up HTTP or subprocesses.
+#[derive(Debug, PartialEq, Eq)]
+enum VoiceReplyGate {
+    /// Send the assistant reply as plain text.
+    Text,
+    /// Reply was over `max_reply_chars` — skip the voice path. Caller logs.
+    SkipOverLength { chars: usize },
+    /// Try the voice-reply pipeline (Piper → ffmpeg → sendVoice).
+    Voice,
+}
+
+fn voice_reply_gate(text: &str, reply_as_voice: bool, max_chars: usize) -> VoiceReplyGate {
+    let trimmed = text.trim();
+    if !reply_as_voice || trimmed.is_empty() {
+        return VoiceReplyGate::Text;
+    }
+    let chars = trimmed.chars().count();
+    if chars > max_chars {
+        return VoiceReplyGate::SkipOverLength { chars };
+    }
+    VoiceReplyGate::Voice
+}
+
 fn strip_bot_mention(text: &str) -> String {
     text.split_whitespace()
         .filter(|part| !part.starts_with('@'))
@@ -729,8 +928,8 @@ struct CoreChatResponse {
 #[cfg(test)]
 mod tests {
     use super::{
-        TELEGRAM_MAX_MESSAGE_LEN, clean_transcript, configured_language, split_message,
-        strip_bot_mention,
+        TELEGRAM_MAX_MESSAGE_LEN, VoiceReplyGate, clean_transcript, configured_language,
+        split_message, strip_bot_mention, voice_reply_gate,
     };
 
     #[test]
@@ -772,6 +971,54 @@ mod tests {
         assert_eq!(
             clean_transcript("turn off the lights"),
             "turn off the lights"
+        );
+    }
+
+    #[test]
+    fn voice_reply_gate_off_returns_text() {
+        // reply_as_voice = false → always text, regardless of length.
+        assert_eq!(voice_reply_gate("hello", false, 100), VoiceReplyGate::Text);
+        assert_eq!(voice_reply_gate("", false, 100), VoiceReplyGate::Text);
+    }
+
+    #[test]
+    fn voice_reply_gate_empty_text_returns_text() {
+        // Empty / whitespace replies don't synthesize — they'd produce
+        // empty WAV and waste a Piper invocation.
+        assert_eq!(voice_reply_gate("", true, 100), VoiceReplyGate::Text);
+        assert_eq!(voice_reply_gate("   \n\t", true, 100), VoiceReplyGate::Text);
+    }
+
+    #[test]
+    fn voice_reply_gate_over_cap_skips_with_char_count() {
+        let long = "a".repeat(150);
+        assert_eq!(
+            voice_reply_gate(&long, true, 100),
+            VoiceReplyGate::SkipOverLength { chars: 150 }
+        );
+    }
+
+    #[test]
+    fn voice_reply_gate_under_cap_returns_voice() {
+        assert_eq!(
+            voice_reply_gate("turn off the lights", true, 100),
+            VoiceReplyGate::Voice
+        );
+        // Exactly at the cap is still voice (uses `>` not `>=`).
+        let at_cap = "x".repeat(100);
+        assert_eq!(voice_reply_gate(&at_cap, true, 100), VoiceReplyGate::Voice);
+    }
+
+    #[test]
+    fn voice_reply_gate_char_count_uses_unicode_chars_not_bytes() {
+        // 5 multi-byte chars should count as 5, not 15 bytes — otherwise
+        // a Japanese / Chinese reply would be skipped at a much shorter
+        // human-perceived length.
+        let s = "東京こんにちは"; // 7 chars, ~21 bytes
+        assert_eq!(voice_reply_gate(s, true, 7), VoiceReplyGate::Voice);
+        assert_eq!(
+            voice_reply_gate(s, true, 6),
+            VoiceReplyGate::SkipOverLength { chars: 7 }
         );
     }
 

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -182,11 +182,17 @@ alert_webhook_url = ""            # Optional local notifier endpoint.
 # Voice-message ingestion (issue #42). Reuses the configured whisper-server
 # (core.whisper_port > 0) or whisper-cli; needs `ffmpeg` on $PATH for the
 # OGG/Opus → 16 kHz mono WAV transcode.
+# Phase 2 (reply_as_voice) reuses `core.piper_path` + `core.piper_model`
+# to synthesize the reply, then ffmpeg encodes WAV → OGG/Opus and the bot
+# uploads via Telegram `sendVoice`. Falls back to text on any failure.
 # [telegram.voice]
 # enabled = false                  # Off by default — opt-in.
 # max_voice_duration_secs = 60     # Hard limit; longer messages are rejected.
 # delete_temp_audio = true         # Remove /tmp/geniepod-tg-voice-*.{ogg,wav} after handling.
 # ffmpeg_path = "ffmpeg"           # Override if ffmpeg isn't on PATH.
+# reply_as_voice = false           # Phase 2 of #42 — voice-out via sendVoice.
+# max_reply_chars = 800            # Replies longer than this fall back to text
+#                                  # so we don't blow the sendVoice 1 MB cap.
 
 # Public web search tool. Default provider is DuckDuckGo Instant Answer, which needs no API key.
 # For a private/local path, run SearXNG and set provider = "searxng" with base_url.


### PR DESCRIPTION
## Summary

Phase 2 of #42 (phase 1 landed in #53). When `[telegram.voice].reply_as_voice
= true`, the bot synthesizes the assistant reply with Piper, encodes it as
OGG/Opus with ffmpeg, and uploads via Telegram's `sendVoice` endpoint instead
of plain `sendMessage`. Falls back to text on any failure so no reply is ever
silently dropped.

## What changes

- `TelegramVoiceConfig` gains `reply_as_voice` (default `false` — opt-in) and
  `max_reply_chars` (default `800` — long replies fall back to text to stay
  under Telegram's 1 MB `sendVoice` cap).
- `TelegramVoiceRuntimeConfig` plumbs Piper paths through, reusing
  `core.piper_path` + `core.piper_model` so the configured on-device voice
  matches the Telegram voice reply.
- `send_reply()` in `telegram.rs` routes between text and voice; three new
  helpers (`synthesize_reply_to_wav`, `wav_to_ogg_opus`, `send_voice`) do
  the work. Each step's failure path logs and falls back to text.
- `voice_reply_gate()` extracted as a pure function so the off / empty /
  over-cap / under-cap / multi-byte-Unicode policy can be unit-tested
  without spinning up Piper or HTTP.

## Design — matches phase 1's decoupling

The adapter still does not import `voice::tts::TtsEngine`. It subprocess-
shells out to Piper directly and uses `reqwest::multipart` for `sendVoice`.
Keeps phase 2 usable on chat-only deployments and honors phase 1's commit
message that explicitly warned against recoupling the two paths.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy -p genie-core --all-targets --all-features -- -D warnings`
      — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p genie-core telegram::` — **11/11 passed**
      (5 phase-1 + 1 wire-format + 5 new phase-2 gate tests)
- [ ] **Manual end-to-end** against a real Telegram bot + Jetson with Piper
      installed: flip `reply_as_voice = true`, send a voice message, expect
      a voice reply.
- [ ] **Manual fallback verification**: temporarily rename `piper` →
      expect text reply with a `tracing::warn!` line.

## What's out of scope (still deferred per the issue)

- **Phase 3** — speaker identity from Telegram `user_id` → memory routing.
  Tracked separately if useful.
- **Mock-Telegram integration test** for `sendVoice` — phase 1's integration-
  test gap still applies; would need an HTTP mock + real Piper + ffmpeg
  fixtures in `crates/genie-core/tests/`.
- **Streaming TTS** — voice messages are bounded; batch synth is fine.

## Related

- #42 — parent issue
- #53 — phase 1 (voice-in)
- #57 — `voice` Cargo feature (independent; phase 2 stays out of it on purpose)
