### PR TITLE
fix(ui): reflect degraded /api/health state in chat header

### DIFF
--- a/crates/genie-core/src/chat_ui.html
+++ b/crates/genie-core/src/chat_ui.html
@@ -8,7 +8,7 @@
 :root {
   --bg: #0a0e14; --surface: #131920; --border: #1e2730;
   --text: #e0e6ed; --text2: #8899aa; --accent: #00d4ff;
-  --green: #00e676; --red: #ff5252; --user-bg: #1a2332; --bot-bg: #0f1820;
+  --green: #00e676; --amber: #ffab40; --red: #ff5252; --user-bg: #1a2332; --bot-bg: #0f1820;
   --tool-bg: #1a1a2e; --tool-border: #7c4dff;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -36,6 +36,7 @@ header .dot {
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--green); display: inline-block;
 }
+header .dot.degraded { background: var(--amber); }
 header .dot.offline { background: var(--red); }
 header button {
   background: none; border: 1px solid var(--border); color: var(--text2);
@@ -164,12 +165,22 @@ const statusText = document.getElementById('status-text');
 
 let sending = false;
 
+function applyHealthStatus(data) {
+  if (data.status === 'ok' && data.llm === 'connected') {
+    statusDot.className = 'dot';
+    statusText.textContent = 'Connected';
+    return;
+  }
+  statusDot.className = 'dot degraded';
+  statusText.textContent = data.llm === 'offline' ? 'LLM offline' : 'Degraded';
+}
+
 async function checkHealth() {
   try {
     const r = await fetch('/api/health');
+    if (!r.ok) throw new Error('health unavailable');
     const data = await r.json();
-    statusDot.className = 'dot';
-    statusText.textContent = 'Connected';
+    applyHealthStatus(data);
   } catch {
     statusDot.className = 'dot offline';
     statusText.textContent = 'Offline';

--- a/crates/genie-core/tests/tool_dispatch_test.rs
+++ b/crates/genie-core/tests/tool_dispatch_test.rs
@@ -403,6 +403,26 @@ fn chat_ui_uses_animated_writing_indicator() {
     );
 }
 
+/// Verify the chat UI header reflects `/api/health` status and LLM state.
+#[test]
+fn chat_ui_reflects_api_health_status() {
+    let path = workspace_root().join("crates/genie-core/src/chat_ui.html");
+    let contents = std::fs::read_to_string(&path).unwrap();
+
+    assert!(
+        contents.contains("function applyHealthStatus"),
+        "chat UI should map health JSON to header state"
+    );
+    assert!(
+        contents.contains("data.status === 'ok'") && contents.contains("data.llm === 'connected'"),
+        "chat UI should require both ok status and connected LLM before showing Connected"
+    );
+    assert!(
+        contents.contains("LLM offline") && contents.contains("dot degraded"),
+        "chat UI should show a degraded state when the LLM is offline"
+    );
+}
+
 /// Verify the model cache helper can inspect GGUF page-cache residency.
 #[test]
 fn model_cache_status_helper_reports_residency() {


### PR DESCRIPTION
## Summary

Fixes #95

The embedded chat UI (`chat_ui.html`) now reads `status` and `llm` from `GET /api/health` instead of treating any HTTP 200 as fully connected. When genie-core is up but the LLM is offline, the header shows an amber degraded dot and **LLM offline** (or **Degraded** for other degraded states).

## Changes

- Add `applyHealthStatus()` to map `/api/health` JSON to header dot + label
- Add `.dot.degraded` (amber) between green (ok) and red (offline)
- Add regression test `chat_ui_reflects_api_health_status` in `tool_dispatch_test.rs`

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
cd genie-claw
cargo build -p genie-core --release
cargo test -p genie-core --test tool_dispatch_test chat_ui_reflects_api_health_status

# LLM stopped; genie-core on port 3001
GENIEPOD_CONFIG=/tmp/geniepod-port3001.toml ./target/release/genie-core

curl -s http://127.0.0.1:3001/api/health | jq '{status, llm}'
```

Browser: `http://127.0.0.1:3001/` (hard refresh). DevTools console:

```javascript
const data = await (await fetch('/api/health')).json();
console.log({ status: data.status, llm: data.llm });
console.log(document.getElementById('status-text').textContent);
console.log(document.getElementById('status-dot').className);
```

### What I observed

- `/api/health` with LLM down: `{"status":"degraded","llm":"offline",...}`
- **Before:** green dot, header text `Connected`; chat POST returned connection error while header stayed connected
- **After:** amber dot (`dot degraded`), header text `LLM offline`
- Regression test passes locally
- No Jetson hardware in this environment; verification is local x86_64 against a running `genie-core` instance with LLM backend stopped

## Test plan

- [ ] `cargo test -p genie-core --test tool_dispatch_test chat_ui_reflects_api_health_status`
- [ ] Stop LLM backend, start `genie-core`, open chat UI — header shows **LLM offline** (amber), not **Connected**
- [ ] Start LLM, confirm header returns to **Connected** (green) when `/api/health` reports `status: ok` and `llm: connected`
- [ ] Stop `genie-core` — header shows **Offline** (red)

## Notes for reviewers

Small HTML/JS-only change in the embedded chat UI; no server-side routing changes. Closes the reproduction from #95.
