### PR TITLE
fix(config): derive core health URL from [core].port

### DIFF
--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -225,7 +225,10 @@ fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
         ServiceTarget {
             service: "core".into(),
             unit: config.services.core.systemd_unit.clone(),
-            latency_url: Some(config.services.core.url.clone()),
+            // Derive from `[core].port` / `[core].bind_host` so the dashboard
+            // Services row stays aligned with where core actually listens,
+            // even when `[services.core].url` is stale. See issue #121.
+            latency_url: Some(config.core_health_url()),
             disabled_reason: None,
         },
         ServiceTarget {
@@ -948,6 +951,27 @@ mod tests {
         ] {
             assert!(names.contains(&expected), "missing {expected}");
         }
+    }
+
+    #[test]
+    fn dashboard_core_target_uses_derived_health_url() {
+        // Regression for #121: when [core].port is overridden without also
+        // updating [services.core].url, the dashboard Services row for core
+        // must probe the derived URL so it does not show false DOWN.
+        let mut config = test_config();
+        config.core.port = 3001;
+        config.services.core.url = "http://127.0.0.1:3000/api/health".into();
+
+        let targets = dashboard_service_targets(&config);
+        let core_target = targets
+            .iter()
+            .find(|target| target.service == "core")
+            .expect("core target should always be present");
+
+        assert_eq!(
+            core_target.latency_url.as_deref(),
+            Some("http://127.0.0.1:3001/api/health"),
+        );
     }
 
     #[test]

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -657,6 +657,18 @@ impl Config {
         format!("{host}:{}", self.core.port)
     }
 
+    /// Health-probe URL for genie-core, always derived from `[core].port` and
+    /// `[core].bind_host` rather than `[services.core].url`.
+    ///
+    /// Local probes (genie-health, the dashboard Services row) must agree with
+    /// where core actually listens. Sourcing from `[services.core].url` lets
+    /// the two drift when an operator overrides `[core].port` without also
+    /// updating the services URL, producing false DOWN signals while the
+    /// service is healthy on the configured port.
+    pub fn core_health_url(&self) -> String {
+        format!("http://{}/api/health", self.core_http_addr())
+    }
+
     /// Resolve the configured Home Assistant endpoint, if this deployment uses one.
     pub fn homeassistant_service(&self) -> Option<&ServiceEndpoint> {
         self.services.homeassistant.as_ref()
@@ -969,6 +981,47 @@ mod tests {
         config.core.port = 3000;
         config.core.bind_host = "0.0.0.0".into();
         assert_eq!(config.core_http_addr(), "127.0.0.1:3000");
+    }
+
+    #[test]
+    fn core_health_url_uses_default_port() {
+        let config = test_config();
+        assert_eq!(config.core_health_url(), "http://127.0.0.1:3000/api/health");
+    }
+
+    #[test]
+    fn core_health_url_tracks_custom_core_port() {
+        // Regression: operator changes only [core].port without touching
+        // [services.core].url — the derived URL must follow the new port so
+        // health probes don't hit the stale default.
+        let mut config = test_config();
+        config.core.port = 3001;
+        assert_eq!(config.core_health_url(), "http://127.0.0.1:3001/api/health");
+    }
+
+    #[test]
+    fn core_health_url_maps_listen_all_to_loopback() {
+        let mut config = test_config();
+        config.core.bind_host = "0.0.0.0".into();
+        assert_eq!(config.core_health_url(), "http://127.0.0.1:3000/api/health");
+    }
+
+    #[test]
+    fn core_health_url_honors_custom_bind_host() {
+        let mut config = test_config();
+        config.core.bind_host = "10.0.0.5".into();
+        config.core.port = 4000;
+        assert_eq!(config.core_health_url(), "http://10.0.0.5:4000/api/health");
+    }
+
+    #[test]
+    fn core_health_url_ignores_stale_services_core_url() {
+        // Even if [services.core].url is left at the default :3000, switching
+        // [core].port must take precedence in the derived URL.
+        let mut config = test_config();
+        config.core.port = 3001;
+        config.services.core.url = "http://127.0.0.1:3000/api/health".into();
+        assert_eq!(config.core_health_url(), "http://127.0.0.1:3001/api/health");
     }
 
     #[test]

--- a/crates/genie-health/src/checker.rs
+++ b/crates/genie-health/src/checker.rs
@@ -24,6 +24,36 @@ pub struct HealthMonitor {
     failure_counts: std::collections::HashMap<String, u32>,
 }
 
+/// Materialize `(name, probe_url)` pairs for every service the health monitor
+/// owns. Core's URL is derived from `[core].port` / `[core].bind_host` via
+/// `Config::core_health_url()` so the probe always tracks where core actually
+/// listens, even when `[services.core].url` is left at the default after an
+/// operator changes the listen port.
+///
+/// Kept as a free function (rather than a `&self` method) so unit tests can
+/// exercise it without constructing a `HealthMonitor`, which would open the
+/// SQLite log DB at `config.data_dir` and contend with parallel tests on the
+/// same path.
+fn collect_endpoints(config: &Config) -> Vec<(String, String)> {
+    let mut endpoints = vec![
+        ("core".into(), config.core_health_url()),
+        ("llm".into(), config.services.llm.url.clone()),
+    ];
+
+    if let Some(ref ha) = config.services.homeassistant {
+        endpoints.push(("homeassistant".into(), ha.url.clone()));
+    }
+
+    if let Some(ref nc) = config.services.nextcloud {
+        endpoints.push(("nextcloud".into(), nc.url.clone()));
+    }
+    if let Some(ref jf) = config.services.jellyfin {
+        endpoints.push(("jellyfin".into(), jf.url.clone()));
+    }
+
+    endpoints
+}
+
 impl HealthMonitor {
     pub fn new(config: Config) -> Result<Self> {
         let db_path = config.data_dir.join("health.db");
@@ -85,7 +115,7 @@ impl HealthMonitor {
         // Owned `(name, url)` pairs so the alert / DB writes below don't
         // borrow `self`. `collect_endpoints` already resolves the core URL
         // from `[core].port` so this loop can stay generic.
-        let services = self.collect_endpoints();
+        let services = collect_endpoints(&self.config);
 
         for (name, url) in &services {
             let status = check_http(name, url).await;
@@ -129,31 +159,6 @@ impl HealthMonitor {
         let _ = self
             .db
             .execute("DELETE FROM health_log WHERE ts_ms < ?1", [cutoff]);
-    }
-
-    /// Materialize `(name, probe_url)` pairs for every service this monitor
-    /// owns. Core's URL is derived from `[core].port` / `[core].bind_host` via
-    /// `Config::core_health_url()` so the probe always tracks where core
-    /// actually listens, even when `[services.core].url` is left at the
-    /// default after an operator changes the listen port.
-    fn collect_endpoints(&self) -> Vec<(String, String)> {
-        let mut endpoints = vec![
-            ("core".into(), self.config.core_health_url()),
-            ("llm".into(), self.config.services.llm.url.clone()),
-        ];
-
-        if let Some(ref ha) = self.config.services.homeassistant {
-            endpoints.push(("homeassistant".into(), ha.url.clone()));
-        }
-
-        if let Some(ref nc) = self.config.services.nextcloud {
-            endpoints.push(("nextcloud".into(), nc.url.clone()));
-        }
-        if let Some(ref jf) = self.config.services.jellyfin {
-            endpoints.push(("jellyfin".into(), jf.url.clone()));
-        }
-
-        endpoints
     }
 
     async fn send_alert(&self, status: &ServiceStatus) {
@@ -331,8 +336,11 @@ mod tests {
 
     #[test]
     fn collect_endpoints_skips_unconfigured_homeassistant() {
-        let monitor = HealthMonitor::new(test_config()).unwrap();
-        let endpoints = monitor.collect_endpoints();
+        // Call the free function directly so the test does not construct a
+        // HealthMonitor — that would open the SQLite log DB at
+        // `config.data_dir` and contend with other tests under the parallel
+        // cargo test runner on the same path.
+        let endpoints = collect_endpoints(&test_config());
         let names: Vec<&str> = endpoints.iter().map(|(name, _)| name.as_str()).collect();
 
         assert!(names.contains(&"core"));
@@ -348,8 +356,7 @@ mod tests {
         config.core.port = 3001;
         config.services.core.url = "http://127.0.0.1:3000/api/health".into();
 
-        let monitor = HealthMonitor::new(config).unwrap();
-        let endpoints = monitor.collect_endpoints();
+        let endpoints = collect_endpoints(&config);
         let core_url = endpoints
             .iter()
             .find(|(name, _)| name == "core")
@@ -367,8 +374,7 @@ mod tests {
         let mut config = test_config();
         config.services.llm.url = "http://127.0.0.1:9999/v1/health".into();
 
-        let monitor = HealthMonitor::new(config).unwrap();
-        let endpoints = monitor.collect_endpoints();
+        let endpoints = collect_endpoints(&config);
         let llm_url = endpoints
             .iter()
             .find(|(name, _)| name == "llm")

--- a/crates/genie-health/src/checker.rs
+++ b/crates/genie-health/src/checker.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use genie_common::config::{Config, ServiceEndpoint};
+use genie_common::config::Config;
 use rusqlite::Connection;
 use tokio::net::TcpStream;
 use tokio::signal::unix::{SignalKind, signal};
@@ -82,12 +82,10 @@ impl HealthMonitor {
     async fn check_all(&mut self) {
         let ts_ms = now_ms();
 
-        // Collect endpoints as owned data to avoid borrowing self in the loop.
-        let services: Vec<(String, String)> = self
-            .collect_endpoints()
-            .into_iter()
-            .map(|(name, ep)| (name, ep.url.clone()))
-            .collect();
+        // Owned `(name, url)` pairs so the alert / DB writes below don't
+        // borrow `self`. `collect_endpoints` already resolves the core URL
+        // from `[core].port` so this loop can stay generic.
+        let services = self.collect_endpoints();
 
         for (name, url) in &services {
             let status = check_http(name, url).await;
@@ -133,21 +131,26 @@ impl HealthMonitor {
             .execute("DELETE FROM health_log WHERE ts_ms < ?1", [cutoff]);
     }
 
-    fn collect_endpoints(&self) -> Vec<(String, &ServiceEndpoint)> {
+    /// Materialize `(name, probe_url)` pairs for every service this monitor
+    /// owns. Core's URL is derived from `[core].port` / `[core].bind_host` via
+    /// `Config::core_health_url()` so the probe always tracks where core
+    /// actually listens, even when `[services.core].url` is left at the
+    /// default after an operator changes the listen port.
+    fn collect_endpoints(&self) -> Vec<(String, String)> {
         let mut endpoints = vec![
-            ("core".into(), &self.config.services.core),
-            ("llm".into(), &self.config.services.llm),
+            ("core".into(), self.config.core_health_url()),
+            ("llm".into(), self.config.services.llm.url.clone()),
         ];
 
         if let Some(ref ha) = self.config.services.homeassistant {
-            endpoints.push(("homeassistant".into(), ha));
+            endpoints.push(("homeassistant".into(), ha.url.clone()));
         }
 
         if let Some(ref nc) = self.config.services.nextcloud {
-            endpoints.push(("nextcloud".into(), nc));
+            endpoints.push(("nextcloud".into(), nc.url.clone()));
         }
         if let Some(ref jf) = self.config.services.jellyfin {
-            endpoints.push(("jellyfin".into(), jf));
+            endpoints.push(("jellyfin".into(), jf.url.clone()));
         }
 
         endpoints
@@ -335,5 +338,43 @@ mod tests {
         assert!(names.contains(&"core"));
         assert!(names.contains(&"llm"));
         assert!(!names.contains(&"homeassistant"));
+    }
+
+    #[test]
+    fn core_endpoint_url_tracks_configured_core_port() {
+        // Regression for #121: operator changes only [core].port; the core
+        // probe URL must follow it, not the stale [services.core].url default.
+        let mut config = test_config();
+        config.core.port = 3001;
+        config.services.core.url = "http://127.0.0.1:3000/api/health".into();
+
+        let monitor = HealthMonitor::new(config).unwrap();
+        let endpoints = monitor.collect_endpoints();
+        let core_url = endpoints
+            .iter()
+            .find(|(name, _)| name == "core")
+            .map(|(_, url)| url.as_str())
+            .expect("core endpoint should always be present");
+
+        assert_eq!(core_url, "http://127.0.0.1:3001/api/health");
+    }
+
+    #[test]
+    fn llm_endpoint_url_still_sources_from_services_config() {
+        // Sibling check: only `core` derives from `[core]`. The LLM probe
+        // must keep reading `[services.llm].url` so its existing override
+        // semantics are preserved.
+        let mut config = test_config();
+        config.services.llm.url = "http://127.0.0.1:9999/v1/health".into();
+
+        let monitor = HealthMonitor::new(config).unwrap();
+        let endpoints = monitor.collect_endpoints();
+        let llm_url = endpoints
+            .iter()
+            .find(|(name, _)| name == "llm")
+            .map(|(_, url)| url.as_str())
+            .expect("llm endpoint should always be present");
+
+        assert_eq!(llm_url, "http://127.0.0.1:9999/v1/health");
     }
 }


### PR DESCRIPTION
## Summary

`genie-health` and the `genie-api` dashboard Services row sourced the core probe URL from `[services.core].url`, while `genie-ctl` and the `genie-api` TCP proxy (post-#90 / PR #102) derive it from `[core].port` via `Config::core_http_addr()`. When an operator changes only `[core].port` and leaves `[services.core].url` at its default, the probes hit the wrong port and report core as DOWN even though it is healthy on the configured port.

Fixes #121.

## Changes

- Add `Config::core_health_url()` in `genie-common` — single source of truth for the local core health URL, derived from `[core].port` and `[core].bind_host`.
- `genie-health::collect_endpoints()` now returns resolved `(name, url)` pairs and uses `core_health_url()` for the `core` entry. LLM and the optional services keep sourcing from `[services.<svc>].url` so their existing override semantics are unchanged.
- `genie-api::dashboard_service_targets()` core entry uses `core_health_url()` for `latency_url`.
- Unit tests in all three crates cover the regression: `[core].port = 3001` with a stale default `[services.core].url` on `:3000` must derive `:3001`.

Behavior is unchanged when the default config is used (`port = 3000`, default URL).

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

Windows dev box, no Jetson available, no cross-compile toolchain installed:

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p genie-common --all-targets -- -D warnings` — clean
- `cargo test -p genie-common` — **38 passed, 0 failed** (5 new tests covering `core_health_url()`: default port, custom port, custom `bind_host`, listen-all → loopback mapping, and the stale `[services.core].url` override case).

`genie-health` and `genie-api` use Unix-only deps (`std::os::unix`, tokio signal handlers) and cannot compile on Windows — pre-existing constraint, not introduced by this PR. New regression tests added in each (`core_endpoint_url_tracks_configured_core_port` in `genie-health`; `dashboard_core_target_uses_derived_health_url` in `genie-api`) will exercise on the Linux CI job.

### What I observed

`cargo test -p genie-common` excerpt:

```
running 38 tests
test config::tests::core_health_url_uses_default_port ... ok
test config::tests::core_health_url_tracks_custom_core_port ... ok
test config::tests::core_health_url_maps_listen_all_to_loopback ... ok
test config::tests::core_health_url_honors_custom_bind_host ... ok
test config::tests::core_health_url_ignores_stale_services_core_url ... ok
...
test result: ok. 38 passed; 0 failed
```

Reviewer with Jetson access: please apply the repro from the issue body (`[core] port = 3001`, leave `[services.core].url` at the `:3000` default) and confirm `genie-health` logs and the dashboard Services row both report core healthy on the new port.

## Test plan

1. Apply the issue's repro config: override `[core] port = 3001`, leave default `[services.core].url`.
2. Start the stack with `GENIEPOD_CONFIG=...` for genie-core, genie-health, genie-api.
3. `genie-ctl health` and `genie-health` logs should agree — core healthy on `:3001`.
4. Open the dashboard Services panel — core row should be healthy.
5. Restore default config (`port = 3000`, default URL) and confirm no regression.

## Notes for reviewers

- `[services.core].url` is intentionally left in the config schema for backward compatibility. The issue body suggested logging a divergence warning at `Config::load()`; deferred from this PR to keep scope tight on the bug fix — happy to follow up if you'd like it.
- LLM and the optional services (Home Assistant, Nextcloud, Jellyfin) still read from `[services.<svc>].url` — only `core` is special-cased because only `core` has a dedicated `[core]` config block as the listen-side source of truth.
