### PR TITLE
fix(ui): reflect degraded /api/health state in chat header

### DIFF
--- a/crates/genie-core/src/chat_ui.html
+++ b/crates/genie-core/src/chat_ui.html
@@ -8,7 +8,7 @@
 :root {
   --bg: #0a0e14; --surface: #131920; --border: #1e2730;
   --text: #e0e6ed; --text2: #8899aa; --accent: #00d4ff;
-  --green: #00e676; --red: #ff5252; --user-bg: #1a2332; --bot-bg: #0f1820;
+  --green: #00e676; --amber: #ffab40; --red: #ff5252; --user-bg: #1a2332; --bot-bg: #0f1820;
   --tool-bg: #1a1a2e; --tool-border: #7c4dff;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -36,6 +36,7 @@ header .dot {
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--green); display: inline-block;
 }
+header .dot.degraded { background: var(--amber); }
 header .dot.offline { background: var(--red); }
 header button {
   background: none; border: 1px solid var(--border); color: var(--text2);
@@ -164,12 +165,22 @@ const statusText = document.getElementById('status-text');
 
 let sending = false;
 
+function applyHealthStatus(data) {
+  if (data.status === 'ok' && data.llm === 'connected') {
+    statusDot.className = 'dot';
+    statusText.textContent = 'Connected';
+    return;
+  }
+  statusDot.className = 'dot degraded';
+  statusText.textContent = data.llm === 'offline' ? 'LLM offline' : 'Degraded';
+}
+
 async function checkHealth() {
   try {
     const r = await fetch('/api/health');
+    if (!r.ok) throw new Error('health unavailable');
     const data = await r.json();
-    statusDot.className = 'dot';
-    statusText.textContent = 'Connected';
+    applyHealthStatus(data);
   } catch {
     statusDot.className = 'dot offline';
     statusText.textContent = 'Offline';

--- a/crates/genie-core/tests/tool_dispatch_test.rs
+++ b/crates/genie-core/tests/tool_dispatch_test.rs
@@ -403,6 +403,26 @@ fn chat_ui_uses_animated_writing_indicator() {
     );
 }
 
+/// Verify the chat UI header reflects `/api/health` status and LLM state.
+#[test]
+fn chat_ui_reflects_api_health_status() {
+    let path = workspace_root().join("crates/genie-core/src/chat_ui.html");
+    let contents = std::fs::read_to_string(&path).unwrap();
+
+    assert!(
+        contents.contains("function applyHealthStatus"),
+        "chat UI should map health JSON to header state"
+    );
+    assert!(
+        contents.contains("data.status === 'ok'") && contents.contains("data.llm === 'connected'"),
+        "chat UI should require both ok status and connected LLM before showing Connected"
+    );
+    assert!(
+        contents.contains("LLM offline") && contents.contains("dot degraded"),
+        "chat UI should show a degraded state when the LLM is offline"
+    );
+}
+
 /// Verify the model cache helper can inspect GGUF page-cache residency.
 #[test]
 fn model_cache_status_helper_reports_residency() {


### PR DESCRIPTION
## Summary

Fixes #95

The embedded chat UI (`chat_ui.html`) now reads `status` and `llm` from `GET /api/health` instead of treating any HTTP 200 as fully connected. When genie-core is up but the LLM is offline, the header shows an amber degraded dot and **LLM offline**.

## Changes

- Add `applyHealthStatus()` to map `/api/health` JSON to header dot + label
- Add `.dot.degraded` (amber) between green (ok) and red (offline)
- Add regression test `chat_ui_reflects_api_health_status` in `tool_dispatch_test.rs`

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
cargo build -p genie-core --release
cargo test -p genie-core --test tool_dispatch_test chat_ui_reflects_api_health_status

GENIEPOD_CONFIG=/tmp/geniepod-port3001.toml ./target/release/genie-core
curl -s http://127.0.0.1:3001/api/health | jq '{status, llm}'
```

Browser: `http://127.0.0.1:3001/` — header shows **LLM offline** (amber) when LLM backend is stopped.

### What I observed

- `/api/health` with LLM down: `status: degraded`, `llm: offline`
- Header: amber dot + **LLM offline** (not **Connected**)
- Regression test passes locally
- No Jetson in this environment; local x86_64 verification only

## Test plan

- [ ] `cargo test -p genie-core --test tool_dispatch_test chat_ui_reflects_api_health_status`
- [ ] Stop LLM, open chat UI — **LLM offline** (amber)
- [ ] Start LLM — **Connected** (green) when health is ok
- [ ] Stop genie-core — **Offline** (red)

## Notes for reviewers

Commit author: `galuis116 <116897328+galuis116@users.noreply.github.com>`. No AI co-author trailers in git log.
