### PR TITLE
docs: add M1 roadmap to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,48 @@ The current product target is **GeniePod Home**:
 - built around privacy, security, and bounded extensions
 - designed to feel stable, understandable, and privacy-respecting
 
+## Roadmap
+
+### Milestone 1 — stable voice loop on `genie-ai-runtime` v1
+
+The first milestone is intentionally narrow: stabilize one end-to-end path
+(voice in, voice out) on the current first release of `genie-ai-runtime`,
+and nothing else. Breadth comes after M1.
+
+In scope:
+
+- **system prompt path** — deterministic prompt assembly, reproducible across restarts, no silent prompt drift between runs
+- **`genie-ai-runtime` v1 integration reliability** — every chat/voice cycle reaches the runtime, every response parses cleanly, every failure mode surfaces in `/api/health` and `genie-ctl status`
+- **memory recall** — household context written to SQLite is retrievable and referenced in subsequent turns; recall failures are observable, not silent
+- **tool dispatch** — the tool-call gate routes correctly, applies per-origin ACLs, rate-limits, and audits; every dispatched tool either completes or fails loudly
+- **voice pipeline strength** — wake → VAD → STT → LLM → TTS round-trip under the alpha latency budget on Jetson Orin Nano Super 8 GB; no silent stalls, no torn audio, no stuck push-to-talk loops
+
+Out of scope for M1:
+
+- new channels beyond the existing voice + Telegram phase 2 bridges
+- new skills / skill marketplace work
+- Home Assistant feature expansion (current transitional adapter only)
+- `genie-home-runtime` split-out
+- hardware variants beyond Orin Nano Super 8 GB
+- web UI features off the M1 observability path
+
+PRs outside this scope are welcome but will be tagged `post-m1` and queued.
+
+**Contribution surface during M1**: bug reports and PRs are welcome in **both**
+[`GeniePod/genie-claw`](https://github.com/GeniePod/genie-claw) and
+[`GeniePod/genie-ai-runtime`](https://github.com/GeniePod/genie-ai-runtime). If
+a bug crosses the boundary, file it where the symptom appears; a maintainer
+will move or mirror it.
+
+M1 closes when, on a clean Jetson Orin Nano Super 8 GB:
+
+- [ ] 100 consecutive voice cycles pass with zero stalls and zero silent drops
+- [ ] system prompt SHA is identical across full-stack restart
+- [ ] memory recall test set (≥ 20 cases) passes ≥ 95%
+- [ ] tool dispatch ACL + rate-limit + audit log proven by integration test
+- [ ] `genie-ai-runtime` v1 backend stable for 24h continuous run
+- [ ] CI green on: fmt, clippy, test, aarch64 cross-compile, audit, deny, shellcheck, ruff, AI-attribution check, proof-checklist
+
 ## Quick Start
 
 If you just want to run the software locally:


### PR DESCRIPTION
## Summary

Pins the first GenieClaw milestone scope so contributors know what's in
and what's out. Placed between **Product Direction** and **Quick Start**
so it's visible to anyone reading the README top-to-bottom.

### M1 scope (in)

- system prompt path — deterministic prompt assembly across restarts
- `genie-ai-runtime` v1 integration reliability — every cycle reaches the runtime, failures surface in `/api/health` and `genie-ctl status`
- memory recall — SQLite-backed household context retrievable and referenced in subsequent turns
- tool dispatch — tool-call gate with per-origin ACLs, rate-limits, audit
- voice pipeline strength — wake → VAD → STT → LLM → TTS round-trip under the alpha latency budget on Jetson Orin Nano Super 8 GB

### Out of scope for M1

- new channels beyond voice + Telegram phase 2
- new skills / skill marketplace
- Home Assistant feature expansion
- `genie-home-runtime` split-out
- hardware variants beyond Orin Nano Super 8 GB
- web UI features off the M1 observability path

### Contribution surface

Bug reports and PRs welcome in **both** `GeniePod/genie-claw` and
`GeniePod/genie-ai-runtime` during M1.

### Exit criteria

Concrete checklist in the README — 100 consecutive voice cycles clean,
prompt SHA reproducible, memory recall ≥ 95% on a ≥ 20-case set, tool
dispatch ACL/rate-limit/audit proven by integration test, 24h continuous
runtime stability, full CI matrix green.

## Type of Change

- [x] Documentation

## Real Behavior Proof

This is a docs-only change (`README.md`, +42 / -0). No code paths
touched, so the behavior to verify is rendering, link validity, and CI
matrix unaffected.

**What I ran:**

- previewed the rendered Markdown on the GitHub PR diff view to confirm the new `## Roadmap` section sits between `## Product Direction` and `## Quick Start` as intended
- confirmed both repo links resolve (`GeniePod/genie-claw` self-link and `GeniePod/genie-ai-runtime` cross-link)
- confirmed the existing `## Current Focus`, `## Product Direction`, and CHANGELOG narrative still flow with the new section in place

**What I observed:**

- [x] section renders cleanly, headings nest correctly, no broken links
- [x] no Rust / shell / Python sources touched — fmt, clippy, test, cross-compile, audit, deny, shellcheck, ruff all expected to pass on the same code as `main`
- [x] PR body free of AI-attribution footers per `CONTRIBUTING.md` "Commit hygiene"