### PR TITLE
fix(ctl,api): probe genie-api and HA from [services.*] config

### DIFF
--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -236,8 +236,8 @@ fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
         },
         ServiceTarget {
             service: "api".into(),
-            unit: "genie-api.service".into(),
-            latency_url: Some("http://127.0.0.1:3080/api/status".into()),
+            unit: config.services.api.systemd_unit.clone(),
+            latency_url: Some(config.services.api.url.clone()),
             disabled_reason: None,
         },
         ServiceTarget {

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -414,6 +414,11 @@ pub struct HealthConfig {
 pub struct ServicesConfig {
     pub core: ServiceEndpoint,
     pub llm: ServiceEndpoint,
+
+    /// Local genie-api dashboard / proxy HTTP endpoint.
+    #[serde(default = "defaults::api_service_endpoint")]
+    pub api: ServiceEndpoint,
+
     pub homeassistant: Option<ServiceEndpoint>,
 
     #[serde(default)]
@@ -626,6 +631,48 @@ pub enum LlmBackendKind {
     LlamaCpp,
 }
 
+/// Parse an `http://` service URL into `(host:port, path)` for local HTTP clients.
+///
+/// `default_port` is used when the URL omits an explicit port (e.g. `8123` for Home Assistant).
+pub fn service_http_probe(url: &str, default_port: u16) -> Result<(String, String), String> {
+    let rest = url.trim();
+    let rest = rest
+        .strip_prefix("http://")
+        .ok_or_else(|| format!("unsupported service URL '{url}': only http:// is supported"))?;
+
+    let (authority, path) = match rest.find('/') {
+        Some(idx) => (&rest[..idx], rest[idx..].to_string()),
+        None => (rest, "/".to_string()),
+    };
+
+    let authority = authority.trim();
+    if authority.is_empty() {
+        return Err(format!("invalid service URL '{url}': missing host"));
+    }
+
+    let path = if path.is_empty() { "/".into() } else { path };
+
+    let (host, port) = if authority.starts_with('[') {
+        let end = authority
+            .find(']')
+            .ok_or_else(|| format!("invalid IPv6 service URL '{url}'"))?;
+        let host = &authority[1..end];
+        let port = authority[end + 1..]
+            .strip_prefix(':')
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(default_port);
+        (host.to_string(), port)
+    } else if let Some((host, port_str)) = authority.rsplit_once(':')
+        && let Ok(port) = port_str.parse::<u16>()
+    {
+        (host.to_string(), port)
+    } else {
+        (authority.to_string(), default_port)
+    };
+
+    Ok((format!("{host}:{port}"), path))
+}
+
 impl Config {
     pub fn load() -> anyhow::Result<Self> {
         let path = std::env::var("GENIEPOD_CONFIG")
@@ -640,6 +687,11 @@ impl Config {
             .map_err(|e| anyhow::anyhow!("failed to read config {}: {}", path.display(), e))?;
         let config: Config = toml::from_str(&contents)?;
         Ok(config)
+    }
+
+    /// Resolve the configured genie-api HTTP endpoint.
+    pub fn api_service(&self) -> &ServiceEndpoint {
+        &self.services.api
     }
 
     /// Resolve the configured Home Assistant endpoint, if this deployment uses one.
@@ -662,7 +714,7 @@ impl Config {
     /// Whether the current deployment should manage a given service alias.
     pub fn manages_service_alias(&self, alias: &str) -> bool {
         match alias {
-            "core" | "genie-core" | "llm" | "genie-llm" => true,
+            "core" | "genie-core" | "llm" | "genie-llm" | "api" | "genie-api" => true,
             "homeassistant" => self.services.homeassistant.is_some(),
             "nextcloud" => self.services.nextcloud.is_some(),
             "jellyfin" => self.services.jellyfin.is_some(),
@@ -677,6 +729,7 @@ impl Config {
         match alias {
             "core" | "genie-core" => Some(self.services.core.systemd_unit.clone()),
             "llm" | "genie-llm" => Some(self.services.llm.systemd_unit.clone()),
+            "api" | "genie-api" => Some(self.services.api.systemd_unit.clone()),
             "homeassistant" => self
                 .services
                 .homeassistant
@@ -849,6 +902,7 @@ impl Default for ServicesConfig {
                 systemd_unit: "genie-ai-runtime.service".into(),
                 backend: LlmBackendKind::GenieAiRuntime,
             },
+            api: defaults::api_service_endpoint(),
             homeassistant: None,
             nextcloud: None,
             jellyfin: None,
@@ -932,6 +986,55 @@ mod tests {
         let config = test_config();
         assert!(config.homeassistant_service().is_none());
         assert!(!config.manages_service_alias("homeassistant"));
+    }
+
+    #[test]
+    fn api_service_has_default_probe_url() {
+        let config = test_config();
+        assert_eq!(
+            config.api_service().url,
+            "http://127.0.0.1:3080/api/status"
+        );
+    }
+
+    #[test]
+    fn service_http_probe_parses_host_port_and_path() {
+        let (addr, path) =
+            service_http_probe("http://192.168.1.50:8123/api/", 8123).unwrap();
+        assert_eq!(addr, "192.168.1.50:8123");
+        assert_eq!(path, "/api/");
+    }
+
+    #[test]
+    fn service_http_probe_uses_default_port_when_missing() {
+        let (addr, path) = service_http_probe("http://homeassistant.local/", 8123).unwrap();
+        assert_eq!(addr, "homeassistant.local:8123");
+        assert_eq!(path, "/");
+    }
+
+    #[test]
+    fn service_http_probe_parses_api_status_url() {
+        let (addr, path) =
+            service_http_probe("http://127.0.0.1:3080/api/status", 3080).unwrap();
+        assert_eq!(addr, "127.0.0.1:3080");
+        assert_eq!(path, "/api/status");
+    }
+
+    #[test]
+    fn services_config_deserializes_without_explicit_api_section() {
+        let config: ServicesConfig = toml::from_str(
+            r#"
+[core]
+url = "http://127.0.0.1:3000/api/health"
+systemd_unit = "genie-core.service"
+
+[llm]
+url = "http://127.0.0.1:8080/health"
+systemd_unit = "genie-llm.service"
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.api.url, "http://127.0.0.1:3080/api/status");
     }
 
     #[test]
@@ -1328,6 +1431,7 @@ device_path = "/dev/spidev1.0"
 }
 
 mod defaults {
+    use super::{LlmBackendKind, ServiceEndpoint};
     use std::path::PathBuf;
 
     pub fn data_dir() -> PathBuf {
@@ -1362,6 +1466,13 @@ mod defaults {
     }
     pub fn alert_webhook_url() -> String {
         String::new()
+    }
+    pub fn api_service_endpoint() -> ServiceEndpoint {
+        ServiceEndpoint {
+            url: "http://127.0.0.1:3080/api/status".into(),
+            systemd_unit: "genie-api.service".into(),
+            backend: LlmBackendKind::default(),
+        }
     }
     pub fn core_port() -> u16 {
         3000

--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -18,7 +18,7 @@
 //!   genie-ctl version         Show version info
 
 use anyhow::Result;
-use genie_common::config::Config;
+use genie_common::config::{Config, service_http_probe};
 use genie_core::skills::{
     SkillLoader, SkillManifestAudit, find_manifest_sidecar, manifest_sidecar_candidates,
     skills_dir as runtime_skills_dir,
@@ -51,6 +51,26 @@ fn core_addr_from_config(config: &Config) -> String {
 fn load_core_addr() -> Result<String> {
     Ok(core_addr_from_config(&Config::load()?))
 }
+
+/// HTTP probes for optional stack services declared in `geniepod.toml`.
+fn configured_http_probes(config: &Config) -> Vec<(&'static str, String, u16)> {
+    let mut probes = vec![("genie-api", config.services.api.url.clone(), 3080_u16)];
+    if let Some(ha) = config.homeassistant_service() {
+        probes.push(("Home Assistant", ha.url.clone(), 8123));
+    }
+    probes
+}
+
+async fn probe_http_service(name: &str, url: &str, default_port: u16) {
+    match service_http_probe(url, default_port) {
+        Ok((addr, path)) => match http_get(&addr, &path).await {
+            Ok(_) => println!("  [OK]   {}", name),
+            Err(_) => println!("  [DOWN] {}", name),
+        },
+        Err(reason) => println!("  [SKIP] {} ({})", name, reason),
+    }
+}
+
 const SKILL_RESTART_HINT: &str =
     "Restart genie-core to load skill changes, or wait until the next startup.";
 
@@ -1048,7 +1068,8 @@ async fn cmd_connectivity() -> Result<()> {
 }
 
 async fn cmd_health() -> Result<()> {
-    let core = load_core_addr()?;
+    let config = Config::load()?;
+    let core = core_addr_from_config(&config);
     let core_health = match http_get(&core, "/api/health").await {
         Ok(body) => {
             println!("  [OK]   genie-core");
@@ -1069,16 +1090,8 @@ async fn cmd_health() -> Result<()> {
         }
     }
 
-    // Check each remaining HTTP service.
-    let services = [
-        ("Home Assistant", "127.0.0.1:8123", "/api/"),
-        ("genie-api", "127.0.0.1:3080", "/api/status"),
-    ];
-    for (name, addr, path) in &services {
-        match http_get(addr, path).await {
-            Ok(_) => println!("  [OK]   {}", name),
-            Err(_) => println!("  [DOWN] {}", name),
-        }
+    for (name, url, default_port) in configured_http_probes(&config) {
+        probe_http_service(name, &url, default_port).await;
     }
 
     // Governor (Unix socket, not HTTP).
@@ -1183,7 +1196,8 @@ async fn cmd_update_check() -> Result<()> {
 }
 
 async fn cmd_diag() -> Result<()> {
-    let core = load_core_addr()?;
+    let config = Config::load()?;
+    let core = core_addr_from_config(&config);
     println!("=== GeniePod Diagnostics ===\n");
 
     // Version.
@@ -1192,17 +1206,21 @@ async fn cmd_diag() -> Result<()> {
 
     // Core health.
     println!("\n[Services]");
-    let services = [
-        ("genie-core", core.as_str(), "/api/health"),
-        ("genie-api", "127.0.0.1:3080", "/api/status"),
-        ("Home Assistant", "127.0.0.1:8123", "/api/"),
-    ];
-    for (name, addr, path) in &services {
-        let status = match http_get(addr, path).await {
-            Ok(_) => "UP",
-            Err(_) => "DOWN",
+    let status = match http_get(&core, "/api/health").await {
+        Ok(_) => "UP",
+        Err(_) => "DOWN",
+    };
+    println!("  {:20} {}", "genie-core", status);
+
+    for (name, url, default_port) in configured_http_probes(&config) {
+        let line_status = match service_http_probe(&url, default_port) {
+            Ok((addr, path)) => match http_get(&addr, &path).await {
+                Ok(_) => "UP",
+                Err(_) => "DOWN",
+            },
+            Err(_) => "SKIP",
         };
-        println!("  {:20} {}", name, status);
+        println!("  {:20} {}", name, line_status);
     }
     let gov_status = match governor_cmd(r#"{"cmd":"status"}"#).await {
         Some(_) => "UP",
@@ -1359,22 +1377,49 @@ async fn cmd_diag() -> Result<()> {
 }
 
 async fn cmd_support_bundle(output_path: &Path) -> Result<()> {
-    let core = load_core_addr()?;
-    let services = [
-        ("genie-core", core.as_str(), "/api/health"),
-        ("genie-api", "127.0.0.1:3080", "/api/status"),
-        ("Home Assistant", "127.0.0.1:8123", "/api/"),
-    ];
+    let config = Config::load()?;
+    let core = core_addr_from_config(&config);
+    let (api_addr, api_probe_error) = match service_http_probe(&config.services.api.url, 3080) {
+        Ok((addr, _path)) => (addr, None::<String>),
+        Err(reason) => (String::new(), Some(reason)),
+    };
 
-    let mut service_status = Vec::new();
-    for (name, addr, path) in &services {
-        service_status.push(serde_json::json!({
-            "service": name,
-            "addr": addr,
-            "path": path,
-            "reachable": http_get(addr, path).await.is_ok(),
-        }));
+    let mut service_status = vec![serde_json::json!({
+        "service": "genie-core",
+        "addr": core,
+        "path": "/api/health",
+        "reachable": http_get(&core, "/api/health").await.is_ok(),
+    })];
+
+    for (name, url, default_port) in configured_http_probes(&config) {
+        let entry = match service_http_probe(&url, default_port) {
+            Ok((addr, path)) => serde_json::json!({
+                "service": name,
+                "url": url,
+                "addr": addr,
+                "path": path,
+                "reachable": http_get(&addr, &path).await.is_ok(),
+            }),
+            Err(reason) => serde_json::json!({
+                "service": name,
+                "url": url,
+                "reachable": false,
+                "error": reason,
+            }),
+        };
+        service_status.push(entry);
     }
+
+    let api_security = if api_probe_error.is_none() {
+        http_json_value(&api_addr, "/api/security").await
+    } else {
+        serde_json::Value::Null
+    };
+    let api_actuation_audit = if api_probe_error.is_none() {
+        http_json_value(&api_addr, "/api/actuation/audit").await
+    } else {
+        serde_json::Value::Null
+    };
 
     let bundle = serde_json::json!({
         "schema_version": 1,
@@ -1390,11 +1435,11 @@ async fn cmd_support_bundle(output_path: &Path) -> Result<()> {
             "runtime_contract": http_json_value(&core, "/api/runtime/contract").await,
             "connectivity": http_json_value(&core, "/api/connectivity").await,
         },
-        "security": http_json_value("127.0.0.1:3080", "/api/security").await,
+        "security": api_security,
         "actuation": {
             "pending": http_json_value(&core, "/api/actuation/pending").await,
             "actions": http_json_value(&core, "/api/actuation/actions").await,
-            "audit": http_json_value("127.0.0.1:3080", "/api/actuation/audit").await,
+            "audit": api_actuation_audit,
         },
         "system": {
             "meminfo": read_file_lines("/proc/meminfo", 8),

--- a/deploy/config/geniepod.dev.toml
+++ b/deploy/config/geniepod.dev.toml
@@ -88,6 +88,10 @@ systemd_unit = "genie-llm.service"
 backend = "llama_cpp"              # Dev default (x86/macOS): local llama.cpp `--server` on :8080.
 # backend = "genie_ai_runtime"      # Jetson-tuned runtime (dev machines typically stay on llama.cpp).
 
+[services.api]
+url = "http://127.0.0.1:3080/api/status"
+systemd_unit = "genie-api.service"
+
 # Uncomment to enable Home Assistant integration during development:
 # [services.homeassistant]
 # url = "http://127.0.0.1:8123/"

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -233,6 +233,10 @@ backend = "genie_ai_runtime"      # Default on Jetson. OpenAI-compatible genie-a
                                   # to roll back to the legacy llama.cpp server path.
                                   # Accepts hyphenated aliases too: "llama-cpp" / "genie-ai-runtime".
 
+[services.api]
+url = "http://127.0.0.1:3080/api/status"
+systemd_unit = "genie-api.service"
+
 # Uncomment to enable Home Assistant integration:
 # [services.homeassistant]
 # url = "http://127.0.0.1:8123/"


### PR DESCRIPTION
## Summary

- Add `[services.api]` to `geniepod.toml` (default `http://127.0.0.1:3080/api/status`) with backward-compatible serde default for existing configs
- Add `service_http_probe()` in `genie-common` to parse `http://` service URLs into `(host:port, path)`
- Update `genie-ctl health`, `diag`, and `support-bundle` to probe genie-api and Home Assistant from configured URLs (skip HA when not configured)
- Update `genie-api` dashboard service targets to use `[services.api].url` instead of a hardcoded latency URL

Fixes #103

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
cargo fmt --all
cargo test -p genie-common -p genie-ctl -p genie-api
```

### What I observed

All **58** unit tests in the three touched crates passed on x86_64 Linux (rustc 1.95.0):

- `genie-common`: new tests for `service_http_probe`, `[services.api]` default, and TOML backward compatibility (missing `[services.api]` section)
- `genie-ctl`: existing tests still pass after health/diag/support-bundle probe changes
- `genie-api`: dashboard target tests still pass with config-driven api latency URL

No Jetson hardware available in this environment; changes are config/HTTP-probe plumbing only and do not touch voice, audio, or actuation paths.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p genie-common -p genie-ctl -p genie-api`
- [ ] Maintainer: verify `genie-ctl health` with custom `[services.homeassistant].url` on a deployment where HA is enabled

Made with [Cursor](https://cursor.com)