### PR TITLE
wakeword: treat empty config as disabled

### DIFF
--- a/crates/dashboard/dashboard.js
+++ b/crates/dashboard/dashboard.js
@@ -137,6 +137,7 @@ async function pollTegrastats() {
 }
 
 function serviceStatus(s) {
+  if (s.source === 'config') return { label: 'Disabled', color: 'var(--text2)', dot: 'dot-unknown' };
   if (s.healthy) return { label: 'Healthy', color: 'var(--green)', dot: 'dot-up' };
   if (s.load_state === 'not-found') return { label: 'Missing', color: 'var(--text2)', dot: 'dot-unknown' };
   if (s.active_state === 'failed') return { label: 'Failed', color: 'var(--red)', dot: 'dot-down' };

--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -101,6 +101,7 @@ struct ServiceTarget {
     service: String,
     unit: String,
     latency_url: Option<String>,
+    disabled_reason: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -225,46 +226,60 @@ fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
             service: "core".into(),
             unit: config.services.core.systemd_unit.clone(),
             latency_url: Some(config.services.core.url.clone()),
+            disabled_reason: None,
         },
         ServiceTarget {
             service: "llm".into(),
             unit: config.services.llm.systemd_unit.clone(),
             latency_url: Some(config.services.llm.url.clone()),
+            disabled_reason: None,
         },
         ServiceTarget {
             service: "api".into(),
             unit: "genie-api.service".into(),
             latency_url: Some("http://127.0.0.1:3080/api/status".into()),
+            disabled_reason: None,
         },
         ServiceTarget {
             service: "health".into(),
             unit: "genie-health.service".into(),
             latency_url: None,
+            disabled_reason: None,
         },
         ServiceTarget {
             service: "governor".into(),
             unit: "genie-governor.service".into(),
             latency_url: None,
+            disabled_reason: None,
         },
         ServiceTarget {
             service: "mqtt".into(),
             unit: "genie-mqtt.service".into(),
             latency_url: None,
+            disabled_reason: None,
         },
         ServiceTarget {
             service: "audio".into(),
             unit: "genie-audio.service".into(),
             latency_url: None,
+            disabled_reason: None,
         },
         ServiceTarget {
             service: "whisper".into(),
             unit: "genie-whisper.service".into(),
             latency_url: None,
+            disabled_reason: None,
         },
         ServiceTarget {
             service: "wakeword".into(),
             unit: "genie-wakeword.service".into(),
             latency_url: None,
+            disabled_reason: config
+                .core
+                .wakeword_script
+                .as_os_str()
+                .is_empty()
+                .then(|| "disabled in config (push-to-talk mode)".into()),
         },
         ServiceTarget {
             service: "homeassistant".into(),
@@ -279,6 +294,7 @@ fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
                 .homeassistant
                 .as_ref()
                 .map(|service| service.url.clone()),
+            disabled_reason: None,
         },
     ];
 
@@ -287,6 +303,7 @@ fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
             service: "nextcloud".into(),
             unit: nextcloud.systemd_unit.clone(),
             latency_url: Some(nextcloud.url.clone()),
+            disabled_reason: None,
         });
     }
     if let Some(jellyfin) = &config.services.jellyfin {
@@ -294,6 +311,7 @@ fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
             service: "jellyfin".into(),
             unit: jellyfin.systemd_unit.clone(),
             latency_url: Some(jellyfin.url.clone()),
+            disabled_reason: None,
         });
     }
 
@@ -303,6 +321,7 @@ fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
 fn unique_units(targets: &[ServiceTarget]) -> Vec<String> {
     targets
         .iter()
+        .filter(|target| target.disabled_reason.is_none())
         .map(|target| target.unit.clone())
         .collect::<BTreeSet<_>>()
         .into_iter()
@@ -318,6 +337,24 @@ fn merge_service_rows(
     targets
         .iter()
         .map(|target| {
+            if let Some(reason) = &target.disabled_reason {
+                return ServiceRow {
+                    service: target.service.clone(),
+                    unit: target.unit.clone(),
+                    healthy: true,
+                    response_ms: None,
+                    latency_source: "not_applicable",
+                    error: Some(reason.clone()),
+                    last_check: None,
+                    source: "config",
+                    load_state: "disabled".into(),
+                    active_state: "inactive".into(),
+                    sub_state: "disabled".into(),
+                    unit_file_state: "disabled".into(),
+                    result: "success".into(),
+                };
+            }
+
             let health_row = health.get(&target.service);
             let live_row = live_latency.get(&target.service);
             let systemd_row = systemd
@@ -380,6 +417,9 @@ async fn collect_live_latency_rows(
     let mut rows = BTreeMap::new();
 
     for target in targets {
+        if target.disabled_reason.is_some() {
+            continue;
+        }
         if health.contains_key(&target.service) {
             continue;
         }
@@ -898,17 +938,41 @@ mod tests {
     }
 
     #[test]
+    fn dashboard_targets_mark_wakeword_disabled_when_config_empty() {
+        let mut config = test_config();
+        config.core.wakeword_script = PathBuf::new();
+
+        let targets = dashboard_service_targets(&config);
+        let wakeword = targets
+            .iter()
+            .find(|target| target.service == "wakeword")
+            .unwrap();
+        let units = unique_units(&targets);
+
+        assert_eq!(
+            wakeword.disabled_reason.as_deref(),
+            Some("disabled in config (push-to-talk mode)")
+        );
+        assert!(
+            !units.contains(&"genie-wakeword.service".into()),
+            "disabled wakeword should not require a systemd probe"
+        );
+    }
+
+    #[test]
     fn service_rows_merge_health_and_systemd_status() {
         let targets = vec![
             ServiceTarget {
                 service: "core".into(),
                 unit: "genie-core.service".into(),
                 latency_url: Some("http://127.0.0.1:3000/api/health".into()),
+                disabled_reason: None,
             },
             ServiceTarget {
                 service: "api".into(),
                 unit: "genie-api.service".into(),
                 latency_url: Some("http://127.0.0.1:3080/api/status".into()),
+                disabled_reason: None,
             },
         ];
         let health = BTreeMap::from([(
@@ -974,6 +1038,7 @@ mod tests {
             service: "wakeword".into(),
             unit: "genie-wakeword.service".into(),
             latency_url: None,
+            disabled_reason: None,
         }];
         let systemd = BTreeMap::from([(
             "genie-wakeword.service".into(),
@@ -995,5 +1060,39 @@ mod tests {
         assert_eq!(wakeword.latency_source, "not_applicable");
         assert_eq!(wakeword.error.as_deref(), Some("failed"));
         assert_eq!(wakeword.source, "systemd");
+    }
+
+    #[test]
+    fn disabled_wakeword_rows_ignore_stale_failed_systemd_state() {
+        let targets = vec![ServiceTarget {
+            service: "wakeword".into(),
+            unit: "genie-wakeword.service".into(),
+            latency_url: None,
+            disabled_reason: Some("disabled in config (push-to-talk mode)".into()),
+        }];
+        let systemd = BTreeMap::from([(
+            "genie-wakeword.service".into(),
+            SystemdRow {
+                load_state: "loaded".into(),
+                active_state: "failed".into(),
+                sub_state: "failed".into(),
+                unit_file_state: "disabled".into(),
+                result: "exit-code".into(),
+                error: None,
+            },
+        )]);
+
+        let rows = merge_service_rows(&targets, &BTreeMap::new(), &BTreeMap::new(), &systemd);
+        let wakeword = rows.first().unwrap();
+
+        assert!(wakeword.healthy);
+        assert_eq!(wakeword.response_ms, None);
+        assert_eq!(wakeword.latency_source, "not_applicable");
+        assert_eq!(
+            wakeword.error.as_deref(),
+            Some("disabled in config (push-to-talk mode)")
+        );
+        assert_eq!(wakeword.source, "config");
+        assert_eq!(wakeword.sub_state, "disabled");
     }
 }

--- a/crates/genie-core/tests/tool_dispatch_test.rs
+++ b/crates/genie-core/tests/tool_dispatch_test.rs
@@ -268,6 +268,15 @@ fn start_all_uses_configured_llm_backend() {
         "start_all should read [services.llm].systemd_unit"
     );
     assert!(
+        contents.contains("read_wakeword_script")
+            && contents.contains("wakeword_script is empty; push-to-talk mode"),
+        "start_all should honor empty [core].wakeword_script as push-to-talk mode"
+    );
+    assert!(
+        contents.contains("reset-failed \"$unit\""),
+        "start_all should clear stale failed state for disabled optional services"
+    );
+    assert!(
         contents.contains("other_llm_units_for"),
         "start_all should stop the non-selected LLM backend before starting"
     );

--- a/deploy/scripts/start_all.sh
+++ b/deploy/scripts/start_all.sh
@@ -21,6 +21,15 @@ read_llm_unit() {
     ' "$CONFIG_FILE" 2>/dev/null || true
 }
 
+read_wakeword_script() {
+    "${AWK[@]}" -F'"' '
+        /^\[core\]/ { in_core = 1; next }
+        /^\[/ && !/^\[core\]/ { in_core = 0 }
+        in_core && /^wakeword_script = / { found = 1; print $2; exit }
+        END { if (!found) print "__missing__" }
+    ' "$CONFIG_FILE" 2>/dev/null || true
+}
+
 normalize_unit() {
     local unit="$1"
     case "$unit" in
@@ -79,11 +88,27 @@ is_warmup_unit() {
     esac
 }
 
+skip_disabled_unit() {
+    local unit="$1"
+    local reason="$2"
+    echo "  Skip: $unit ($reason)"
+    if unit_exists "$unit"; then
+        "${SYSTEMCTL[@]}" stop "$unit" > /dev/null 2>&1 || true
+        "${SYSTEMCTL[@]}" reset-failed "$unit" > /dev/null 2>&1 || true
+    fi
+}
+
 start_unit() {
     local unit="$1"
     if [ -z "$unit" ]; then
         return 0
     fi
+
+    if [ "$unit" = "genie-wakeword.service" ] && [ "$wakeword_enabled" != "1" ]; then
+        skip_disabled_unit "$unit" "wakeword_script is empty; push-to-talk mode"
+        return 0
+    fi
+
     if ! unit_exists "$unit"; then
         if is_optional_unit "$unit"; then
             echo "  Skip: $unit (unit not installed)"
@@ -116,6 +141,14 @@ start_unit() {
 raw_llm_unit="$(read_llm_unit)"
 configured_llm_unit="$(normalize_unit "$raw_llm_unit")"
 configured_warmup_unit="$(warmup_unit_for "$configured_llm_unit")"
+wakeword_script="$(read_wakeword_script)"
+wakeword_enabled=1
+if [ -z "$wakeword_script" ]; then
+    wakeword_enabled=0
+elif [ "$wakeword_script" = "__missing__" ]; then
+    # Missing key falls back to genie-core's compiled default.
+    wakeword_script="/opt/geniepod/bin/genie-wake-listen.py"
+fi
 
 UNITS=(
     genie-audio.service
@@ -135,6 +168,11 @@ UNITS=(
 echo "=== GeniePod start all ==="
 echo ""
 echo "Configured LLM unit: $configured_llm_unit"
+if [ "$wakeword_enabled" = "1" ]; then
+    echo "Wake word script: $wakeword_script"
+else
+    echo "Wake word: disabled (push-to-talk mode)"
+fi
 echo "Reloading systemd units..."
 "${SYSTEMCTL[@]}" daemon-reload
 


### PR DESCRIPTION
## Summary
- treat empty `[core].wakeword_script` as explicit push-to-talk mode in `start_all.sh`
- stop and `reset-failed` `genie-wakeword.service` when wakeword is disabled by config
- report wakeword as `Disabled` / `config` in `/api/services` instead of surfacing stale failed systemd state

Fixes #100

## Testing
- cargo fmt --check
- cargo test -p genie-api
- cargo test -p genie-core --test tool_dispatch_test -- jetson_lifecycle_scripts_are_valid_shell start_all_uses_configured_llm_backend
- bash -n deploy/scripts/start_all.sh
- local fake-systemctl simulation for `wakeword_script = ""`
- Jetson deploy + dashboard/API validation

## Real Behavior Proof
- [x] I have built and run the affected code locally.
- [x] I have verified the change end-to-end on Jetson hardware.

Jetson dashboard result after deploying this branch:

```text
core          Healthy       87ms
llm           Healthy       5ms
api           Healthy       0ms live
health        Healthy       n/a
governor      Healthy       n/a
mqtt          auto-restart  n/a
audio         Healthy       n/a
whisper       Healthy       n/a
wakeword      Disabled      n/a
homeassistant Healthy       n/a
```