### PR TITLE
docs: add milestone index links to README roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ The current product target is **GeniePod Home**:
 
 ## Roadmap
 
+### Milestones
+
+- [M1 — Stable Voice Loop on `genie-ai-runtime` v1](https://github.com/GeniePod/genie-claw/milestone/1) — *active*
+- [M2 — Native Telegram, Stable Memory, Clarified Agent Harness](https://github.com/GeniePod/genie-claw/milestone/2) — *planned*
+- [M3 — Smart Home Native: HA + `genie-home-runtime` + First Skill + Security Hardening](https://github.com/GeniePod/genie-claw/milestone/3) — *planned*
+- [M4 — Community Buildout: Discord, X, Reddit, GitHub → 500 stars](https://github.com/GeniePod/genie-claw/milestone/4) — *planned*
+- [M5 — Hardware, OS, and Mobile App: GeniePod Home V1 appliance shape](https://github.com/GeniePod/genie-claw/milestone/5) — *planned*
+- [M6 — Ship GeniePod Home V1 + `genie-hub` skill ecosystem + premium audio](https://github.com/GeniePod/genie-claw/milestone/6) — *planned*
+- [M7 — AI Model Optimization + Public Home Dataset + `genie-ai-model` Fine-Tuning](https://github.com/GeniePod/genie-claw/milestone/7) — *planned*
+- [M8 — Satellite Devices: Contactless Sleep Tracker + Multi-Room Satellite Speaker](https://github.com/GeniePod/genie-claw/milestone/8) — *planned*
+- [M9 — Product Line: GeniePod Home / Pro / Max + Tiered Stack Integration](https://github.com/GeniePod/genie-claw/milestone/9) — *planned*
+
 ### Milestone 1 — stable voice loop on `genie-ai-runtime` v1
 
 The first milestone is intentionally narrow: stabilize one end-to-end path


### PR DESCRIPTION
## Summary

Adds a one-line index of M1–M9 with links to the GitHub milestone pages,
placed at the top of the Roadmap section so readers see the full
zero-to-product-line arc before diving into the M1 detail block.

Each line: title + status (active / planned) + link to the milestone
page where the full scope description lives.

## Type of Change

- [x] Documentation

## Real Behavior Proof

Docs-only change (\`README.md\`, +12 / -0). No code paths touched, so
the behavior to verify is rendering, link validity, and CI matrix
unaffected.

**What I ran:**

- previewed the rendered Markdown on the GitHub PR diff view to confirm the new \`### Milestones\` subsection sits at the top of \`## Roadmap\`, before \`### Milestone 1 — ...\`
- confirmed all 9 milestone URLs resolve (\`/milestone/1\` through \`/milestone/9\`)
- confirmed the existing M1 detail block, \`## Quick Start\`, and downstream sections still flow unchanged

**What I observed:**

- [x] index renders cleanly, headings nest correctly, all 9 links resolve
- [x] no Rust / shell / Python sources touched — fmt, clippy, test, cross-compile, audit, deny, shellcheck, ruff expected to pass on the same code as \`main\`
- [x] PR body free of AI-attribution footers per \`CONTRIBUTING.md\` "Commit hygiene"