### PR TITLE
docs: add gittensor community acknowledgement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,3 +469,7 @@ Found a vulnerability? **Do not open a public issue.** Email <contact@genieclaw.
 GNU Affero General Public License v3.0
 
 See [LICENSE](LICENSE).
+
+## Acknowledgements
+
+Together we advance. Thanks to the [gittensor community](https://gittensor.io/repositories) for supporting this project.


### PR DESCRIPTION
## Summary

Adds a brief \"Acknowledgements\" section at the bottom of the README
crediting the gittensor community for supporting the project.

\`\`\`markdown
## Acknowledgements

Together we advance. Thanks to the [gittensor community](https://gittensor.io/repositories) for supporting this project.
\`\`\`

Placed below \`## License\` so it lives alongside the other meta sections
(Contributing / Security / License) without competing with product
content above the fold.

## Type of Change

- [x] Documentation

## Real Behavior Proof

Docs-only change (\`README.md\`, +4 / -0). No code paths touched.

**What I ran:**

- previewed the rendered Markdown on the GitHub PR diff view to confirm the new \`## Acknowledgements\` section renders at the bottom of the README with the gittensor link resolving to <https://gittensor.io/repositories>
- confirmed the existing License section above is unchanged

**What I observed:**

- [x] section renders cleanly, link target is the gittensor repositories page
- [x] no Rust / shell / Python sources touched — fmt, clippy, test, cross-compile, audit, deny, shellcheck, ruff expected to pass on the same code as \`main\`
- [x] PR body free of AI-attribution footers per \`CONTRIBUTING.md\` \"Commit hygiene\"