### PR TITLE
dashboard: show full systemd service status

### DIFF
--- a/crates/dashboard/dashboard.js
+++ b/crates/dashboard/dashboard.js
@@ -136,6 +136,20 @@ async function pollTegrastats() {
   }
 }
 
+function serviceStatus(s) {
+  if (s.healthy) return { label: 'Healthy', color: 'var(--green)', dot: 'dot-up' };
+  if (s.load_state === 'not-found') return { label: 'Missing', color: 'var(--text2)', dot: 'dot-unknown' };
+  if (s.active_state === 'failed') return { label: 'Failed', color: 'var(--red)', dot: 'dot-down' };
+  if (s.active_state && s.active_state !== 'active') {
+    return {
+      label: s.sub_state || s.active_state,
+      color: 'var(--yellow)',
+      dot: 'dot-unknown',
+    };
+  }
+  return { label: s.error || 'Unknown', color: 'var(--red)', dot: 'dot-down' };
+}
+
 async function pollServices() {
   const data = await fetchJson('/api/services');
   const tbody = document.getElementById('services-body');
@@ -147,13 +161,13 @@ async function pollServices() {
   }
 
   tbody.innerHTML = data.map(s => {
-    const dotClass = s.healthy ? 'dot-up' : 'dot-down';
-    const status = s.healthy ? 'Healthy' : (s.error || 'Down');
-    const statusColor = s.healthy ? 'var(--green)' : 'var(--red)';
+    const status = serviceStatus(s);
+    const latency = s.response_ms == null ? '--' : `${s.response_ms}ms`;
+    const detail = s.unit ? `<div class="small">${escapeHtml(s.unit)}</div>` : '';
     return `<tr>
-      <td><span class="dot ${dotClass}"></span>${s.service}</td>
-      <td style="color:${statusColor}">${status}</td>
-      <td>${s.response_ms}ms</td>
+      <td><span class="dot ${status.dot}"></span>${escapeHtml(s.service)}${detail}</td>
+      <td style="color:${status.color}">${escapeHtml(status.label)}</td>
+      <td>${latency}</td>
     </tr>`;
   }).join('');
 }

--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -1,5 +1,8 @@
 use genie_common::config::Config;
 use genie_common::tegrastats;
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+use tokio::process::Command;
 
 use crate::http::Response;
 
@@ -89,57 +92,306 @@ pub async fn get_tegrastats(config: &Config) -> Response {
     }
 }
 
-/// GET /api/services — health check status from health monitor's SQLite.
+#[derive(Debug, Clone)]
+struct ServiceTarget {
+    service: String,
+    unit: String,
+}
+
+#[derive(Debug, Clone)]
+struct HealthRow {
+    healthy: bool,
+    response_ms: i64,
+    error: Option<String>,
+    last_check: i64,
+}
+
+#[derive(Debug, Clone, Default)]
+struct SystemdRow {
+    load_state: String,
+    active_state: String,
+    sub_state: String,
+    unit_file_state: String,
+    result: String,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ServiceRow {
+    service: String,
+    unit: String,
+    healthy: bool,
+    response_ms: Option<i64>,
+    error: Option<String>,
+    last_check: Option<i64>,
+    source: &'static str,
+    load_state: String,
+    active_state: String,
+    sub_state: String,
+    unit_file_state: String,
+    result: String,
+}
+
+/// GET /api/services — URL health plus systemd state for deployed services.
 pub async fn get_services(config: &Config) -> Response {
     let db_path = config.data_dir.join("health.db");
+    let targets = dashboard_service_targets(config);
+    let health = read_latest_health_rows(db_path).await.unwrap_or_default();
+    let mut systemd = BTreeMap::new();
 
-    let result = tokio::task::spawn_blocking(move || -> Result<String, String> {
-        let conn = rusqlite::Connection::open_with_flags(
-            &db_path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-        )
-        .map_err(|e| e.to_string())?;
+    for unit in unique_units(&targets) {
+        systemd.insert(unit.clone(), query_systemd_unit(&unit).await);
+    }
 
-        // Get the latest health check for each service.
-        let mut stmt = conn
-            .prepare(
-                "SELECT service, healthy, response_ms, error, MAX(ts_ms) as last_check
-                 FROM health_log
-                 GROUP BY service
-                 ORDER BY service",
+    let rows = merge_service_rows(&targets, &health, &systemd);
+    let body = serde_json::to_string(&rows).unwrap_or_else(|_| "[]".into());
+
+    Response {
+        status: 200,
+        content_type: "application/json",
+        body,
+    }
+}
+
+async fn read_latest_health_rows(
+    db_path: std::path::PathBuf,
+) -> Result<BTreeMap<String, HealthRow>, String> {
+    let result =
+        tokio::task::spawn_blocking(move || -> Result<BTreeMap<String, HealthRow>, String> {
+            let conn = rusqlite::Connection::open_with_flags(
+                &db_path,
+                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
             )
             .map_err(|e| e.to_string())?;
 
-        let rows: Vec<serde_json::Value> = stmt
-            .query_map([], |row| {
-                Ok(serde_json::json!({
-                    "service": row.get::<_, String>(0)?,
-                    "healthy": row.get::<_, i32>(1)? == 1,
-                    "response_ms": row.get::<_, i64>(2)?,
-                    "error": row.get::<_, Option<String>>(3)?,
-                    "last_check": row.get::<_, i64>(4)?,
-                }))
-            })
-            .map_err(|e| e.to_string())?
-            .filter_map(|r| r.ok())
-            .collect();
+            // Get the latest health check for each URL-polled service.
+            let mut stmt = conn
+                .prepare(
+                    "SELECT h.service, h.healthy, h.response_ms, h.error, h.ts_ms
+                 FROM health_log h
+                 JOIN (
+                     SELECT service, MAX(ts_ms) AS ts_ms
+                     FROM health_log
+                     GROUP BY service
+                 ) latest
+                   ON latest.service = h.service AND latest.ts_ms = h.ts_ms
+                 ORDER BY h.service",
+                )
+                .map_err(|e| e.to_string())?;
 
-        serde_json::to_string(&rows).map_err(|e| e.to_string())
-    })
-    .await;
+            let rows: BTreeMap<String, HealthRow> = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        HealthRow {
+                            healthy: row.get::<_, i32>(1)? == 1,
+                            response_ms: row.get::<_, i64>(2)?,
+                            error: row.get::<_, Option<String>>(3)?,
+                            last_check: row.get::<_, i64>(4)?,
+                        },
+                    ))
+                })
+                .map_err(|e| e.to_string())?
+                .filter_map(|r| r.ok())
+                .collect();
+
+            Ok(rows)
+        })
+        .await;
 
     match result {
-        Ok(Ok(json)) => Response {
-            status: 200,
-            content_type: "application/json",
-            body: json,
-        },
-        _ => Response {
-            status: 200,
-            content_type: "application/json",
-            body: "[]".into(),
-        },
+        Ok(rows) => rows,
+        Err(e) => Err(e.to_string()),
     }
+}
+
+fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
+    let mut targets = vec![
+        ServiceTarget {
+            service: "core".into(),
+            unit: config.services.core.systemd_unit.clone(),
+        },
+        ServiceTarget {
+            service: "llm".into(),
+            unit: config.services.llm.systemd_unit.clone(),
+        },
+        ServiceTarget {
+            service: "api".into(),
+            unit: "genie-api.service".into(),
+        },
+        ServiceTarget {
+            service: "health".into(),
+            unit: "genie-health.service".into(),
+        },
+        ServiceTarget {
+            service: "governor".into(),
+            unit: "genie-governor.service".into(),
+        },
+        ServiceTarget {
+            service: "mqtt".into(),
+            unit: "genie-mqtt.service".into(),
+        },
+        ServiceTarget {
+            service: "audio".into(),
+            unit: "genie-audio.service".into(),
+        },
+        ServiceTarget {
+            service: "whisper".into(),
+            unit: "genie-whisper.service".into(),
+        },
+        ServiceTarget {
+            service: "wakeword".into(),
+            unit: "genie-wakeword.service".into(),
+        },
+        ServiceTarget {
+            service: "homeassistant".into(),
+            unit: config
+                .services
+                .homeassistant
+                .as_ref()
+                .map(|service| service.systemd_unit.clone())
+                .unwrap_or_else(|| "homeassistant.service".into()),
+        },
+    ];
+
+    if let Some(nextcloud) = &config.services.nextcloud {
+        targets.push(ServiceTarget {
+            service: "nextcloud".into(),
+            unit: nextcloud.systemd_unit.clone(),
+        });
+    }
+    if let Some(jellyfin) = &config.services.jellyfin {
+        targets.push(ServiceTarget {
+            service: "jellyfin".into(),
+            unit: jellyfin.systemd_unit.clone(),
+        });
+    }
+
+    targets
+}
+
+fn unique_units(targets: &[ServiceTarget]) -> Vec<String> {
+    targets
+        .iter()
+        .map(|target| target.unit.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn merge_service_rows(
+    targets: &[ServiceTarget],
+    health: &BTreeMap<String, HealthRow>,
+    systemd: &BTreeMap<String, SystemdRow>,
+) -> Vec<ServiceRow> {
+    targets
+        .iter()
+        .map(|target| {
+            let health_row = health.get(&target.service);
+            let systemd_row = systemd
+                .get(&target.unit)
+                .cloned()
+                .unwrap_or_else(|| SystemdRow {
+                    error: Some("systemd status unavailable".into()),
+                    ..SystemdRow::default()
+                });
+            let systemd_active = systemd_row.active_state == "active";
+            let missing = systemd_row.load_state == "not-found";
+            let healthy =
+                !missing && systemd_active && health_row.map(|row| row.healthy).unwrap_or(true);
+            let error = health_row
+                .and_then(|row| row.error.clone())
+                .or_else(|| systemd_row.error.clone())
+                .or_else(|| service_state_error(&systemd_row));
+            let source = if health_row.is_some() {
+                "health+systemd"
+            } else {
+                "systemd"
+            };
+
+            ServiceRow {
+                service: target.service.clone(),
+                unit: target.unit.clone(),
+                healthy,
+                response_ms: health_row.map(|row| row.response_ms),
+                error,
+                last_check: health_row.map(|row| row.last_check),
+                source,
+                load_state: systemd_row.load_state,
+                active_state: systemd_row.active_state,
+                sub_state: systemd_row.sub_state,
+                unit_file_state: systemd_row.unit_file_state,
+                result: systemd_row.result,
+            }
+        })
+        .collect()
+}
+
+fn service_state_error(row: &SystemdRow) -> Option<String> {
+    match row.load_state.as_str() {
+        "not-found" => Some("unit not installed".into()),
+        "" => None,
+        _ if row.active_state == "active" => None,
+        _ if !row.sub_state.is_empty() => Some(row.sub_state.clone()),
+        _ if !row.active_state.is_empty() => Some(row.active_state.clone()),
+        _ => None,
+    }
+}
+
+async fn query_systemd_unit(unit: &str) -> SystemdRow {
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        Command::new("systemctl")
+            .arg("show")
+            .arg(unit)
+            .arg("--no-page")
+            .arg("--property=LoadState")
+            .arg("--property=ActiveState")
+            .arg("--property=SubState")
+            .arg("--property=UnitFileState")
+            .arg("--property=Result")
+            .output(),
+    )
+    .await;
+
+    let output = match output {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => {
+            return SystemdRow {
+                error: Some(e.to_string()),
+                ..SystemdRow::default()
+            };
+        }
+        Err(_) => {
+            return SystemdRow {
+                error: Some("systemctl timed out".into()),
+                ..SystemdRow::default()
+            };
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let mut row = SystemdRow::default();
+
+    for line in stdout.lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            match key {
+                "LoadState" => row.load_state = value.into(),
+                "ActiveState" => row.active_state = value.into(),
+                "SubState" => row.sub_state = value.into(),
+                "UnitFileState" => row.unit_file_state = value.into(),
+                "Result" => row.result = value.into(),
+                _ => {}
+            }
+        }
+    }
+
+    if !output.status.success() && !stderr.trim().is_empty() {
+        row.error = Some(stderr.trim().into());
+    }
+
+    row
 }
 
 /// GET /api/security — redacted household security posture.
@@ -481,4 +733,110 @@ async fn proxy_core_json(
         status,
         body: body.to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use genie_common::config::{
+        ConnectivityConfig, CoreConfig, GovernorConfig, HealthConfig, ServicesConfig,
+        TelegramConfig, WebSearchConfig,
+    };
+    use std::path::PathBuf;
+
+    fn test_config() -> Config {
+        Config {
+            data_dir: PathBuf::from("/tmp/geniepod-api-test"),
+            core: CoreConfig::default(),
+            governor: GovernorConfig::default(),
+            health: HealthConfig::default(),
+            services: ServicesConfig::default(),
+            telegram: TelegramConfig::default(),
+            web_search: WebSearchConfig::default(),
+            connectivity: ConnectivityConfig::default(),
+        }
+    }
+
+    #[test]
+    fn dashboard_targets_include_deployed_stack_services() {
+        let config = test_config();
+        let targets = dashboard_service_targets(&config);
+        let names: Vec<&str> = targets
+            .iter()
+            .map(|target| target.service.as_str())
+            .collect();
+
+        for expected in [
+            "core",
+            "llm",
+            "api",
+            "health",
+            "governor",
+            "mqtt",
+            "audio",
+            "whisper",
+            "wakeword",
+            "homeassistant",
+        ] {
+            assert!(names.contains(&expected), "missing {expected}");
+        }
+    }
+
+    #[test]
+    fn service_rows_merge_health_and_systemd_status() {
+        let targets = vec![
+            ServiceTarget {
+                service: "core".into(),
+                unit: "genie-core.service".into(),
+            },
+            ServiceTarget {
+                service: "api".into(),
+                unit: "genie-api.service".into(),
+            },
+        ];
+        let health = BTreeMap::from([(
+            "core".into(),
+            HealthRow {
+                healthy: true,
+                response_ms: 42,
+                error: None,
+                last_check: 123,
+            },
+        )]);
+        let systemd = BTreeMap::from([
+            (
+                "genie-core.service".into(),
+                SystemdRow {
+                    load_state: "loaded".into(),
+                    active_state: "active".into(),
+                    sub_state: "running".into(),
+                    unit_file_state: "enabled".into(),
+                    result: "success".into(),
+                    error: None,
+                },
+            ),
+            (
+                "genie-api.service".into(),
+                SystemdRow {
+                    load_state: "loaded".into(),
+                    active_state: "inactive".into(),
+                    sub_state: "dead".into(),
+                    unit_file_state: "enabled".into(),
+                    result: "success".into(),
+                    error: None,
+                },
+            ),
+        ]);
+
+        let rows = merge_service_rows(&targets, &health, &systemd);
+        let core = rows.iter().find(|row| row.service == "core").unwrap();
+        let api = rows.iter().find(|row| row.service == "api").unwrap();
+
+        assert!(core.healthy);
+        assert_eq!(core.response_ms, Some(42));
+        assert_eq!(core.source, "health+systemd");
+        assert!(!api.healthy);
+        assert_eq!(api.error.as_deref(), Some("dead"));
+        assert_eq!(api.source, "systemd");
+    }
 }


### PR DESCRIPTION
## Summary

- expands `/api/services` beyond URL health rows by merging health monitor data with systemd state for the deployed GeniePod units
- includes core, configured LLM, API, health, governor, MQTT, audio, Whisper, wakeword, Home Assistant, and configured optional media/cloud services
- updates the dashboard services table to show the systemd unit under each service and distinguish healthy, inactive, failed, missing, and unknown states

Fixes #80.

## Verification

- `cargo fmt --check`
- `cargo test -p genie-api`
- `cargo test -p genie-core --test tool_dispatch_test chat_ui_uses_animated_writing_indicator`
- `RUSTFLAGS='-D warnings' cargo clippy -p genie-api --all-targets --locked -- -D warnings`
- `git diff --check`

## Jetson

Not run from this environment: SSH to `aihpc@192.168.55.1` timed out before deploy/test, so this PR only claims local validation.
