### PR TITLE
feat(deploy): hard-reset genie-restart-all.sh — stop, reap, drop_caches, swap, start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### Changed
+
+- `deploy/scripts/genie-restart-all.sh` rewritten as a full hard-reset:
+  delegates to `stop_all.sh` for the systemd stops, best-effort
+  `pkill -x` reaps known LLM/STT/TTS/audio subprocess names that may
+  have survived the cgroup stop (piper, whisper-server, whisper-cli,
+  jetson-llm-server, jetson-llm, llama-server, deep-filter, sox,
+  ffmpeg), `sync; echo 3 > /proc/sys/vm/drop_caches` releases page
+  cache, `swapoff -a; swapon -a` flushes the swap file to a clean
+  baseline, then delegates to `start_all.sh` to bring the stack back
+  up. Deliberately gives back the warm Qwen3-4B page-cache residency
+  PR #70 preserves across plain `systemctl restart` — the script
+  exists for the post-`make deploy` case where binaries / config /
+  model path may have changed and the prior warm cache is stale.
+  Pass `--soft` to skip the cache + swap reset for a service-only
+  refresh that preserves the warm LLM cache. `swapoff` failure
+  (no swap, or not enough free RAM to absorb the swap contents) is
+  logged and skipped rather than fatal so the script never wedges
+  the box mid-restart. New regression test
+  `genie_restart_all_hard_mode_performs_full_memory_reset` pins
+  the five-step shape (stop → reap → drop_caches → swapoff/swapon
+  → start) and the ordering, so future edits can't quietly drop a
+  step without failing CI.
+
 ### Added
 
 - `CONTRIBUTING.md`, `SECURITY.md`, `.github/PULL_REQUEST_TEMPLATE.md`,

--- a/crates/genie-core/tests/tool_dispatch_test.rs
+++ b/crates/genie-core/tests/tool_dispatch_test.rs
@@ -284,6 +284,60 @@ fn start_all_uses_configured_llm_backend() {
     );
 }
 
+/// Pin the hard-reset shape of genie-restart-all.sh so future edits can't
+/// quietly drop the orphan reap / cache drop / swap free steps.
+#[test]
+fn genie_restart_all_hard_mode_performs_full_memory_reset() {
+    let path = workspace_root().join("deploy/scripts/genie-restart-all.sh");
+    let contents = std::fs::read_to_string(&path).unwrap();
+
+    assert!(
+        contents.contains("stop_all.sh"),
+        "genie-restart-all should delegate to stop_all.sh before reset"
+    );
+    assert!(
+        contents.contains("pkill -x"),
+        "genie-restart-all should reap orphaned subprocesses by exact basename"
+    );
+    assert!(
+        contents.contains("drop_caches"),
+        "genie-restart-all --hard should drop page cache"
+    );
+    assert!(
+        contents.contains("swapoff -a") && contents.contains("swapon -a"),
+        "genie-restart-all --hard should free + re-enable swap"
+    );
+    assert!(
+        contents.contains("start_all.sh"),
+        "genie-restart-all should delegate to start_all.sh after reset"
+    );
+    assert!(
+        contents.contains("--soft"),
+        "genie-restart-all should expose --soft to skip the cache+swap reset (preserves PR #70 warm cache)"
+    );
+    assert!(
+        contents.contains("PR #70") || contents.contains("issue #69"),
+        "genie-restart-all should document the warm-cache trade-off relative to PR #70 / issue #69"
+    );
+
+    // Ordering invariant against the imperative code section (matched via
+    // strings that only appear in the code body, not the doc-comment header):
+    //   stop_all → reap orphans → drop page cache → free swap → start_all.
+    let stop_pos = contents.find("\"$STOP_ALL\"").expect("STOP_ALL invocation");
+    let reap_pos = contents
+        .find("Reaping orphaned subprocesses")
+        .expect("reap echo line");
+    let drop_pos = contents
+        .find("Dropping page cache")
+        .expect("drop_caches echo line");
+    let swap_pos = contents.find("Freeing swap").expect("swap echo line");
+    let start_pos = contents.find("\"$START_ALL\"").expect("START_ALL invocation");
+    assert!(stop_pos < reap_pos, "stop_all must run before reaping orphans");
+    assert!(reap_pos < drop_pos, "orphan reap must run before drop_caches");
+    assert!(drop_pos < swap_pos, "drop_caches must run before swap reset");
+    assert!(swap_pos < start_pos, "swap reset must run before start_all");
+}
+
 /// Verify genie-ai-runtime service preserves warm GGUF pages across restarts.
 #[test]
 fn genie_ai_runtime_service_preserves_model_page_cache() {

--- a/crates/genie-core/tests/tool_dispatch_test.rs
+++ b/crates/genie-core/tests/tool_dispatch_test.rs
@@ -331,10 +331,21 @@ fn genie_restart_all_hard_mode_performs_full_memory_reset() {
         .find("Dropping page cache")
         .expect("drop_caches echo line");
     let swap_pos = contents.find("Freeing swap").expect("swap echo line");
-    let start_pos = contents.find("\"$START_ALL\"").expect("START_ALL invocation");
-    assert!(stop_pos < reap_pos, "stop_all must run before reaping orphans");
-    assert!(reap_pos < drop_pos, "orphan reap must run before drop_caches");
-    assert!(drop_pos < swap_pos, "drop_caches must run before swap reset");
+    let start_pos = contents
+        .find("\"$START_ALL\"")
+        .expect("START_ALL invocation");
+    assert!(
+        stop_pos < reap_pos,
+        "stop_all must run before reaping orphans"
+    );
+    assert!(
+        reap_pos < drop_pos,
+        "orphan reap must run before drop_caches"
+    );
+    assert!(
+        drop_pos < swap_pos,
+        "drop_caches must run before swap reset"
+    );
     assert!(swap_pos < start_pos, "swap reset must run before start_all");
 }
 

--- a/deploy/scripts/genie-restart-all.sh
+++ b/deploy/scripts/genie-restart-all.sh
@@ -1,81 +1,138 @@
 #!/bin/bash
-# Restart the deployed GeniePod stack after updating binaries/config on Jetson.
+# Hard restart of the deployed GeniePod stack on Jetson.
+#
+# Default (--hard) order of operations:
+#   1. Stop every GeniePod systemd unit (delegates to stop_all.sh).
+#   2. Best-effort kill of any subprocess that survived the stop. systemctl
+#      stop kills the cgroup so this is rare, but genie-core spawns
+#      piper / whisper / sox / ffmpeg / jetson-llm-server / deep-filter,
+#      and a crashed parent may leave them behind.
+#   3. `sync; echo 3 > /proc/sys/vm/drop_caches` — release page cache.
+#   4. `swapoff -a; swapon -a` — flush the swap file back to free state.
+#   5. Start every GeniePod systemd unit (delegates to start_all.sh).
+#
+# Trade-off — important for issue #69 / PR #70 readers:
+#   Step 3 evicts the Qwen3-4B GGUF from page cache, so the first LLM
+#   request after restart hits the ~30 s cold-load path instead of the
+#   ~1.3 s warm path PR #70 preserved across plain `systemctl restart
+#   genie-ai-runtime`. That's the intended behavior here — this script
+#   exists to give back a clean memory state after `make deploy`, where
+#   the binaries / config / model path may have changed and the prior
+#   warm cache is stale anyway. If you only want a soft service refresh
+#   (and want to keep the warm LLM cache), pass `--soft` instead.
+#
+# Usage:
+#   genie-restart-all.sh          # full hard reset (cache + swap)
+#   genie-restart-all.sh --hard   # explicit form of the default
+#   genie-restart-all.sh --soft   # services only; preserve page cache + swap
 
-set -euo pipefail
+set -uo pipefail
 
-if [ "$(id -u)" -eq 0 ]; then
-    SYSTEMCTL=(systemctl)
-else
-    SYSTEMCTL=(sudo systemctl)
-fi
-
-UNITS=(
-    genie-audio.service
-    genie-mqtt.service
-    genie-core.service
-    genie-governor.service
-    genie-health.service
-    genie-api.service
-    genie-wakeword.service
-    homeassistant.service
-)
-
-OPTIONAL_UNITS=(
-    genie-audio.service
-    genie-wakeword.service
-    homeassistant.service
-)
-
-is_optional_unit() {
-    local unit="$1"
-    local optional
-    for optional in "${OPTIONAL_UNITS[@]}"; do
-        if [ "$optional" = "$unit" ]; then
-            return 0
-        fi
-    done
-    return 1
-}
-
-unit_exists() {
-    "${SYSTEMCTL[@]}" cat "$1" > /dev/null 2>&1
-}
-
-echo "=== GeniePod restart after update ==="
-echo ""
-echo "Reloading systemd units..."
-"${SYSTEMCTL[@]}" daemon-reload
-
-failed_required=()
-failed_optional=()
-
-for unit in "${UNITS[@]}"; do
-    if ! unit_exists "$unit"; then
-        echo "  Skip: $unit (unit not installed)"
-        continue
-    fi
-
-    printf "  Restarting %s ... " "$unit"
-    if "${SYSTEMCTL[@]}" restart "$unit"; then
-        echo "OK"
-    else
-        echo "FAILED"
-        if is_optional_unit "$unit"; then
-            failed_optional+=("$unit")
-        else
-            failed_required+=("$unit")
-        fi
-    fi
+MODE="hard"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --soft) MODE="soft" ; shift ;;
+        --hard) MODE="hard" ; shift ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo "Usage: $0 [--hard|--soft]" >&2
+            exit 2
+            ;;
+    esac
 done
 
-echo ""
-if [ "${#failed_optional[@]}" -gt 0 ]; then
-    echo "Optional units failed: ${failed_optional[*]}"
+if [ "$(id -u)" -eq 0 ]; then
+    SUDO=()
+else
+    SUDO=(sudo)
 fi
 
-if [ "${#failed_required[@]}" -gt 0 ]; then
-    echo "Required units failed: ${failed_required[*]}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STOP_ALL="$SCRIPT_DIR/stop_all.sh"
+START_ALL="$SCRIPT_DIR/start_all.sh"
+
+# Process names that GeniePod units typically spawn as subprocesses. If a
+# parent crashed or a previous shutdown left descendants behind, reap them
+# before we reclaim memory in step 3-4. `pkill -x` matches exact basenames
+# only, so unrelated processes that happen to embed these strings (e.g.
+# "ffmpeg-tutorial-screenshot.png" in a file viewer) are not at risk.
+ORPHAN_CMDS=(
+    piper
+    whisper-server
+    whisper-cli
+    jetson-llm-server
+    jetson-llm
+    llama-server
+    deep-filter
+    sox
+    ffmpeg
+)
+
+echo "=== GeniePod restart (mode=$MODE) ==="
+echo ""
+
+# 1. Stop all systemd units.
+if [ -x "$STOP_ALL" ]; then
+    "$STOP_ALL"
+else
+    echo "WARN: $STOP_ALL not executable; skipping stop step" >&2
+fi
+
+# 2. Reap orphaned subprocesses.
+echo ""
+echo "Reaping orphaned subprocesses..."
+reaped=0
+for cmd in "${ORPHAN_CMDS[@]}"; do
+    if "${SUDO[@]}" pkill -x "$cmd" 2>/dev/null; then
+        echo "  Killed orphan: $cmd"
+        reaped=$((reaped + 1))
+    fi
+done
+if [ "$reaped" -eq 0 ]; then
+    echo "  None — systemctl stop reaped the cgroups cleanly."
+fi
+
+if [ "$MODE" = "hard" ]; then
+    # 3. Drop page cache. Loses the warm Qwen3-4B GGUF residency from
+    # PR #70 by design — see header comment for the trade-off.
+    echo ""
+    echo "Dropping page cache (sync + drop_caches=3)..."
+    if "${SUDO[@]}" sh -c 'sync && echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null; then
+        echo "  OK"
+    else
+        echo "  WARN: drop_caches write failed (need root). Continuing."
+    fi
+
+    # 4. Free swap. swapoff returns the swap file's pages to RAM (or
+    # discards them if backed by clean files), then swapon re-enables it
+    # at a clean baseline. If swap was full and not enough free RAM
+    # exists to absorb it, swapoff fails — we don't want to wedge the
+    # box, so fall through without retrying.
+    echo "Freeing swap (swapoff -a && swapon -a)..."
+    if "${SUDO[@]}" swapoff -a 2>/dev/null; then
+        echo "  swapoff: OK"
+        if "${SUDO[@]}" swapon -a 2>/dev/null; then
+            echo "  swapon:  OK"
+        else
+            echo "  swapon:  no swap entries in /etc/fstab (continuing)"
+        fi
+    else
+        echo "  swapoff: not configured or not enough free RAM to absorb (continuing)"
+    fi
+fi
+
+# 5. Start all systemd units.
+echo ""
+if [ -x "$START_ALL" ]; then
+    "$START_ALL"
+else
+    echo "WARN: $START_ALL not executable; skipping start step" >&2
     exit 1
 fi
 
-echo "All required GeniePod services restarted."
+echo ""
+echo "=== GeniePod restart complete (mode=$MODE) ==="


### PR DESCRIPTION
## Summary

Rewrites `deploy/scripts/genie-restart-all.sh` from a per-unit `systemctl restart` loop into a deliberate full memory reset:

1. **stop_all.sh** — every GeniePod systemd unit.
2. **`pkill -x`** — best-effort reap of orphan subprocesses that escaped the cgroup stop (piper / whisper-server / whisper-cli / jetson-llm-server / jetson-llm / llama-server / deep-filter / sox / ffmpeg).
3. **`sync && echo 3 > /proc/sys/vm/drop_caches`** — release page cache.
4. **`swapoff -a && swapon -a`** — flush the swap file to a clean baseline.
5. **start_all.sh** — bring the stack back up.

Pass `--soft` to skip steps 3-4 for a service-only refresh that preserves the warm LLM cache from PR #70.

## Trade-off vs PR #70

PR #70 just landed the page-cache-preservation fix on `genie-ai-runtime.service` (issue #69 — warm restart ~1.3 s vs cold ~30 s). This script **deliberately undoes** that win on the restart-all code path, because `genie-restart-all.sh` is documented for the post-`make deploy` case where binaries / config / model path may have changed and the prior warm cache is stale anyway. The `--soft` flag is the escape hatch for operators who just want to bounce services without paying the cold-load cost.

## Changes

- `deploy/scripts/genie-restart-all.sh` — full rewrite. Header comment documents the order, the `--hard` / `--soft` modes, and the explicit trade-off relative to PR #70. `set -uo pipefail` (no `-e`) so individual `pkill` / `swapoff` failures don't wedge the script mid-restart.
- `crates/genie-core/tests/tool_dispatch_test.rs` — new test `genie_restart_all_hard_mode_performs_full_memory_reset` pins the five-step shape and the ordering. Markers are chosen from the imperative code section (echo strings + `"$STOP_ALL"` / `"$START_ALL"` invocations), not the doc-comment header, so refactors can't satisfy the test by just shuffling words around the comments.
- `CHANGELOG.md` — Unreleased `### Changed` entry.

## Failure modes covered

- **`swapoff -a` fails** (no swap configured, or not enough free RAM to absorb swap contents): script logs and continues. This is the safety net — refusing to start services because swap couldn't be reset would be worse than just skipping the swap-reset step.
- **`drop_caches` write fails** (running unprivileged without sudo): logged + continue.
- **`pkill -x <name>` returns 1** (no process found, the common case): silently continue.
- **stop_all.sh or start_all.sh not deployed**: warn + skip / fail respectively. Doesn't crash the harness.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

Dev machine (macOS, no Jetson handy this session). Verification path:

```bash
# Shell syntax.
bash -n deploy/scripts/genie-restart-all.sh

# Help output renders cleanly.
bash deploy/scripts/genie-restart-all.sh --help | head -25

# Unknown-flag handling.
bash deploy/scripts/genie-restart-all.sh --bogus 2>&1
# → ERROR: unknown argument: --bogus (exit 2)

# Regression test.
cargo test -p genie-core --test tool_dispatch_test \
    genie_restart_all_hard_mode_performs_full_memory_reset
# → 1 passed

# All existing tool_dispatch_test cases still pass.
cargo test -p genie-core --test tool_dispatch_test
# → 17 passed (note: `binary_size_budget` known-flaky in some
#   environments; unrelated to this change)
```

### What I observed

- Shell syntax clean.
- Help output exactly matches the documented usage.
- Unknown flag → exit 2 with the right error message.
- Regression test catches the ordering invariant: I deliberately broke an early draft by putting `drop_caches` before `pkill`, and the test failed with "orphan reap must run before drop_caches" — which is the desired regression signal.
- Other 16 `tool_dispatch_test` cases unchanged.

End-to-end on Jetson is the natural next step: an operator running `make deploy JETSON_HOST=... && ssh ... '/opt/geniepod/bin/genie-restart-all.sh'` should see the five steps print in order, `free -h` should show more free RAM after step 4 vs before step 1, and `/opt/geniepod/bin/genie-model-cache-status.sh` (from PR #70) should report `cold` after step 3 and back to `warm` once `genie-ai-runtime-warmup.service` re-runs as part of step 5.

## Test plan

- [ ] Run `/opt/geniepod/bin/genie-restart-all.sh` on Jetson after this lands. Confirm the five-step flow prints, `free -h` shows the cache drop, and `genie-model-cache-status.sh` reports cold-then-warm.
- [ ] Run `/opt/geniepod/bin/genie-restart-all.sh --soft` and confirm steps 3-4 are skipped, warm cache stays at 100%.

## Notes for reviewers

- **Why a full stop-then-start instead of rolling per-unit restart**: the original script's `systemctl restart` loop kept the service gap minimal but didn't actually give back memory — `genie-core` would keep its process maps in RAM during its own restart, swap contents stayed, page cache untouched. The stop-everything-first approach is required for `swapoff -a` to have any free-RAM headroom to work with, since swapoff has to move swap contents back into RAM.
- **`pkill -x` (exact basename)**: matches `piper` exactly, not `piper-tutorial.txt` in a file viewer. Safer than `pkill -f` (full-command-line match) which would have a wider blast radius.
- **No fork-bomb risk from the `pkill` loop**: the loop iterates a fixed 9-element list, each `pkill` is bounded by the system's process count.
