### PR TITLE
docs: restructure README — richer how-it-works, roadmap above the fold, drop alpha-deploy logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Voice in, voice out, controls Home Assistant, no cloud.**
 
 ## How it works
 
+A complete voice cycle never leaves the appliance. Audio is captured on
+the Jetson, routed through five on-device stages, and answered in audio.
+No audio, no transcripts, no model traffic crosses your network boundary.
+
 ```
    you speak                      you hear
        │                              ▲
@@ -44,11 +48,108 @@ Voice in, voice out, controls Home Assistant, no cloud.**
                           (rate-limited, audited)
 ```
 
+### Per-stage walkthrough
+
+1. **Wake + VAD** — wake-word detection plus voice-activity tail. The
+   rest of the pipeline stays cold until both fire.
+
+2. **STT (Whisper)** — local transcription on the Jetson. Transcripts
+   live in process memory only; nothing is written to disk by default.
+
+3. **Agent layer (GenieClaw, Rust)** — assembles the system prompt from
+   frozen identity blocks, hydrated household memory, and the tool
+   manifest. Routes to the local LLM. Dispatches tool calls through the
+   safety gate — per-origin ACL, rate limits, confirmation tokens for
+   high-risk actions. Every decision and dispatched call lands in an
+   append-only audit ledger.
+
+4. **Local LLM (`genie-ai-runtime`)** — default backend, a Jetson-tuned
+   C++ / CUDA inference runtime derived from `llama.cpp`. On the 8 GB
+   Orin Nano the system runs **Phi-4-mini Q4_K_M** with a 4096-token
+   context budget. The stock `llama.cpp` server remains selectable
+   per-deployment via `[services.llm].backend = "llama_cpp"`.
+
+5. **TTS (Piper)** — streamed sentence-by-sentence so the first audible
+   reply begins before the LLM finishes generating.
+
+**Side outputs:** SQLite-backed household memory (scope, sensitivity,
+spoken-policy filtering, durable promotion under `memory/MEMORY.md`),
+and Home Assistant integration behind a final actuation safety gate
+(rate limit + confirmation + audit).
+
+### What stays local — always
+
+- **audio capture** — never leaves the device
+- **transcripts** — in-memory only, no disk write
+- **LLM inference** — runs on the Jetson's GPU
+- **household memory** — SQLite, never synced
+- **Home Assistant traffic** — local network only
+- **audit ledger** — append-only, on-device
+
+The only network egress GenieClaw makes by default is the optional
+`web_search` tool, which calls DuckDuckGo Instant Answer (no API key,
+no account, no telemetry). Disable it via `[web_search] enabled = false`
+and the appliance is fully air-gappable.
+
 GenieClaw owns the **agent layer**: prompts, memory, tool routing, voice
 orchestration, channel adapters. It does **not** own the LLM kernels (see
 [`genie-ai-runtime`](https://github.com/GeniePod/genie-ai-runtime)) or the
 eventual device-control runtime (`genie-home-runtime`, planned). See
 [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full stack.
+
+## Roadmap
+
+### Milestones
+
+- [M1 — Stable Voice Loop on `genie-ai-runtime` v1](https://github.com/GeniePod/genie-claw/milestone/1) — *active*
+- [M2 — Native Telegram, Stable Memory, Clarified Agent Harness](https://github.com/GeniePod/genie-claw/milestone/2) — *planned*
+- [M3 — Smart Home Native: HA + `genie-home-runtime` + First Skill + Security Hardening](https://github.com/GeniePod/genie-claw/milestone/3) — *planned*
+- [M4 — Community Buildout: Discord, X, Reddit, GitHub → 500 stars](https://github.com/GeniePod/genie-claw/milestone/4) — *planned*
+- [M5 — Hardware, OS, and Mobile App: GeniePod Home V1 appliance shape](https://github.com/GeniePod/genie-claw/milestone/5) — *planned*
+- [M6 — Ship GeniePod Home V1 + `genie-hub` skill ecosystem + premium audio](https://github.com/GeniePod/genie-claw/milestone/6) — *planned*
+- [M7 — AI Model Optimization + Public Home Dataset + `genie-ai-model` Fine-Tuning](https://github.com/GeniePod/genie-claw/milestone/7) — *planned*
+- [M8 — Satellite Devices: Contactless Sleep Tracker + Multi-Room Satellite Speaker](https://github.com/GeniePod/genie-claw/milestone/8) — *planned*
+- [M9 — Product Line: GeniePod Home / Pro / Max + Tiered Stack Integration](https://github.com/GeniePod/genie-claw/milestone/9) — *planned*
+
+### Milestone 1 — stable voice loop on `genie-ai-runtime` v1
+
+The first milestone is intentionally narrow: stabilize one end-to-end path
+(voice in, voice out) on the current first release of `genie-ai-runtime`,
+and nothing else. Breadth comes after M1.
+
+In scope:
+
+- **system prompt path** — deterministic prompt assembly, reproducible across restarts, no silent prompt drift between runs
+- **`genie-ai-runtime` v1 integration reliability** — every chat/voice cycle reaches the runtime, every response parses cleanly, every failure mode surfaces in `/api/health` and `genie-ctl status`
+- **memory recall** — household context written to SQLite is retrievable and referenced in subsequent turns; recall failures are observable, not silent
+- **tool dispatch** — the tool-call gate routes correctly, applies per-origin ACLs, rate-limits, and audits; every dispatched tool either completes or fails loudly
+- **voice pipeline strength** — wake → VAD → STT → LLM → TTS round-trip under the alpha latency budget on Jetson Orin Nano Super 8 GB; no silent stalls, no torn audio, no stuck push-to-talk loops
+
+Out of scope for M1:
+
+- new channels beyond the existing voice + Telegram phase 2 bridges
+- new skills / skill marketplace work
+- Home Assistant feature expansion (current transitional adapter only)
+- `genie-home-runtime` split-out
+- hardware variants beyond Orin Nano Super 8 GB
+- web UI features off the M1 observability path
+
+PRs outside this scope are welcome but will be tagged `post-m1` and queued.
+
+**Contribution surface during M1**: bug reports and PRs are welcome in **both**
+[`GeniePod/genie-claw`](https://github.com/GeniePod/genie-claw) and
+[`GeniePod/genie-ai-runtime`](https://github.com/GeniePod/genie-ai-runtime). If
+a bug crosses the boundary, file it where the symptom appears; a maintainer
+will move or mirror it.
+
+M1 closes when, on a clean Jetson Orin Nano Super 8 GB:
+
+- [ ] 100 consecutive voice cycles pass with zero stalls and zero silent drops
+- [ ] system prompt SHA is identical across full-stack restart
+- [ ] memory recall test set (≥ 20 cases) passes ≥ 95%
+- [ ] tool dispatch ACL + rate-limit + audit log proven by integration test
+- [ ] `genie-ai-runtime` v1 backend stable for 24h continuous run
+- [ ] CI green on: fmt, clippy, test, aarch64 cross-compile, audit, deny, shellcheck, ruff, AI-attribution check, proof-checklist
 
 ---
 
@@ -214,60 +315,6 @@ The current product target is **GeniePod Home**:
 - built around privacy, security, and bounded extensions
 - designed to feel stable, understandable, and privacy-respecting
 
-## Roadmap
-
-### Milestones
-
-- [M1 — Stable Voice Loop on `genie-ai-runtime` v1](https://github.com/GeniePod/genie-claw/milestone/1) — *active*
-- [M2 — Native Telegram, Stable Memory, Clarified Agent Harness](https://github.com/GeniePod/genie-claw/milestone/2) — *planned*
-- [M3 — Smart Home Native: HA + `genie-home-runtime` + First Skill + Security Hardening](https://github.com/GeniePod/genie-claw/milestone/3) — *planned*
-- [M4 — Community Buildout: Discord, X, Reddit, GitHub → 500 stars](https://github.com/GeniePod/genie-claw/milestone/4) — *planned*
-- [M5 — Hardware, OS, and Mobile App: GeniePod Home V1 appliance shape](https://github.com/GeniePod/genie-claw/milestone/5) — *planned*
-- [M6 — Ship GeniePod Home V1 + `genie-hub` skill ecosystem + premium audio](https://github.com/GeniePod/genie-claw/milestone/6) — *planned*
-- [M7 — AI Model Optimization + Public Home Dataset + `genie-ai-model` Fine-Tuning](https://github.com/GeniePod/genie-claw/milestone/7) — *planned*
-- [M8 — Satellite Devices: Contactless Sleep Tracker + Multi-Room Satellite Speaker](https://github.com/GeniePod/genie-claw/milestone/8) — *planned*
-- [M9 — Product Line: GeniePod Home / Pro / Max + Tiered Stack Integration](https://github.com/GeniePod/genie-claw/milestone/9) — *planned*
-
-### Milestone 1 — stable voice loop on `genie-ai-runtime` v1
-
-The first milestone is intentionally narrow: stabilize one end-to-end path
-(voice in, voice out) on the current first release of `genie-ai-runtime`,
-and nothing else. Breadth comes after M1.
-
-In scope:
-
-- **system prompt path** — deterministic prompt assembly, reproducible across restarts, no silent prompt drift between runs
-- **`genie-ai-runtime` v1 integration reliability** — every chat/voice cycle reaches the runtime, every response parses cleanly, every failure mode surfaces in `/api/health` and `genie-ctl status`
-- **memory recall** — household context written to SQLite is retrievable and referenced in subsequent turns; recall failures are observable, not silent
-- **tool dispatch** — the tool-call gate routes correctly, applies per-origin ACLs, rate-limits, and audits; every dispatched tool either completes or fails loudly
-- **voice pipeline strength** — wake → VAD → STT → LLM → TTS round-trip under the alpha latency budget on Jetson Orin Nano Super 8 GB; no silent stalls, no torn audio, no stuck push-to-talk loops
-
-Out of scope for M1:
-
-- new channels beyond the existing voice + Telegram phase 2 bridges
-- new skills / skill marketplace work
-- Home Assistant feature expansion (current transitional adapter only)
-- `genie-home-runtime` split-out
-- hardware variants beyond Orin Nano Super 8 GB
-- web UI features off the M1 observability path
-
-PRs outside this scope are welcome but will be tagged `post-m1` and queued.
-
-**Contribution surface during M1**: bug reports and PRs are welcome in **both**
-[`GeniePod/genie-claw`](https://github.com/GeniePod/genie-claw) and
-[`GeniePod/genie-ai-runtime`](https://github.com/GeniePod/genie-ai-runtime). If
-a bug crosses the boundary, file it where the symptom appears; a maintainer
-will move or mirror it.
-
-M1 closes when, on a clean Jetson Orin Nano Super 8 GB:
-
-- [ ] 100 consecutive voice cycles pass with zero stalls and zero silent drops
-- [ ] system prompt SHA is identical across full-stack restart
-- [ ] memory recall test set (≥ 20 cases) passes ≥ 95%
-- [ ] tool dispatch ACL + rate-limit + audit log proven by integration test
-- [ ] `genie-ai-runtime` v1 backend stable for 24h continuous run
-- [ ] CI green on: fmt, clippy, test, aarch64 cross-compile, audit, deny, shellcheck, ruff, AI-attribution check, proof-checklist
-
 ## Quick Start
 
 If you just want to run the software locally:
@@ -408,174 +455,6 @@ The current memory system is built for a shared-room appliance:
 - promoted durable memory is also projected into a local namespace tree under `memory/namespaces/`
 - `memory/INDEX.md` acts as the generated entry point for the durable memory tree
 - person/private/restricted durable namespace notes are kept structured, but non-shared-safe entries are redacted in the markdown projection by default
-
-## Alpha.5 Verified Deploy (2026-05-11)
-
-End-to-end deploy from an x86_64 build VM (`tiny@tiny-virtual-machine`) to a
-Jetson Orin Nano (`aihpc@192.168.55.1`) confirms the alpha.5 workflow: the
-build host only cross-compiles and SCPs; the target receives binaries,
-canonical config, systemd units, and helper scripts in one `make deploy`,
-then `setup-jetson.sh` audits every prereq before enabling services.
-
-### From the build host (cross-compile + deploy via SSH)
-
-```
-tiny@tiny-virtual-machine:~/genie-claw$ make deploy JETSON_HOST=192.168.55.1 JETSON_USER=aihpc
-
-CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
-AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar \
-cargo build --release --target aarch64-unknown-linux-gnu -p genie-core
-    Finished `release` profile [optimized] target(s) in 0.32s
-cargo build --release --target aarch64-unknown-linux-gnu -p genie-ctl -p genie-governor -p genie-health -p genie-api
-    Finished `release` profile [optimized] target(s) in 0.28s
-
-Jetson binaries:
--rwxrwxr-x  2.2M  target/aarch64-unknown-linux-gnu/release/genie-api
--rwxrwxr-x  4.3M  target/aarch64-unknown-linux-gnu/release/genie-core
--rwxrwxr-x  917K  target/aarch64-unknown-linux-gnu/release/genie-ctl
--rwxrwxr-x  2.3M  target/aarch64-unknown-linux-gnu/release/genie-governor
--rwxrwxr-x  2.2M  target/aarch64-unknown-linux-gnu/release/genie-health
-
-# deploy-binaries: scp + sudo mv for each of the 5 aarch64 binaries
-genie-core      100% 4317KB   7.0MB/s   00:00
-genie-ctl       100%  917KB   6.5MB/s   00:00
-genie-governor  100% 2282KB   9.2MB/s   00:00
-genie-health    100% 2157KB  10.5MB/s   00:00
-genie-api       100% 2249KB  10.3MB/s   00:00
-
-# deploy-config: force-overwrite — repo is the single source of truth
-Config deployed — /etc/geniepod/geniepod.toml refreshed from repo.
-WARNING: any hand-edits on the target were overwritten. Keep secrets in env vars
-         (HA_TOKEN, TELEGRAM_BOT_TOKEN, etc.), not in geniepod.toml directly.
-
-# deploy-systemd: 11 units (9 .service + 2 .target)
-# deploy-docker:  compose.yml -> /opt/geniepod/docker/
-# deploy-setup:   5 helper scripts + setup-jetson.sh -> /opt/geniepod/bin/
-
-=== Deployed to aihpc@192.168.55.1 ===
-  Binaries: /opt/geniepod/bin/
-  Config:   /etc/geniepod/
-  Systemd:  /etc/systemd/system/
-
-Run first-time setup on the Jetson:
-  ssh aihpc@192.168.55.1 'bash /opt/geniepod/setup-jetson.sh'
-```
-
-### On the Jetson (first-time setup audit)
-
-```
-aihpc@ubuntu:/opt/geniepod$ bash /opt/geniepod/setup-jetson.sh
-=== GeniePod Jetson Setup ===
-
-[1/6] Creating directories...
-[2/6] Checking binaries...
-  OK: genie-core (4.3M)
-  OK: genie-governor (2.3M)
-  OK: genie-health (2.2M)
-  OK: genie-api (2.2M)
-  OK: genie-ctl (920K)
-  OK: genie-audio-init (4.0K)
-[3/6] Checking config...
-  OK: /etc/geniepod/geniepod.toml
-  Secured config permissions
-[4/6] Checking LLM model...
-  OK: phi-4-mini-instruct-q4_k_m.gguf (2.4G)
-[5/6] Checking llama.cpp...
-  OK: llama-server
-  OK: docker compose
-[5b/6] Setting Jetson performance mode...
-  Set nvpmodel to mode 1 (25W / max speed)
-  Clocks locked to max
-[5c/6] Applying memory optimizations...
-  sysctl already configured
-[5e/6] Checking voice runtime prerequisites...
-  OK: whisper-cli (928K) at /opt/geniepod/bin/whisper-cli
-  OK: ggml-small.bin (466M)
-  OK: piper (5.1M) at /opt/geniepod/piper/piper
-  OK: en_US-amy-medium.onnx (61M)
-[6/6] Enabling systemd services...
-  Enabled: geniepod.target
-  Enabled: homeassistant
-  Enabled: genie-audio
-  Enabled: genie-llm
-  Enabled: genie-core
-  Enabled: genie-governor
-  Enabled: genie-health
-  Enabled: genie-api
-  Enabled: genie-mqtt
-[genie-audio-init] WARN: card APE has no I2S2 controls — overlay not applied? skipping route setup.
-
-=== Setup complete ===
-```
-
-The final `[genie-audio-init] WARN` is benign in this snapshot — the Jetson's
-40-pin I2S2 overlay was not active at this run; on hosts where the overlay is
-applied via `sudo /opt/nvidia/jetson-io/jetson-io.py`, the same script
-reports each of the 10 amixer `cset` lines and exits with status 0. See
-[`doc/lyrat-jetson-audio.md`](doc/lyrat-jetson-audio.md) for the full LyraT
-audio frontend setup.
-
-## Alpha.7 Verified Voice Cycle (2026-05-13)
-
-After the alpha.7 PRs landed —
-[#13](https://github.com/GeniePod/genie-claw/pull/13) (DeepFilterNet capture
-denoise), [#16](https://github.com/GeniePod/genie-claw/pull/16) (half-duplex
-post-TTS gate), [#18](https://github.com/GeniePod/genie-claw/pull/18)
-(`genie-whisper-warmup.service`), and
-[#20](https://github.com/GeniePod/genie-claw/pull/20) (first-reply latency
-banner) — a fresh push-to-talk run on the same Jetson Orin Nano + LyraT V4.3
-hardware reports the following first-cycle behavior:
-
-```
-aihpc@ubuntu:~$ sudo -E /opt/geniepod/bin/genie-core
-[voice] Capture device: plughw:APE,0  |  Playback device: plughw:0,0
-INFO STT using long-running whisper-server (model stays loaded in GPU) port=8178 model=/opt/geniepod/models/ggml-small.bin
-[voice] LLM server connected
-
-=== GeniePod Voice Mode (Push-to-Talk) ===
-Press Enter to speak (3 sec), 'quit' to exit.
-
-[voice] Press Enter to speak >
-[voice] Recording 3 seconds — speak now!
-INFO recording complete path=/tmp/geniepod-rec-23998.wav size_bytes=288044
-INFO preprocessed audio with DeepFilterNet chain (bandpass, deep-filter denoise, peak-normalize -3 dBFS) dfn_ms=808 atten_lim_db=100.0
-[voice] Transcribing...
-[voice] You said: "Hello, this is Christine." (STT: 285 ms)
-[voice] Thinking...
-[voice] Tool: memory_recall → Your name is Jared
-[voice] Speaking...
-INFO Piper generated audio, playing... pcm_bytes=216808
-[voice] GeniePod: Understood, Christine is Jared. How can I assist you further? (LLM+TTS: 1018 ms)
-
-=== first voice reply latency ===
-  speech end -> STT done:      285 ms
-  STT done   -> first audio:   3679 ms
-  total (first reply):         3964 ms
-=================================
-
-[voice] Total cycle: 15395 ms
-```
-
-What this confirms:
-
-- **DFN denoise** runs in ~808 ms per 3 s capture (`dfn_ms=808`); whisper
-  receives clean audio.
-- **Half-duplex gate** keeps Piper's previous response out of the next
-  capture — STT correctly transcribes "Hello, this is Christine." instead
-  of bleeding the assistant's voice.
-- **Whisper warmup** has the model resident in iGPU: STT 285 ms warm,
-  vs the 60-90 s cold path before #18.
-- **Memory recall** tool fires and surfaces "Your name is Jared" from
-  the durable namespace tree.
-- **First-reply banner** prints a one-shot 3-line summary on the first
-  successful cycle, then stops. (Latest `main` further decomposes the
-  `STT done -> first audio` line into LLM-until-first-sentence and
-  TTS-first-synth phases for diagnostic clarity — see
-  [#20](https://github.com/GeniePod/genie-claw/pull/20).)
-
-Total first-reply latency of **~4 seconds** from end-of-user-speech to
-first audible TTS audio, on a 7.6 GB Orin Nano running Phi-4-mini Q4_K_M
-LLM + whisper-small + Piper en_US-amy concurrently.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Three structural changes to README so first-time readers see the
appliance shape, the privacy posture, and the M1-M9 product arc inside
the first ~2 screens.

### 1. \"How it works\" gets a richer walkthrough

The ASCII diagram is unchanged. Added underneath it:

- **Per-stage walkthrough** — what wake/VAD, STT (Whisper), the Rust
  agent layer, the local LLM (\`genie-ai-runtime\`), and TTS (Piper)
  each actually do
- **\"What stays local — always\"** — concrete list of every artifact
  that never crosses the network boundary
- **Default-egress callout** — the optional \`web_search\` tool calls
  DuckDuckGo Instant Answer; disable it and the appliance is fully
  air-gappable

These details were previously only visible in the Alpha.7 verified
voice cycle notes near the bottom. Promoting them to How-it-works
serves first-time readers without making them scroll.

### 2. Roadmap moves up

\"## Roadmap\" (M1-M9 milestone index + M1 detail block) was at line 217
behind 8 other sections. It now sits immediately after \"How it works\",
visible inside the first scroll on most viewports.

The position swap is structural — no content edits to the milestone
index or M1 detail block. The 9 milestone links from PR #114 still
resolve.

### 3. Alpha-deploy verification logs removed

Deleted:
- \`## Alpha.5 Verified Deploy (2026-05-11)\` — the full \`make deploy\`
  + \`setup-jetson.sh\` audit transcript
- \`## Alpha.7 Verified Voice Cycle (2026-05-13)\` — the push-to-talk
  trace with latency numbers

Both are release-specific verification logs. \`CHANGELOG.md\` is the
right home for them; the top-level README should describe what the
product *is*, not how a specific past release was verified. The Phi-4-mini
Q4_K_M / 4096-token / first-reply-latency facts that mattered for
readers are now folded into the enhanced How-it-works section.

## Type of Change

- [x] Documentation

## Real Behavior Proof

Docs-only restructure (\`README.md\`, +101 / -222). No code paths
touched, so the behavior to verify is structure, link validity, and
CI matrix unaffected.

**What I ran:**

- previewed the rendered Markdown on the GitHub PR diff view to confirm: enhanced How-it-works renders cleanly, the moved Roadmap section sits immediately after it, all 9 milestone links still resolve, and \"## Why It Exists\" through \"## License\" flow unchanged with the alpha-deploy sections removed
- confirmed the table of \"## \" headings in the new README contains: How it works, Roadmap, Why It Exists, What It Is, Ecosystem Position, What It Does, What It Is Not, How It Fits Together, Why Minimal-First On Jetson, Repo Layout, Product Direction, Quick Start, Documentation, Deployment, Design Principles, Current Focus, Memory Safety Notes, Contributing, Security, License — no Alpha.* sections remain
- confirmed line count dropped from 632 to 471 (-161 net) — consistent with -222 deletions + 101 insertions = -121 plus ~40 lines that moved within the file

**What I observed:**

- [x] structure verified — Roadmap is the second section, above the first scroll on standard viewports
- [x] no broken links — all 9 milestone URLs + internal anchors verified by inspection
- [x] no Rust / shell / Python sources touched — fmt, clippy, test, cross-compile, audit, deny, shellcheck, ruff expected to pass on the same code as \`main\`
- [x] PR body free of AI-attribution footers per \`CONTRIBUTING.md\` \"Commit hygiene\"