### PR TITLE
core: avoid push-to-talk loop under systemd

### DIFF
--- a/crates/genie-core/src/lib.rs
+++ b/crates/genie-core/src/lib.rs
@@ -52,6 +52,7 @@ pub mod prompt;
 pub mod reasoning;
 pub mod repl;
 pub mod runtime_contract;
+pub mod runtime_mode;
 pub mod security;
 pub mod server;
 pub mod skills;

--- a/crates/genie-core/src/main.rs
+++ b/crates/genie-core/src/main.rs
@@ -172,7 +172,8 @@ async fn main() -> Result<()> {
         || config.core.voice_enabled;
     let wakeword_available =
         !config.core.wakeword_script.as_os_str().is_empty() && config.core.wakeword_script.exists();
-    let voice_runnable = should_enter_voice_mode(voice_requested, interactive, wakeword_available);
+    let startup_decision =
+        runtime_mode::decide_startup_mode(voice_requested, interactive, wakeword_available);
 
     // Whether the running binary actually has the voice subsystem compiled in.
     // When voice was requested but the binary is chat-only (issue #41 feature
@@ -180,13 +181,13 @@ async fn main() -> Result<()> {
     // voice-tagged `geniepod.toml` still deploys cleanly on a chat-only build.
     #[cfg(feature = "voice")]
     let voice_mode = {
-        if voice_requested && !voice_runnable {
+        if startup_decision.blocked_push_to_talk() {
             tracing::warn!(
                 "push-to-talk voice mode requested without an interactive terminal and no wakeword script is available; \
                  running HTTP API only"
             );
         }
-        voice_runnable
+        startup_decision.enters_voice()
     };
     #[cfg(not(feature = "voice"))]
     let voice_mode = {
@@ -198,7 +199,7 @@ async fn main() -> Result<()> {
                  enable the voice loop."
             );
         }
-        let _ = voice_runnable;
+        let _ = startup_decision;
         false
     };
 
@@ -369,39 +370,6 @@ fn atty_check() -> bool {
     #[cfg(not(unix))]
     {
         false
-    }
-}
-
-fn should_enter_voice_mode(
-    voice_requested: bool,
-    stdin_interactive: bool,
-    wakeword_available: bool,
-) -> bool {
-    voice_requested && (stdin_interactive || wakeword_available)
-}
-
-#[cfg(test)]
-mod voice_mode_tests {
-    use super::should_enter_voice_mode;
-
-    #[test]
-    fn systemd_push_to_talk_falls_back_to_http() {
-        assert!(!should_enter_voice_mode(true, false, false));
-    }
-
-    #[test]
-    fn terminal_push_to_talk_still_runs() {
-        assert!(should_enter_voice_mode(true, true, false));
-    }
-
-    #[test]
-    fn wakeword_voice_can_run_without_terminal() {
-        assert!(should_enter_voice_mode(true, false, true));
-    }
-
-    #[test]
-    fn voice_disabled_stays_http_only() {
-        assert!(!should_enter_voice_mode(false, true, true));
     }
 }
 

--- a/crates/genie-core/src/main.rs
+++ b/crates/genie-core/src/main.rs
@@ -170,13 +170,24 @@ async fn main() -> Result<()> {
     let voice_requested = std::env::args().any(|a| a == "--voice")
         || std::env::var("GENIEPOD_VOICE").unwrap_or_default() == "1"
         || config.core.voice_enabled;
+    let wakeword_available =
+        !config.core.wakeword_script.as_os_str().is_empty() && config.core.wakeword_script.exists();
+    let voice_runnable = should_enter_voice_mode(voice_requested, interactive, wakeword_available);
 
     // Whether the running binary actually has the voice subsystem compiled in.
     // When voice was requested but the binary is chat-only (issue #41 feature
     // gate), emit one warning and fall through to the chat path so an existing
     // voice-tagged `geniepod.toml` still deploys cleanly on a chat-only build.
     #[cfg(feature = "voice")]
-    let voice_mode = voice_requested;
+    let voice_mode = {
+        if voice_requested && !voice_runnable {
+            tracing::warn!(
+                "push-to-talk voice mode requested without an interactive terminal and no wakeword script is available; \
+                 running HTTP API only"
+            );
+        }
+        voice_runnable
+    };
     #[cfg(not(feature = "voice"))]
     let voice_mode = {
         if voice_requested {
@@ -187,6 +198,7 @@ async fn main() -> Result<()> {
                  enable the voice loop."
             );
         }
+        let _ = voice_runnable;
         false
     };
 
@@ -357,6 +369,39 @@ fn atty_check() -> bool {
     #[cfg(not(unix))]
     {
         false
+    }
+}
+
+fn should_enter_voice_mode(
+    voice_requested: bool,
+    stdin_interactive: bool,
+    wakeword_available: bool,
+) -> bool {
+    voice_requested && (stdin_interactive || wakeword_available)
+}
+
+#[cfg(test)]
+mod voice_mode_tests {
+    use super::should_enter_voice_mode;
+
+    #[test]
+    fn systemd_push_to_talk_falls_back_to_http() {
+        assert!(!should_enter_voice_mode(true, false, false));
+    }
+
+    #[test]
+    fn terminal_push_to_talk_still_runs() {
+        assert!(should_enter_voice_mode(true, true, false));
+    }
+
+    #[test]
+    fn wakeword_voice_can_run_without_terminal() {
+        assert!(should_enter_voice_mode(true, false, true));
+    }
+
+    #[test]
+    fn voice_disabled_stays_http_only() {
+        assert!(!should_enter_voice_mode(false, true, true));
     }
 }
 

--- a/crates/genie-core/src/runtime_mode.rs
+++ b/crates/genie-core/src/runtime_mode.rs
@@ -1,0 +1,108 @@
+//! Startup-mode selection for genie-core.
+
+/// High-level interface selected at process startup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupMode {
+    /// Run the voice loop.
+    Voice,
+    /// Run the HTTP API / daemon path.
+    HttpOnly,
+}
+
+/// Why startup selected a mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupReason {
+    VoiceNotRequested,
+    InteractivePushToTalk,
+    WakewordDaemon,
+    PushToTalkNeedsTerminal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StartupDecision {
+    pub mode: StartupMode,
+    pub reason: StartupReason,
+}
+
+impl StartupDecision {
+    pub fn enters_voice(self) -> bool {
+        self.mode == StartupMode::Voice
+    }
+
+    pub fn blocked_push_to_talk(self) -> bool {
+        self.reason == StartupReason::PushToTalkNeedsTerminal
+    }
+}
+
+/// Decide whether startup may enter voice mode.
+///
+/// Push-to-talk consumes stdin, so it is only valid with an interactive
+/// terminal. Wake-word mode owns its own listener process and can run as a
+/// daemon under systemd.
+pub fn decide_startup_mode(
+    voice_requested: bool,
+    stdin_interactive: bool,
+    wakeword_available: bool,
+) -> StartupDecision {
+    if !voice_requested {
+        return StartupDecision {
+            mode: StartupMode::HttpOnly,
+            reason: StartupReason::VoiceNotRequested,
+        };
+    }
+
+    if wakeword_available {
+        return StartupDecision {
+            mode: StartupMode::Voice,
+            reason: StartupReason::WakewordDaemon,
+        };
+    }
+
+    if stdin_interactive {
+        return StartupDecision {
+            mode: StartupMode::Voice,
+            reason: StartupReason::InteractivePushToTalk,
+        };
+    }
+
+    StartupDecision {
+        mode: StartupMode::HttpOnly,
+        reason: StartupReason::PushToTalkNeedsTerminal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StartupMode, StartupReason, decide_startup_mode};
+
+    #[test]
+    fn systemd_push_to_talk_falls_back_to_http() {
+        let decision = decide_startup_mode(true, false, false);
+        assert_eq!(decision.mode, StartupMode::HttpOnly);
+        assert_eq!(decision.reason, StartupReason::PushToTalkNeedsTerminal);
+        assert!(decision.blocked_push_to_talk());
+    }
+
+    #[test]
+    fn terminal_push_to_talk_still_runs() {
+        let decision = decide_startup_mode(true, true, false);
+        assert_eq!(decision.mode, StartupMode::Voice);
+        assert_eq!(decision.reason, StartupReason::InteractivePushToTalk);
+        assert!(decision.enters_voice());
+    }
+
+    #[test]
+    fn wakeword_voice_can_run_without_terminal() {
+        let decision = decide_startup_mode(true, false, true);
+        assert_eq!(decision.mode, StartupMode::Voice);
+        assert_eq!(decision.reason, StartupReason::WakewordDaemon);
+        assert!(decision.enters_voice());
+    }
+
+    #[test]
+    fn voice_disabled_stays_http_only() {
+        let decision = decide_startup_mode(false, true, true);
+        assert_eq!(decision.mode, StartupMode::HttpOnly);
+        assert_eq!(decision.reason, StartupReason::VoiceNotRequested);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #71.

`genie-core.service` runs with `StandardInput=null`, but the deployed config can request voice mode with `voice_enabled = true` and no wakeword script. That selects push-to-talk mode, which immediately reads stdin EOF under systemd, exits successfully, and then restarts forever because the unit has `Restart=always`.

This PR gates voice mode so it only runs when:

- voice is requested and stdin is interactive, allowing terminal push-to-talk; or
- voice is requested and a wakeword script is configured and present, allowing daemon wake-word mode.

Otherwise `genie-core` logs a warning and runs the HTTP API instead of entering the stdin-driven push-to-talk loop.

## Validation

- `cargo fmt --all --check`
- `cargo test -p genie-core --bin genie-core voice_mode_tests`
- `cargo test -p genie-core --no-default-features --bin genie-core voice_mode_tests`
- `git diff --check`

## Notes

This keeps issue #71 separate from issue #69 / PR #70. `genie-ai-runtime` and the OpenAI-compatible chat endpoint were already validated; this fixes the `genie-core` daemon mode selection.
