### PR TITLE
ci(contribution): block AI-attribution footers in PR body

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,11 @@
 Thanks for contributing to GenieClaw! Please fill this template in honestly.
 The "Real Behavior Proof" section is required and enforced by CI.
 See CONTRIBUTING.md for the full rules.
+
+NOTE: Strip any AI-attribution footer (e.g. "🤖 Generated with Claude Code")
+from your PR body before submitting. Using AI tooling to draft the PR is
+fine; attribution in the PR body and in git history stays with the human
+contributor. CI enforces this.
 -->
 
 ## Summary

--- a/.github/workflows/contribution.yml
+++ b/.github/workflows/contribution.yml
@@ -40,6 +40,16 @@ jobs:
               exit 1
           fi
 
+          # Block AI-attribution footers in PR body. Using Claude Code (or any
+          # other AI agent) to help draft the PR is fine — but `git log`,
+          # `git shortlog`, and the PR description record attribution to the
+          # human contributor, not the tool. Strip the trailer before
+          # submitting. See CONTRIBUTING.md "Commit hygiene".
+          if printf '%s' "$PR_BODY" | grep -Eqi 'Generated[[:space:]]+with[[:space:]]+\[?Claude[[:space:]]+Code\]?'; then
+              echo "::error::PR body contains an AI-attribution footer (e.g. '🤖 Generated with Claude Code'). Strip it before submitting — see CONTRIBUTING.md 'Commit hygiene'."
+              exit 1
+          fi
+
           # Allow Dependabot / Renovate / release automation to skip the
           # human-written proof requirement. These are bot PRs whose
           # contents are mechanically generated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
   `Contribution / PR body checklist` CI job (triggered via
   `pull_request_target` so the check runs from the base branch's
   workflow definition — fires on every PR regardless of whether the
-  PR head pre-dates the workflow). Quality / engineering /
+  PR head pre-dates the workflow). Checklist also blocks PR bodies
+  that include AI-attribution footers like `🤖 Generated with Claude
+  Code` (case-insensitive, matches the bracketed-link form as well)
+  to keep PR attribution with the human contributor; same spirit as
+  the existing no-`Co-Authored-By: Claude` commit-trailer rule. Quality / engineering /
   bug-fix contributions are explicitly welcomed; every PR must include
   a `## Real Behavior Proof` section in the body (CI enforces structure,
   reviewer reads the content) so reviewers can see what was actually

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,7 @@ All checks must be green before merge. We squash-merge PRs, with the maintainer 
 - Write commit subjects in the imperative mood, scoped if useful: `fix(voice/stt): per-call nonce on transcribe_pcm tempfile`.
 - Keep commit bodies useful — explain *why*, not *what*. The diff already shows what changed.
 - Do **not** add `Co-Authored-By: Claude` / Copilot / other AI-assistant trailers to commit messages. Tools to draft code are fine; we keep `git log` attribution to the human contributor so credit is unambiguous.
+- Do **not** include AI-generated attribution footers like `🤖 Generated with Claude Code` (or any variant) in **PR bodies** either. Enforced by the `Contribution / PR body checklist` CI job. Same reason as the commit-trailer rule: attribution stays with the human contributor.
 - Don't `--no-verify` past pre-commit hooks. Fix the underlying issue.
 
 ## Security disclosures


### PR DESCRIPTION
## Summary

Adds a check to the `Contribution / PR body checklist` workflow that fails when the PR body contains the Claude Code default attribution footer (the line that starts with the robot emoji and the words `Generated`-then-`with`-then-`Claude Code`). Same spirit as the existing `CONTRIBUTING.md` commit-trailer rule (no `Co-Authored-By: Claude` on commits): attribution stays with the human contributor in both git history and the PR description.

## Changes

- `.github/workflows/contribution.yml` — adds the regex-based check after the empty-body guard and **before** the bot-title exemption, so the rule applies universally. Case-insensitive match against `Generated[[:space:]]+with[[:space:]]+\[?Claude[[:space:]]+Code\]?` — catches both the plain form and the bracketed-link form (`[Claude Code](https://...)`) the Claude Code template emits.
- `.github/PULL_REQUEST_TEMPLATE.md` — adds a one-paragraph note in the leading HTML comment warning contributors to strip the trailer before submitting.
- `CONTRIBUTING.md` — adds a new "Commit hygiene" bullet covering the PR-body rule alongside the existing commit-trailer rule.
- `CHANGELOG.md` — extends the existing Unreleased entry.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
bash -n .github/workflows/contribution.yml      # syntax clean
bash /tmp/test-checklist-v2.sh                  # 7-case test matrix
```

Test matrix targets:

| # | Input shape | Expected |
|---|---|---|
| T1 | Valid body, no AI footer | PASS |
| T2 | Valid body + footer with the robot emoji and the bare phrase | FAIL |
| T3 | Valid body + the bracketed-link form `[Claude Code](https://...)` | FAIL |
| T4 | Valid body + lowercased variant | FAIL |
| T5 | Valid body + footer with extra spacing between tokens | FAIL |
| T6 | Valid body, casual mention of the tool name in prose without the `Generated`-`with` lead | PASS |
| T7 | Dependabot-titled PR body with the footer | FAIL (norm applies universally) |

### What I observed

All 7 verdicts match the expected column. The false-positive case (T6, casual prose mention) correctly passes — the regex requires the literal `Generated` + whitespace + `with` + whitespace + `Claude` + whitespace + `Code` lead-in, so contributors can still discuss the tool by name in their writeup.

A note on this PR's own body: I deliberately avoided typing the literal forbidden phrase anywhere in this description, which is why I refer to it via "the robot emoji and the words `Generated`-then-`with`-then-`Claude Code`" instead. If the PR body checklist had been on `pull_request_target` *and* I had pasted the literal phrase, this PR would have rejected itself — which is the correct behavior, just inconvenient for the PR that introduces the rule.

## Test plan

After merge, the next PR body that includes the literal Claude-Code attribution trailer will see `PR body checklist: FAILURE` with a clear error message pointing at `CONTRIBUTING.md` and asking the contributor to strip the trailer. Existing open PRs (#78 / #83 / #87 / #61 / #48) are unaffected unless their body is edited to add the trailer.

## Notes for reviewers

- **Universality of the rule**: the new check fires before the bot-title exemption (Dependabot / release PRs). The reasoning: those bots don't include AI attribution footers in practice, but if they ever did, we'd still want to catch it — the rule is about project history hygiene, not about who/what authored.
- **False-positive surface**: a contributor writing "I used Claude Code to draft this PR" in their prose is fine. A contributor pasting the actual footer trailer is not. The regex requires the specific `Generated`+`with`+`Claude`+`Code` sequence with whitespace between, so prose discussion is safe.
- **No `Cargo.toml` / runtime change** — this PR only touches `.github/`, `CONTRIBUTING.md`, and `CHANGELOG.md`. The existing 5 CI checks (fmt / clippy / test / aarch64 / no-default-features) should all pass unchanged.
