### PR TITLE
chore: add GitHub issue templates with Jetson-aware fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug report
+description: Something is broken or behaves incorrectly. Please include Jetson context — it almost always matters.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. GenieClaw is Jetson-first, so
+        hardware and JetPack context are usually load-bearing.
+
+        If this is specifically a **voice-pipeline** or **audio-chain** bug,
+        please use those dedicated templates instead — their structured fields
+        capture the right context up-front.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence — what is broken?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Concrete steps. Commands, config, what you did.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: dropdown
+    id: hardware
+    attributes:
+      label: Hardware
+      options:
+        - Jetson Orin Nano Super 8 GB
+        - Jetson Orin Nano 8 GB (non-Super)
+        - Jetson Orin NX 16 GB
+        - Jetson AGX Orin
+        - Other Jetson (specify in additional context)
+        - Non-Jetson (x86_64 dev / cross-build host)
+    validations:
+      required: true
+
+  - type: input
+    id: jetpack
+    attributes:
+      label: JetPack / L4T version
+      placeholder: "e.g. JetPack 6.1 / L4T R36.4"
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: GenieClaw version / commit
+      placeholder: "v1.0.0-alpha.9 or commit SHA"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Output from `journalctl -u genie-core`, `genie-ctl status`, or
+        `/api/health` if relevant. Trim long logs — leave the failure window.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# Disable blank issues so every report uses one of the templates.
+# Reserved channels stay reachable via contact_links.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Security disclosure (private)
+    url: https://github.com/GeniePod/genie-claw/security/policy
+    about: >-
+      For vulnerabilities, do not open a public issue — email
+      contact@genieclaw.org. See SECURITY.md for the response timeline.
+
+  - name: Question or help
+    url: https://github.com/GeniePod/genie-claw/discussions
+    about: >-
+      Setup help, deployment questions, and general discussion belong in
+      GitHub Discussions, not the issue tracker.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,73 @@
+name: Feature request
+description: New behavior, new tool, new channel, or scope change.
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        GenieClaw is intentionally narrow on Jetson — see
+        *Why Minimal-First On Jetson* in the README. Feature requests are
+        welcome but please frame them against the current milestone scope.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The user-visible problem or limitation you've hit. Not the proposed solution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed feature
+      description: One paragraph. What would the new behavior look like from the outside?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing tools, workarounds, or other ways to solve the same problem.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Which milestone is this aimed at?
+      description: See the [Roadmap](../blob/main/README.md#roadmap).
+      options:
+        - M1 — Stable Voice Loop on genie-ai-runtime v1
+        - M2 — Native Telegram, Stable Memory, Clarified Agent Harness
+        - M3 — Smart Home Native (HA + genie-home-runtime + first skill + security)
+        - M4 — Community Buildout (Discord / X / Reddit / GitHub)
+        - M5 — Hardware / OS / Mobile App bring-up
+        - M6 — Ship V1 + genie-hub + premium audio
+        - M7 — Model optimization + public dataset + home LoRA
+        - M8 — Satellite devices (sleep tracker + satellite speaker)
+        - M9 — Product line (Home / Pro / Max)
+        - Post-M9 / unscheduled
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: privacy
+    attributes:
+      label: Privacy / security considerations
+      description: |
+        GenieClaw's posture is local-only — no audio, transcripts, or model
+        traffic leaves the box. Does this feature touch that posture? If so,
+        how is it preserved?
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/jetson_audio.yml
+++ b/.github/ISSUE_TEMPLATE/jetson_audio.yml
@@ -1,0 +1,124 @@
+name: Jetson audio / I2S / LyraT issue
+description: LyraT V4.3, I2S overlay, mic array routing, speaker output, ALSA / amixer, [genie-audio-init] errors.
+title: "[audio] "
+labels: ["bug", "audio", "jetson"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for hardware-side audio issues — LyraT V4.3 wiring,
+        I2S overlay state, ALSA capture/playback device routing, or
+        `[genie-audio-init]` warnings. See
+        [`doc/lyrat-jetson-audio.md`](../blob/main/doc/lyrat-jetson-audio.md)
+        for the canonical setup steps before filing.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence — what's wrong with audio I/O?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which audio surface?
+      multiple: true
+      options:
+        - Capture (mic) — wrong device / no input
+        - Capture (mic) — wrong sample rate or clock (LRCK / BCK)
+        - Playback (speaker) — no output / wrong device
+        - I2S overlay — not applied / wrong pins
+        - LyraT V4.3 ALSA cset / mixer setup
+        - genie-audio systemd service / genie-audio-init script
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        Commands, output of `aplay -l` / `arecord -l`, what you ran, what happened.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: overlay
+    attributes:
+      label: 40-pin I2S overlay applied?
+      description: Result of `sudo /opt/nvidia/jetson-io/jetson-io.py` configuration on the target.
+      options:
+        - "Yes — I2S2 overlay active"
+        - "No — overlay not applied"
+        - "Unsure / not checked"
+    validations:
+      required: true
+
+  - type: textarea
+    id: setup_jetson_output
+    attributes:
+      label: setup-jetson.sh output (relevant section)
+      description: |
+        Paste the `[5e/6] Checking voice runtime prerequisites...` and
+        `[genie-audio-init]` sections from `bash /opt/geniepod/setup-jetson.sh`.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: amixer_state
+    attributes:
+      label: ALSA / amixer state
+      description: |
+        Output of `amixer -c <card> contents` or `amixer -c <card> sget <control>`
+        for the relevant card, if available.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: lyrat_rev
+    attributes:
+      label: LyraT revision
+      placeholder: "e.g. V4.3"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: hardware
+    attributes:
+      label: Jetson hardware
+      options:
+        - Jetson Orin Nano Super 8 GB
+        - Jetson Orin Nano 8 GB (non-Super)
+        - Jetson Orin NX 16 GB
+        - Jetson AGX Orin
+        - Other Jetson (specify in additional context)
+    validations:
+      required: true
+
+  - type: input
+    id: jetpack
+    attributes:
+      label: JetPack / L4T version
+      placeholder: "e.g. JetPack 6.1 / L4T R36.4"
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: GenieClaw version / commit
+      placeholder: "v1.0.0-alpha.9 or commit SHA"
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/voice_pipeline.yml
+++ b/.github/ISSUE_TEMPLATE/voice_pipeline.yml
@@ -1,0 +1,122 @@
+name: Voice pipeline issue
+description: Wake word, VAD, STT (Whisper), LLM, TTS (Piper), or first-reply latency banner — anything in the voice loop.
+title: "[voice] "
+labels: ["bug", "voice"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for any issue in the **wake → VAD → STT → LLM → TTS**
+        loop. The structured fields collect the context needed to diagnose
+        latency, accuracy, or routing problems without a back-and-forth.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence — what's wrong in the voice loop?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: stage
+    attributes:
+      label: Which stage(s) are affected?
+      multiple: true
+      options:
+        - Wake word / VAD
+        - STT (Whisper)
+        - Agent layer (prompt assembly / memory / tool dispatch)
+        - LLM (genie-ai-runtime or llama.cpp)
+        - TTS (Piper)
+        - First-reply latency banner / cycle timing
+        - Half-duplex gate / capture during TTS
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Voice mode
+      options:
+        - Continuous (wake word)
+        - Push-to-talk
+        - Telegram voice (inbound)
+        - Telegram voice (outbound)
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        Command, utterance, expected behavior. If safe to share, attach a
+        short capture (`/tmp/geniepod-rec-*.wav`).
+    validations:
+      required: true
+
+  - type: textarea
+    id: latency_banner
+    attributes:
+      label: First-reply latency banner output
+      description: |
+        Paste the `=== first voice reply latency ===` block from `genie-core`
+        stdout or `journalctl -u genie-core` if this is a latency-related issue.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: stt_model
+    attributes:
+      label: STT model
+      placeholder: "e.g. ggml-small.bin, ggml-medium.bin"
+    validations:
+      required: false
+
+  - type: input
+    id: llm_backend
+    attributes:
+      label: LLM backend + model
+      placeholder: "genie-ai-runtime / phi-4-mini-instruct-q4_k_m.gguf"
+    validations:
+      required: false
+
+  - type: input
+    id: tts_voice
+    attributes:
+      label: TTS voice
+      placeholder: "e.g. en_US-amy-medium.onnx"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: hardware
+    attributes:
+      label: Hardware
+      options:
+        - Jetson Orin Nano Super 8 GB
+        - Jetson Orin Nano 8 GB (non-Super)
+        - Jetson Orin NX 16 GB
+        - Jetson AGX Orin
+        - Other Jetson (specify in additional context)
+        - Non-Jetson (x86_64 dev / cross-build host)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: GenieClaw version / commit
+      placeholder: "v1.0.0-alpha.9 or commit SHA"
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds four structured YAML issue forms plus a config to gate the issue
tracker, with fields chosen so reports stop being lossy on the
context that actually matters for a Jetson-first project.

### Templates

| File | Purpose | Required structured fields |
|---|---|---|
| \`bug_report.yml\` | General bug | hardware (Jetson model), GenieClaw version, repro steps, expected vs actual |
| \`voice_pipeline.yml\` | Wake / VAD / STT / LLM / TTS / latency | affected stage (multi-select), voice mode, latency banner output, STT model, LLM backend, TTS voice, hardware, version |
| \`jetson_audio.yml\` | LyraT / I2S / ALSA / \`[genie-audio-init]\` | audio surface (multi-select), I2S overlay applied, setup-jetson.sh output, amixer state, LyraT rev, JetPack version, GenieClaw version |
| \`feature_request.yml\` | New behavior / scope change | problem statement, proposal, target milestone (M1-M9), privacy consideration |

### config.yml

- \`blank_issues_enabled: false\` — every new issue uses a template
- security disclosure routed to SECURITY.md (private channel preserved)
- general questions routed to GitHub Discussions (the repo has them enabled)

### Most Jetson-specific

\`voice_pipeline.yml\` and \`jetson_audio.yml\` are the most Jetson-tied:
they pull structured context (Jetson model, JetPack version, overlay state,
latency banner output, audio chain config) that is consistently lossy in
free-text bug reports. The \`amixer state\` and \`setup-jetson.sh output\`
fields in particular cover the \`[genie-audio-init] WARN\` failure
mode from older alpha-deploy runs.

## Type of Change

- [x] Documentation / repo hygiene

## Real Behavior Proof

Repo-hygiene change (no code paths touched). Five new files under
\`.github/ISSUE_TEMPLATE/\`, total +431 / -0.

**What I ran:**

- validated all 5 YAML files parse cleanly via \`ruby -ryaml -e 'YAML.load_file(...)\`' — every file reported OK
- previewed the rendered Markdown sections of each template on the GitHub PR diff view (the YAML structure is what GitHub consumes; the \`markdown\` body fields render as instructions to the issue filer)
- confirmed \`config.yml\` references resolve: \`/security/policy\`, \`/discussions\` (both exist on this repo)
- confirmed no existing \`.github/ISSUE_TEMPLATE/\` files were overwritten — \`ls .github/\` showed only \`workflows/\` and the new template directory

**What I observed:**

- [x] YAML syntax verified for all 5 files
- [x] no Rust / shell / Python sources touched — fmt, clippy, test, cross-compile, audit, deny, shellcheck, ruff expected to pass on the same code as \`main\`
- [x] PR body free of AI-attribution footers per \`CONTRIBUTING.md\` \"Commit hygiene\"

Once merged, the templates will be picked up automatically by GitHub's
\`New Issue\` flow — no further action needed. Verify by clicking
**New issue** on the repo after merge.