### PR TITLE
docs: add CONTRIBUTING.md, SECURITY.md, PR template, and proof-checklist CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+Thanks for contributing to GenieClaw! Please fill this template in honestly.
+The "Real Behavior Proof" section is required and enforced by CI.
+See CONTRIBUTING.md for the full rules.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what does this PR do and why. Link the issue it closes with `Fixes #NN` or `Closes #NN`. -->
+
+## Changes
+
+<!-- Bullet list of the meaningful changes. -->
+
+-
+
+## Real Behavior Proof
+
+<!--
+REQUIRED. CI will fail if this section is missing or empty.
+See CONTRIBUTING.md "Required: Real Behavior Proof" for the rules.
+
+The bar is: tell us what you ran, where you ran it, and what happened.
+A green CI run is NOT sufficient by itself — it doesn't exercise voice,
+audio, Home Assistant, or the dashboard.
+-->
+
+- [ ] I have built and run the affected code locally (or noted why I could not).
+- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.
+
+### What I ran
+
+<!-- Commands you executed, with environment details (Jetson model + L4T version, or "no Jetson available"). -->
+
+### What I observed
+
+<!-- The actual result — log lines, screenshots, latency numbers, error messages, dashboard state, etc. -->
+
+## Test plan
+
+<!-- Optional but encouraged. Steps a reviewer can follow to re-verify on their own hardware. -->
+
+-
+
+## Notes for reviewers
+
+<!-- Anything reviewer-specific: open questions, known limitations, deferred follow-ups. -->

--- a/.github/workflows/contribution.yml
+++ b/.github/workflows/contribution.yml
@@ -1,0 +1,75 @@
+# Contribution checklist: enforces the CONTRIBUTING.md requirement that every
+# PR body documents real-world verification. See CONTRIBUTING.md "Required:
+# Real Behavior Proof" for the human-readable spec.
+#
+# The check is intentionally lightweight: it confirms structure, not content
+# quality. Reviewers still have to read what you wrote and decide whether the
+# verification path is reasonable for the change.
+name: Contribution
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-body-checklist:
+    name: PR body checklist
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Verify PR body has Real Behavior Proof section
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [ -z "${PR_BODY:-}" ]; then
+              echo "::error::PR body is empty. See CONTRIBUTING.md — every PR must include a 'Real Behavior Proof' section."
+              exit 1
+          fi
+
+          # Allow Dependabot / Renovate / release automation to skip the
+          # human-written proof requirement. These are bot PRs whose
+          # contents are mechanically generated.
+          case "${PR_TITLE:-}" in
+              "chore(deps)"*|"chore(deps-dev)"*|"build(deps)"*|"deps:"*|"release:"*|"Release "*)
+                  echo "Bot / release PR — skipping proof check (title prefix matched)."
+                  exit 0
+                  ;;
+          esac
+
+          # Hard requirement: a "Real Behavior Proof" heading exists.
+          if ! printf '%s' "$PR_BODY" | grep -Eqi '^##+[[:space:]]+Real Behavior Proof[[:space:]]*$'; then
+              echo "::error::PR body must include a '## Real Behavior Proof' section. See CONTRIBUTING.md and the PR template."
+              exit 1
+          fi
+
+          # That section must not be empty (i.e., the boilerplate must have
+          # been replaced with actual content). We check for at least one
+          # non-blank, non-HTML-comment line between the proof heading and
+          # the next heading (or end of body).
+          proof_body="$(printf '%s' "$PR_BODY" | awk '
+              BEGIN { in_section = 0 }
+              /^##+[[:space:]]+Real Behavior Proof[[:space:]]*$/ { in_section = 1; next }
+              in_section && /^##+[[:space:]]/ { in_section = 0 }
+              in_section { print }
+          ' | grep -Ev '^[[:space:]]*$' | grep -Ev '^[[:space:]]*<!--' | grep -Ev '^[[:space:]]*-->')"
+
+          if [ -z "$proof_body" ]; then
+              echo "::error::'## Real Behavior Proof' section is empty. Fill in 'What I ran' and 'What I observed' (or the equivalent narrative — see CONTRIBUTING.md)."
+              exit 1
+          fi
+
+          # Require at least one of the two acknowledgement checkboxes to be
+          # ticked. This is the minimum signal that the contributor read the
+          # template instead of pasting an empty section.
+          if ! printf '%s' "$PR_BODY" | grep -Eq '^[[:space:]]*-[[:space:]]*\[[xX]\]'; then
+              echo "::error::At least one checkbox under '## Real Behavior Proof' must be ticked (use '- [x]')."
+              exit 1
+          fi
+
+          echo "OK: PR body has a non-empty 'Real Behavior Proof' section with at least one ticked acknowledgement checkbox."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Added
+
+- `CONTRIBUTING.md`, `SECURITY.md`, `.github/PULL_REQUEST_TEMPLATE.md`,
+  and `.github/workflows/contribution.yml` — formal contribution guide
+  + private-disclosure security policy + PR template +
+  `Contribution / PR body checklist` CI job. Quality / engineering /
+  bug-fix contributions are explicitly welcomed; every PR must include
+  a `## Real Behavior Proof` section in the body (CI enforces structure,
+  reviewer reads the content) so reviewers can see what was actually
+  run and where, not just what CI checked. Security disclosures go to
+  <contact@genieclaw.org> privately rather than the public issue tracker;
+  scope, in-scope/out-of-scope categories, and response timeline are
+  documented in `SECURITY.md`. Dependabot / Renovate / release PRs
+  are exempt from the proof requirement via a title-prefix allowlist
+  in the checklist workflow. README's bottom-of-file gets a brief
+  "Contributing" + "Security" pair of sections pointing at the
+  canonical docs.
+
 ## 1.0.0-alpha.9 - 2026-05-18
 
 Alpha 9 is the **CI / supply-chain hardening + voice-frontend maturation**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to GenieClaw
+
+GenieClaw is a local home AI runtime that ships on Jetson hardware. Most pull requests touch code that has to actually work on a real Jetson Orin Nano with a microphone, a Home Assistant install, and a chat UI in front of an end user. That constraint shapes how this project reviews contributions.
+
+## Welcome
+
+**Quality, engineering, and bug fixes are always welcome.** That includes:
+
+- Bug fixes against any open issue (or a clear new one you've filed alongside the PR).
+- Test coverage improvements, even for existing behavior nothing else is changing.
+- Documentation fixes — typos, broken links, out-of-date setup instructions.
+- Performance work backed by real measurements on Jetson hardware.
+- Refactors that reduce surface area, kill latent bugs, or simplify the public API.
+- New features that fit the [product direction in README.md](README.md) — please open an issue first to confirm scope.
+
+What we are slower to land:
+
+- Wholesale rewrites of subsystems without a clearly-filed motivating issue.
+- New runtime dependencies (especially anything that needs CUDA, ALSA, or root). Discuss in an issue first.
+- Cosmetic-only changes to working code (style sweeps, mass renames). These churn `git blame` and slow review for everyone else.
+
+## Required: Real Behavior Proof
+
+Every PR body must include a **"Real Behavior Proof"** section that demonstrates you have actually run the code you are changing. This is **enforced by CI** — a PR with no proof section will fail the `Contribution checklist` job and cannot be merged.
+
+The bar is **truth, not theatre**: tell us what you ran, where you ran it, and what happened. Real validation > performative completeness.
+
+### Minimum content
+
+Copy the section from the PR template and fill it in honestly:
+
+```markdown
+## Real Behavior Proof
+
+- [ ] I have built and run the affected code locally (or noted why I could not).
+- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.
+
+### What I ran
+
+<commands you executed, with output if useful>
+
+### What I observed
+
+<the actual result — log lines, screenshots, latency numbers, error messages>
+```
+
+### What counts as "verified end-to-end on Jetson"
+
+In rough order of preference:
+
+1. **You ran it on a real Jetson** (Orin Nano, Orin AGX, or Xavier — any L4T target the repo supports). Include the device, the model loaded, and the output of the affected subsystem (chat reply, voice loop banner, `journalctl -u genie-core`, `genie-ctl status`, dashboard screenshot, etc.).
+2. **The `aarch64-unknown-linux-gnu release build` CI job built your branch cleanly**, AND the code path you changed is exercised by an existing unit / integration test you can show passing under `cargo test`. Document the test names you ran.
+3. **You cannot run on Jetson** (no hardware, no cross-compile toolchain on your dev machine, etc.) — say so explicitly under "What I ran". Explain what verification you did do (`cargo fmt --check`, `cargo clippy -- -D warnings`, targeted unit tests, manual code reading). The reviewer will then decide whether a maintainer needs to run your branch on Jetson before merge.
+
+### What does NOT count
+
+- "Looks correct to me." — judgment without execution.
+- "Tests pass" without naming which tests or what they cover for the change.
+- A green CI run as the only proof — CI runs `cargo fmt / clippy / test / aarch64 cross-compile`, none of which exercise voice, audio, or Home Assistant.
+- Auto-generated PR bodies from `git log --format=%s | head` or AI-coding-tool default templates with nothing filled in.
+
+If you suspect your change is too small to need proof (e.g., a one-line typo fix in a comment), say that explicitly and the reviewer will agree or push back.
+
+## Filing issues before PRs
+
+For anything non-trivial, file an issue first. Most successful PRs in this repo close a specific issue and reference it in the body (`Fixes #NN` or `Closes #NN`). That keeps the discussion attached to the issue and lets reviewers see motivation before reading code.
+
+Bug reports should include:
+
+- The Jetson model + L4T / JetPack version
+- The git SHA you're running (`/opt/geniepod/bin/genie-core --version` or the SHA you deployed via `make deploy`)
+- The exact reproduction steps
+- Relevant `journalctl -u <unit>` excerpts or dashboard error output
+- What you expected to happen vs. what happened
+
+## Code style and CI gates
+
+CI runs against every push and PR:
+
+- `cargo fmt --all -- --check` (workflow: `CI / cargo fmt`)
+- `cargo clippy --workspace --all-targets --locked -- -D warnings` (workflow: `CI / cargo clippy`)
+- `cargo test --workspace --locked --all-targets` + doc tests (workflow: `CI / cargo test`)
+- `cargo clippy + test -p genie-core -p genie-ctl --no-default-features` (workflow: `CI / cargo clippy + test (--no-default-features)`)
+- `aarch64-unknown-linux-gnu` cross-compile of all five release binaries (workflow: `Cross-compile (aarch64 / Jetson)`)
+- `cargo audit` + `cargo deny` on `Cargo.{toml,lock}` / `deny.toml` / workflow changes, plus a weekly cron (workflow: `Audit`)
+- `shellcheck` + `ruff` on tracked `*.sh` and `*.py` (workflow: `Scripts`)
+- **Contribution checklist** — verifies the PR body has the Real Behavior Proof section (workflow: `Contribution / PR body checklist`)
+
+All checks must be green before merge. We squash-merge PRs, with the maintainer writing the squash body — your commit history is a working journal, not the public record.
+
+## Commit hygiene
+
+- Write commit subjects in the imperative mood, scoped if useful: `fix(voice/stt): per-call nonce on transcribe_pcm tempfile`.
+- Keep commit bodies useful — explain *why*, not *what*. The diff already shows what changed.
+- Do **not** add `Co-Authored-By: Claude` / Copilot / other AI-assistant trailers to commit messages. Tools to draft code are fine; we keep `git log` attribution to the human contributor so credit is unambiguous.
+- Don't `--no-verify` past pre-commit hooks. Fix the underlying issue.
+
+## Security disclosures
+
+**Do not file security issues on the public tracker.** Email the security team privately at **<contact@genieclaw.org>** with:
+
+- A description of the issue and where in the codebase it lives
+- Steps to reproduce
+- The potential impact (data exposure, RCE, DoS, privilege escalation, etc.)
+- Any proof-of-concept you've developed
+
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy and response timeline.
+
+## License
+
+By contributing, you agree that your contribution is licensed under the [GNU Affero General Public License v3.0](LICENSE), the same license as the rest of the project. The standard "if you don't own the rights, don't paste it in" rule applies — don't commit code you copied from a non-AGPL-compatible source.
+
+## Questions?
+
+Open a [Discussion](https://github.com/GeniePod/genie-claw/discussions) or comment on the issue you're picking up.

--- a/README.md
+++ b/README.md
@@ -522,6 +522,14 @@ Total first-reply latency of **~4 seconds** from end-of-user-speech to
 first audible TTS audio, on a 7.6 GB Orin Nano running Phi-4-mini Q4_K_M
 LLM + whisper-small + Piper en_US-amy concurrently.
 
+## Contributing
+
+Quality, engineering, and bug fixes are always welcome. Every PR must include a **Real Behavior Proof** section in the description — a brief statement of what you ran, where you ran it, and what happened (Jetson hardware preferred). CI enforces the structure; reviewers read the content. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
+
+## Security
+
+Found a vulnerability? **Do not open a public issue.** Email <contact@genieclaw.org> with the details. See [SECURITY.md](SECURITY.md) for the response timeline and scope.
+
 ## License
 
 GNU Affero General Public License v3.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not file security issues on the public GitHub tracker.** Public disclosure of an unpatched issue puts every GenieClaw deployment at risk.
+
+Email the security team privately at **<contact@genieclaw.org>** with:
+
+- A description of the issue and where in the codebase it lives (file paths, line numbers, commit SHA if known).
+- Steps to reproduce.
+- The potential impact — data exposure, remote code execution, denial of service, privilege escalation, information leak, tampering with audit logs, etc.
+- Any proof-of-concept you've developed.
+- Your contact info for follow-up.
+
+If you do not have email available, open a private security advisory via the [GitHub Security Advisories](https://github.com/GeniePod/genie-claw/security/advisories/new) flow instead. Do **not** open a regular public issue or pull request.
+
+## What We Treat as Security-Sensitive
+
+In a local home AI runtime that touches voice, household memory, Home Assistant actuation, and tool execution, the following are all in scope:
+
+- Anything that could let an unauthenticated caller execute tools, actuate Home Assistant devices, or read household memory.
+- Anything that could let a malicious skill, prompt, or LLM response escape its sandbox.
+- Anything that could leak `geniepod.toml` contents, secrets (`HA_TOKEN`, `TELEGRAM_BOT_TOKEN`, etc.), or raw audio/transcripts off the device.
+- Anything that lets a remote network caller crash, hang, or trigger unbounded resource use in `genie-core`, `genie-api`, `genie-governor`, `genie-health`, or the LLM backend.
+- Tampering with the actuation audit log or the redacted security posture surface.
+- Authentication bypasses against the dashboard, chat API, or the `genie-ai-runtime` HTTP path.
+- Supply-chain risks: a dependency we ship that is itself compromised, or a setup script that fetches an unverified binary.
+
+Out of scope:
+
+- Vulnerabilities in upstream dependencies that don't reach a GenieClaw code path (file those upstream).
+- Issues that require physical access plus root to exploit (operator-side trust boundary).
+- Best-practice recommendations that aren't tied to a concrete exploit (those are welcome as regular `enhancement`-tagged issues).
+
+## Response Timeline
+
+We aim to:
+
+- **Acknowledge** your report within 3 business days.
+- **Triage** (confirm reproducibility + estimated severity) within 7 business days.
+- **Ship a fix** for critical / high-severity issues within 30 days of triage, sooner if exploitation is in the wild.
+
+If a fix takes longer, we'll communicate why. We will credit you in the release notes and CHANGELOG when the fix ships, unless you prefer to stay anonymous.
+
+## Disclosure
+
+We follow coordinated disclosure. Once a fix is released:
+
+- The CHANGELOG and release notes name the issue, the fix, and (with your permission) the reporter.
+- A GitHub Security Advisory is published with the affected version range and the fix version.
+- We do not publicly tag commits or PRs as security fixes until the advisory is live.
+
+## Scope
+
+This policy covers the `GeniePod/genie-claw` repository and the prebuilt artifacts published from its release tags. The companion runtime `GeniePod/genie-ai-runtime` has its own SECURITY.md — file there for issues specific to the C++ inference layer.
+
+## Bug Bounty
+
+GenieClaw is an alpha-stage open-source project. We do not currently offer a paid bug bounty, but well-written reports against the in-scope surfaces above get acknowledged in release notes and earn the reporter's name in the project credits.


### PR DESCRIPTION
## Summary

Formalizes the contribution norms the project has been operating under informally — welcomes quality / engineering / bug-fix work, requires a "Real Behavior Proof" section in every PR body (CI enforces structure), and routes security disclosures to <contact@genieclaw.org> privately. Adds the docs + PR template + checklist workflow as a bundle so the first PR after this lands actually sees and uses the template.

## Changes

- `CONTRIBUTING.md` — what we accept, the proof requirement, CI gates, commit hygiene, where to email security.
- `SECURITY.md` — private-disclosure policy with scope, response timeline (3-day ack / 7-day triage / 30-day critical-fix), and coordinated-disclosure rules.
- `.github/PULL_REQUEST_TEMPLATE.md` — the canonical PR body with the `## Real Behavior Proof` section pre-filled.
- `.github/workflows/contribution.yml` (`Contribution / PR body checklist`) — verifies the proof section exists, is non-empty after stripping HTML comments / blanks, and has at least one ticked acknowledgement box. Dependabot / Renovate / release PRs are exempted via a title-prefix allowlist.
- `README.md` — bottom-of-file "Contributing" and "Security" sections pointing at the canonical docs.
- `CHANGELOG.md` — `## Unreleased` entry.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

This PR is documentation + a CI workflow — no Rust code change, so the Jetson runtime is not affected. The verification path is:

1. **YAML / shell syntax** on the new workflow:
   ```bash
   bash -n .github/workflows/contribution.yml
   ```
2. **Workflow logic against 7 representative PR-body inputs** via a script that replicates the workflow's `bash` checker:
   ```bash
   bash /tmp/test-checklist.sh
   ```
   Test matrix:
   - `T1` empty body → FAIL
   - `T2` no proof heading → FAIL
   - `T3` proof heading but only template comments + unticked boxes → FAIL (no ticked box)
   - `T4` proof present + comment + real "What I ran/observed" + one ticked box → **PASS**
   - `T5` Dependabot-style title (`chore(deps): ...`) → **PASS (bot skip)**
   - `T6` ticked box exists but is under a *different* heading (proof section is empty stub) → FAIL (empty section)
   - `T7` proof present but no ticked box → FAIL

3. **Repo-side sanity**:
   ```bash
   git diff --check          # no whitespace damage
   grep -n 'contact@genieclaw.org' CONTRIBUTING.md SECURITY.md README.md   # 4 hits, all correct
   ```

4. **Self-test**: this PR's own body (the one you're reading) follows the new template and ticks the two acknowledgement boxes — so the `Contribution / PR body checklist` job will run against this PR and prove the check actually fires before it can land elsewhere.

### What I observed

```
T1 empty body (expect FAIL):            FAIL (empty)              ✓
T2 missing proof section (expect FAIL): FAIL (no proof heading)   ✓
T3 template-stub (expect FAIL):         FAIL (no ticked box)      ✓
T4 valid (expect PASS):                 PASS                      ✓
T5 dependabot (expect PASS):            PASS (bot skip)           ✓
T6 ticked but empty section (FAIL):     FAIL (empty section)      ✓
T7 valid but unticked (expect FAIL):    FAIL (no ticked box)      ✓
```

All 7 verdicts match expectations.

## Test plan

For reviewers who want to re-run the workflow logic:

```bash
gh pr checkout 86  # or whatever number this PR gets
# inspect the workflow file:
cat .github/workflows/contribution.yml
# walk through the 7 cases above:
bash /tmp/test-checklist.sh  # paste the same test harness from this PR's "What I ran"
```

After this lands, the next contributor PR will see the new template prompt and the `Contribution / PR body checklist` job in the required-checks list.

## Notes for reviewers

- **Bot exemption** (Dependabot / Renovate / `release:` / `Release ` titles) is intentional — those bodies are mechanically generated and adding a fake proof section would just teach contributors that the field is theatre.
- **The check is structural, not semantic.** A contributor who pastes "I ran cargo test" into the section will pass CI. The reviewer still has to read what was written and decide whether the verification is appropriate for the change. That's by design — we don't want CI to second-guess judgment, just to make sure the contributor was prompted to think about it.
- **No code change to `crates/*` or `deploy/*`** — this PR doesn't touch any runtime behavior, so the existing CI suite (fmt / clippy / test / aarch64 cross-compile / no-default-features / shellcheck / ruff / audit) should all pass unchanged.
- This will be the first PR to run the new `Contribution / PR body checklist` job. If it self-passes, the check is wired correctly.
