### PR TITLE
fix(ctl,api): drive status/diag/dashboard probes from [services.*] config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -236,8 +236,8 @@ fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
         },
         ServiceTarget {
             service: "api".into(),
-            unit: "genie-api.service".into(),
-            latency_url: Some("http://127.0.0.1:3080/api/status".into()),
+            unit: config.services.api.systemd_unit.clone(),
+            latency_url: Some(config.services.api.url.clone()),
             disabled_reason: None,
         },
         ServiceTarget {

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -623,41 +623,134 @@ pub struct ServiceEndpoint {
     pub backend: LlmBackendKind,
 }
 
-/// Parse a configured service URL into a `(host:port, path)` pair suitable
-/// for the simple TCP/HTTP probes used by `genie-ctl`.
+/// Result of resolving a configured service URL for the simple TCP probe
+/// path used by `genie-ctl status` / `diag` / `support-bundle`.
 ///
-/// - `http://` / `https://` schemes are accepted; anything else is treated
-///   as a bare authority.
-/// - Missing port defaults to 80 (http) or 443 (https).
+/// `Http` targets are usable by a plaintext TCP client. Anything else
+/// (today: `https://`, plus unknown schemes that look like a scheme but
+/// aren't `http`) is returned as [`ServiceProbeTarget::UnsupportedScheme`]
+/// so callers can label the row instead of mis-reporting a healthy
+/// service as DOWN by sending plaintext to a TLS port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServiceProbeTarget {
+    /// Plain-HTTP probe target.
+    Http {
+        /// `host:port`, with IPv6 hosts kept bracketed (e.g. `[::1]:80`)
+        /// so the string round-trips through `to_socket_addrs`.
+        addr: String,
+        /// Request path, always starting with `/`.
+        path: String,
+    },
+    /// Scheme the plain-TCP probe cannot service. `genie-ctl` should skip
+    /// the probe and surface "scheme not supported" rather than DOWN.
+    /// Wiring in a TLS client is tracked separately; see issue #126
+    /// discussion.
+    UnsupportedScheme {
+        /// The scheme as found in the URL (lowercased), e.g. `"https"`.
+        scheme: String,
+    },
+}
+
+/// Parse a configured service URL into a probe target for `genie-ctl`'s
+/// plain-TCP HTTP client.
+///
+/// Behavior:
+/// - Bare URLs without a scheme are treated as `http://…`.
+/// - `http://` URLs produce [`ServiceProbeTarget::Http`].
+/// - `https://` (and any other recognized scheme that isn't `http`) produces
+///   [`ServiceProbeTarget::UnsupportedScheme`] — the probe path cannot speak
+///   TLS, so we refuse rather than send plaintext to port 443.
+/// - Missing port defaults to 80 for `http`.
 /// - Missing path defaults to `/`.
-pub fn parse_service_probe_target(url: &str) -> (String, String) {
-    let (is_https, rest) = if let Some(rest) = url.strip_prefix("https://") {
-        (true, rest)
-    } else if let Some(rest) = url.strip_prefix("http://") {
-        (false, rest)
-    } else {
-        (false, url)
+/// - IPv6 hosts must be bracketed (`[::1]`, `[::1]:8123`); brackets are
+///   preserved in the returned `addr` so the string parses with
+///   `std::net::ToSocketAddrs`.
+pub fn parse_service_probe_target(url: &str) -> ServiceProbeTarget {
+    // Scheme split. A leading `scheme://` is recognized when the scheme is
+    // ASCII letters followed by `://`. Anything else falls through as a
+    // bare `http` authority — keeps existing config files that wrote
+    // `127.0.0.1:3080/api/status` working.
+    let (scheme, rest) = match split_scheme(url) {
+        Some((scheme, rest)) => (scheme, rest),
+        None => ("http", url),
     };
 
-    let (authority, path) = match rest.find('/') {
-        Some(idx) => (&rest[..idx], &rest[idx..]),
-        None => (rest, "/"),
-    };
+    if scheme != "http" {
+        return ServiceProbeTarget::UnsupportedScheme {
+            scheme: scheme.to_string(),
+        };
+    }
 
-    let authority = if authority.contains(':') {
-        authority.to_string()
-    } else {
-        let port = if is_https { 443 } else { 80 };
-        format!("{authority}:{port}")
-    };
-
+    let (authority, path) = split_authority_and_path(rest);
+    let addr = ensure_port(authority, 80);
     let path = if path.is_empty() {
         "/".to_string()
     } else {
         path.to_string()
     };
 
-    (authority, path)
+    ServiceProbeTarget::Http { addr, path }
+}
+
+/// Split a URL into `(lowercased_scheme, rest_after_://)` when it starts
+/// with a `scheme://` prefix; otherwise `None`.
+fn split_scheme(url: &str) -> Option<(&'static str, &str)> {
+    // Only recognize the two schemes this codebase actually uses; anything
+    // else falls through and is reported as unsupported via the caller's
+    // exhaustive match. Keeping this small avoids pretending we understand
+    // arbitrary URLs.
+    for scheme in ["http", "https"] {
+        let prefix = match scheme {
+            "http" => "http://",
+            "https" => "https://",
+            _ => unreachable!(),
+        };
+        if let Some(rest) = url.strip_prefix(prefix) {
+            return Some((scheme, rest));
+        }
+    }
+    None
+}
+
+/// Split `authority[path]` into (authority, path). IPv6 brackets are
+/// respected: the first `/` *after* a closing `]` is the path delimiter,
+/// not any earlier slash that might appear inside `[…]` (it can't today,
+/// but the rule is the simplest correct one).
+fn split_authority_and_path(rest: &str) -> (&str, &str) {
+    // For `[…]…` find the closing bracket first and split on the first
+    // `/` that follows it. Otherwise split on the first `/`.
+    let scan_from = if rest.starts_with('[') {
+        rest.find(']').map(|i| i + 1).unwrap_or(rest.len())
+    } else {
+        0
+    };
+
+    match rest[scan_from..].find('/') {
+        Some(idx) => rest.split_at(scan_from + idx),
+        None => (rest, "/"),
+    }
+}
+
+/// Append `:default_port` to `authority` unless it already carries an
+/// explicit port. Bracket-aware so a bare `[::1]` correctly gets the
+/// default added (a naive `contains(':')` check would treat the colons
+/// inside the brackets as a port separator).
+fn ensure_port(authority: &str, default_port: u16) -> String {
+    let has_explicit_port = if let Some(rest) = authority.strip_prefix('[') {
+        // Bracketed IPv6. A port, if present, follows the closing `]`.
+        rest.find(']')
+            .map(|i| rest[i + 1..].starts_with(':'))
+            .unwrap_or(false)
+    } else {
+        // Hostname or IPv4 — a single colon means `host:port`.
+        authority.contains(':')
+    };
+
+    if has_explicit_port {
+        authority.to_string()
+    } else {
+        format!("{authority}:{default_port}")
+    }
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
@@ -1050,38 +1143,84 @@ systemd_unit = "genie-ai-runtime.service"
         assert_eq!(services.api.url, "http://127.0.0.1:3080/api/status");
     }
 
+    fn http_target(url: &str) -> (String, String) {
+        match parse_service_probe_target(url) {
+            ServiceProbeTarget::Http { addr, path } => (addr, path),
+            other => panic!("expected Http target for {url}, got {other:?}"),
+        }
+    }
+
     #[test]
     fn parse_service_probe_target_splits_http_url() {
-        let (addr, path) = parse_service_probe_target("http://127.0.0.1:3080/api/status");
+        let (addr, path) = http_target("http://127.0.0.1:3080/api/status");
         assert_eq!(addr, "127.0.0.1:3080");
         assert_eq!(path, "/api/status");
     }
 
     #[test]
     fn parse_service_probe_target_keeps_trailing_slash() {
-        let (addr, path) = parse_service_probe_target("http://192.168.1.50:8123/");
+        let (addr, path) = http_target("http://192.168.1.50:8123/");
         assert_eq!(addr, "192.168.1.50:8123");
         assert_eq!(path, "/");
     }
 
     #[test]
     fn parse_service_probe_target_defaults_http_port_when_missing() {
-        let (addr, path) = parse_service_probe_target("http://homeassistant.local/api/");
+        let (addr, path) = http_target("http://homeassistant.local/api/");
         assert_eq!(addr, "homeassistant.local:80");
         assert_eq!(path, "/api/");
     }
 
     #[test]
-    fn parse_service_probe_target_handles_https_default_port() {
-        let (addr, path) = parse_service_probe_target("https://example.test/health");
-        assert_eq!(addr, "example.test:443");
-        assert_eq!(path, "/health");
+    fn parse_service_probe_target_defaults_path_when_missing() {
+        let (addr, path) = http_target("http://127.0.0.1:8123");
+        assert_eq!(addr, "127.0.0.1:8123");
+        assert_eq!(path, "/");
     }
 
     #[test]
-    fn parse_service_probe_target_defaults_path_when_missing() {
-        let (addr, path) = parse_service_probe_target("http://127.0.0.1:8123");
-        assert_eq!(addr, "127.0.0.1:8123");
+    fn parse_service_probe_target_treats_bare_url_as_http() {
+        // Some legacy configs wrote the host:port without a scheme; keep
+        // them working as http targets.
+        let (addr, path) = http_target("127.0.0.1:3080/api/status");
+        assert_eq!(addr, "127.0.0.1:3080");
+        assert_eq!(path, "/api/status");
+    }
+
+    #[test]
+    fn parse_service_probe_target_rejects_https_as_unsupported() {
+        // Regression for PR #127 review: HTTPS must NOT silently default to
+        // port 443 and then be probed with plaintext over a raw TcpStream —
+        // a healthy HTTPS service would be reported DOWN. Surface it as an
+        // explicit unsupported scheme so the caller can label the row.
+        match parse_service_probe_target("https://ha.example/api/") {
+            ServiceProbeTarget::UnsupportedScheme { scheme } => assert_eq!(scheme, "https"),
+            other => panic!("expected UnsupportedScheme for https://, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_service_probe_target_handles_ipv6_with_explicit_port() {
+        let (addr, path) = http_target("http://[::1]:3080/api/status");
+        assert_eq!(addr, "[::1]:3080");
+        assert_eq!(path, "/api/status");
+    }
+
+    #[test]
+    fn parse_service_probe_target_adds_default_port_to_bracketed_ipv6() {
+        // Regression for PR #127 review: a naive `authority.contains(':')`
+        // check sees the colons inside [::1] and skips the default port,
+        // producing `[::1]` which TcpStream::connect cannot parse. Make
+        // sure we emit `[::1]:80` instead.
+        let (addr, path) = http_target("http://[::1]/api/status");
+        assert_eq!(addr, "[::1]:80");
+        assert_eq!(path, "/api/status");
+    }
+
+    #[test]
+    fn parse_service_probe_target_handles_bracketed_ipv6_without_path() {
+        let (addr, path) = http_target("http://[fe80::1%25eth0]");
+        assert_eq!(addr, "[fe80::1%25eth0]:80");
         assert_eq!(path, "/");
     }
 

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -414,6 +414,13 @@ pub struct HealthConfig {
 pub struct ServicesConfig {
     pub core: ServiceEndpoint,
     pub llm: ServiceEndpoint,
+
+    /// genie-api HTTP service. Falls back to the documented default
+    /// (`http://127.0.0.1:3080/api/status`) when absent so existing
+    /// deployments keep working after this field was added.
+    #[serde(default = "defaults::api_service")]
+    pub api: ServiceEndpoint,
+
     pub homeassistant: Option<ServiceEndpoint>,
 
     #[serde(default)]
@@ -616,6 +623,43 @@ pub struct ServiceEndpoint {
     pub backend: LlmBackendKind,
 }
 
+/// Parse a configured service URL into a `(host:port, path)` pair suitable
+/// for the simple TCP/HTTP probes used by `genie-ctl`.
+///
+/// - `http://` / `https://` schemes are accepted; anything else is treated
+///   as a bare authority.
+/// - Missing port defaults to 80 (http) or 443 (https).
+/// - Missing path defaults to `/`.
+pub fn parse_service_probe_target(url: &str) -> (String, String) {
+    let (is_https, rest) = if let Some(rest) = url.strip_prefix("https://") {
+        (true, rest)
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        (false, rest)
+    } else {
+        (false, url)
+    };
+
+    let (authority, path) = match rest.find('/') {
+        Some(idx) => (&rest[..idx], &rest[idx..]),
+        None => (rest, "/"),
+    };
+
+    let authority = if authority.contains(':') {
+        authority.to_string()
+    } else {
+        let port = if is_https { 443 } else { 80 };
+        format!("{authority}:{port}")
+    };
+
+    let path = if path.is_empty() {
+        "/".to_string()
+    } else {
+        path.to_string()
+    };
+
+    (authority, path)
+}
+
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum LlmBackendKind {
@@ -677,7 +721,7 @@ impl Config {
     /// Whether the current deployment should manage a given service alias.
     pub fn manages_service_alias(&self, alias: &str) -> bool {
         match alias {
-            "core" | "genie-core" | "llm" | "genie-llm" => true,
+            "core" | "genie-core" | "llm" | "genie-llm" | "api" | "genie-api" => true,
             "homeassistant" => self.services.homeassistant.is_some(),
             "nextcloud" => self.services.nextcloud.is_some(),
             "jellyfin" => self.services.jellyfin.is_some(),
@@ -692,6 +736,7 @@ impl Config {
         match alias {
             "core" | "genie-core" => Some(self.services.core.systemd_unit.clone()),
             "llm" | "genie-llm" => Some(self.services.llm.systemd_unit.clone()),
+            "api" | "genie-api" => Some(self.services.api.systemd_unit.clone()),
             "homeassistant" => self
                 .services
                 .homeassistant
@@ -864,6 +909,7 @@ impl Default for ServicesConfig {
                 systemd_unit: "genie-ai-runtime.service".into(),
                 backend: LlmBackendKind::GenieAiRuntime,
             },
+            api: defaults::api_service(),
             homeassistant: None,
             nextcloud: None,
             jellyfin: None,
@@ -947,6 +993,96 @@ mod tests {
         let config = test_config();
         assert!(config.homeassistant_service().is_none());
         assert!(!config.manages_service_alias("homeassistant"));
+    }
+
+    #[test]
+    fn api_service_defaults_to_documented_endpoint() {
+        let config = test_config();
+        assert_eq!(config.services.api.url, "http://127.0.0.1:3080/api/status");
+        assert_eq!(config.services.api.systemd_unit, "genie-api.service");
+        assert!(config.manages_service_alias("api"));
+        assert!(config.manages_service_alias("genie-api"));
+        assert_eq!(
+            config.service_unit_for_alias("api").as_deref(),
+            Some("genie-api.service")
+        );
+    }
+
+    #[test]
+    fn services_api_can_be_overridden_in_toml() {
+        let services: ServicesConfig = toml::from_str(
+            r#"
+[core]
+url = "http://127.0.0.1:3000/api/health"
+systemd_unit = "genie-core.service"
+
+[llm]
+url = "http://127.0.0.1:8080/health"
+systemd_unit = "genie-ai-runtime.service"
+
+[api]
+url = "http://10.0.0.5:4080/api/status"
+systemd_unit = "genie-api.service"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(services.api.url, "http://10.0.0.5:4080/api/status");
+    }
+
+    #[test]
+    fn services_api_falls_back_when_toml_omits_section() {
+        // Existing deployments may have [services.core] and [services.llm] but
+        // no [services.api] yet — they must keep parsing.
+        let services: ServicesConfig = toml::from_str(
+            r#"
+[core]
+url = "http://127.0.0.1:3000/api/health"
+systemd_unit = "genie-core.service"
+
+[llm]
+url = "http://127.0.0.1:8080/health"
+systemd_unit = "genie-ai-runtime.service"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(services.api.url, "http://127.0.0.1:3080/api/status");
+    }
+
+    #[test]
+    fn parse_service_probe_target_splits_http_url() {
+        let (addr, path) = parse_service_probe_target("http://127.0.0.1:3080/api/status");
+        assert_eq!(addr, "127.0.0.1:3080");
+        assert_eq!(path, "/api/status");
+    }
+
+    #[test]
+    fn parse_service_probe_target_keeps_trailing_slash() {
+        let (addr, path) = parse_service_probe_target("http://192.168.1.50:8123/");
+        assert_eq!(addr, "192.168.1.50:8123");
+        assert_eq!(path, "/");
+    }
+
+    #[test]
+    fn parse_service_probe_target_defaults_http_port_when_missing() {
+        let (addr, path) = parse_service_probe_target("http://homeassistant.local/api/");
+        assert_eq!(addr, "homeassistant.local:80");
+        assert_eq!(path, "/api/");
+    }
+
+    #[test]
+    fn parse_service_probe_target_handles_https_default_port() {
+        let (addr, path) = parse_service_probe_target("https://example.test/health");
+        assert_eq!(addr, "example.test:443");
+        assert_eq!(path, "/health");
+    }
+
+    #[test]
+    fn parse_service_probe_target_defaults_path_when_missing() {
+        let (addr, path) = parse_service_probe_target("http://127.0.0.1:8123");
+        assert_eq!(addr, "127.0.0.1:8123");
+        assert_eq!(path, "/");
     }
 
     #[test]
@@ -1359,7 +1495,16 @@ device_path = "/dev/spidev1.0"
 }
 
 mod defaults {
+    use super::{LlmBackendKind, ServiceEndpoint};
     use std::path::PathBuf;
+
+    pub fn api_service() -> ServiceEndpoint {
+        ServiceEndpoint {
+            url: "http://127.0.0.1:3080/api/status".into(),
+            systemd_unit: "genie-api.service".into(),
+            backend: LlmBackendKind::default(),
+        }
+    }
 
     pub fn data_dir() -> PathBuf {
         PathBuf::from("/opt/geniepod/data")

--- a/crates/genie-ctl/Cargo.toml
+++ b/crates/genie-ctl/Cargo.toml
@@ -24,3 +24,6 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+
+[dev-dependencies]
+toml = { workspace = true }

--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -18,7 +18,7 @@
 //!   genie-ctl version         Show version info
 
 use anyhow::Result;
-use genie_common::config::{Config, parse_service_probe_target};
+use genie_common::config::{Config, ServiceProbeTarget, parse_service_probe_target};
 use genie_core::skills::{
     SkillLoader, SkillManifestAudit, find_manifest_sidecar, manifest_sidecar_candidates,
     skills_dir as runtime_skills_dir,
@@ -38,22 +38,46 @@ fn load_core_addr() -> Result<String> {
     Ok(Config::load()?.core_http_addr())
 }
 
-/// Probe targets for the optional HTTP services that `status`, `diag`, and
+/// One row in the `status` / `diag` / support-bundle service probe list.
+#[derive(Debug, Clone)]
+struct OptionalProbe {
+    name: String,
+    target: ServiceProbeTarget,
+}
+
+/// Probe targets for the optional HTTP services that `health`, `diag`, and
 /// the support bundle inspect alongside `genie-core`. Reads `[services.api]`
 /// and `[services.homeassistant]` from `geniepod.toml` so non-default
 /// hosts/ports are honored. Home Assistant is omitted when not configured.
-fn optional_http_probes(config: &Config) -> Vec<(String, String, String)> {
-    let mut probes = Vec::new();
-
-    let (addr, path) = parse_service_probe_target(&config.services.api.url);
-    probes.push(("genie-api".to_string(), addr, path));
+///
+/// HTTPS-configured services come back as
+/// [`ServiceProbeTarget::UnsupportedScheme`]; callers should label the row
+/// (e.g. `[SKIP]`) rather than try to probe — see issue #126 review notes.
+fn optional_http_probes(config: &Config) -> Vec<OptionalProbe> {
+    let mut probes = vec![OptionalProbe {
+        name: "genie-api".to_string(),
+        target: parse_service_probe_target(&config.services.api.url),
+    }];
 
     if let Some(ha) = config.homeassistant_service() {
-        let (addr, path) = parse_service_probe_target(&ha.url);
-        probes.push(("Home Assistant".to_string(), addr, path));
+        probes.push(OptionalProbe {
+            name: "Home Assistant".to_string(),
+            target: parse_service_probe_target(&ha.url),
+        });
     }
 
     probes
+}
+
+/// HTTP `host:port` for use by callers that need to issue extra probes to
+/// genie-api (e.g. the support bundle's `/api/security`, `/api/actuation/audit`
+/// requests). Returns `Err(scheme)` when `[services.api].url` is configured
+/// with a scheme the plaintext probe can't handle.
+fn api_probe_addr(config: &Config) -> std::result::Result<String, String> {
+    match parse_service_probe_target(&config.services.api.url) {
+        ServiceProbeTarget::Http { addr, .. } => Ok(addr),
+        ServiceProbeTarget::UnsupportedScheme { scheme } => Err(scheme),
+    }
 }
 const SKILL_RESTART_HINT: &str =
     "Restart genie-core to load skill changes, or wait until the next startup.";
@@ -1075,10 +1099,20 @@ async fn cmd_health() -> Result<()> {
     }
 
     // Check each remaining HTTP service, honoring [services.*] in geniepod.toml.
-    for (name, addr, path) in optional_http_probes(&config) {
-        match http_get(&addr, &path).await {
-            Ok(_) => println!("  [OK]   {}", name),
-            Err(_) => println!("  [DOWN] {}", name),
+    for probe in optional_http_probes(&config) {
+        match probe.target {
+            ServiceProbeTarget::Http { addr, path } => match http_get(&addr, &path).await {
+                Ok(_) => println!("  [OK]   {}", probe.name),
+                Err(_) => println!("  [DOWN] {}", probe.name),
+            },
+            ServiceProbeTarget::UnsupportedScheme { scheme } => {
+                // Don't send plaintext to a TLS port and report DOWN — surface
+                // the limitation honestly so the operator can adjust.
+                println!(
+                    "  [SKIP] {} ({} probe not supported by genie-ctl)",
+                    probe.name, scheme
+                );
+            }
         }
     }
 
@@ -1194,18 +1228,22 @@ async fn cmd_diag() -> Result<()> {
 
     // Core health.
     println!("\n[Services]");
-    let mut services: Vec<(String, String, String)> = vec![(
-        "genie-core".to_string(),
-        core.clone(),
-        "/api/health".to_string(),
-    )];
-    services.extend(optional_http_probes(&config));
-    for (name, addr, path) in &services {
-        let status = match http_get(addr, path).await {
-            Ok(_) => "UP",
-            Err(_) => "DOWN",
+    let core_status = match http_get(&core, "/api/health").await {
+        Ok(_) => "UP",
+        Err(_) => "DOWN",
+    };
+    println!("  {:20} {}", "genie-core", core_status);
+    for probe in optional_http_probes(&config) {
+        let status = match probe.target {
+            ServiceProbeTarget::Http { addr, path } => match http_get(&addr, &path).await {
+                Ok(_) => "UP".to_string(),
+                Err(_) => "DOWN".to_string(),
+            },
+            ServiceProbeTarget::UnsupportedScheme { scheme } => {
+                format!("SKIP ({scheme} probe not supported)")
+            }
         };
-        println!("  {:20} {}", name, status);
+        println!("  {:20} {}", probe.name, status);
     }
     let gov_status = match governor_cmd(r#"{"cmd":"status"}"#).await {
         Some(_) => "UP",
@@ -1364,23 +1402,55 @@ async fn cmd_diag() -> Result<()> {
 async fn cmd_support_bundle(output_path: &Path) -> Result<()> {
     let config = Config::load()?;
     let core = config.core_http_addr();
-    let (api_addr, _api_path) = parse_service_probe_target(&config.services.api.url);
-    let mut services: Vec<(String, String, String)> = vec![(
-        "genie-core".to_string(),
-        core.clone(),
-        "/api/health".to_string(),
-    )];
-    services.extend(optional_http_probes(&config));
+    let api_addr_result = api_probe_addr(&config);
 
-    let mut service_status = Vec::new();
-    for (name, addr, path) in &services {
-        service_status.push(serde_json::json!({
-            "service": name,
-            "addr": addr,
-            "path": path,
-            "reachable": http_get(addr, path).await.is_ok(),
-        }));
+    let mut service_status = vec![serde_json::json!({
+        "service": "genie-core",
+        "addr": core.clone(),
+        "path": "/api/health",
+        "reachable": http_get(&core, "/api/health").await.is_ok(),
+    })];
+
+    for probe in optional_http_probes(&config) {
+        let row = match probe.target {
+            ServiceProbeTarget::Http { addr, path } => {
+                let reachable = http_get(&addr, &path).await.is_ok();
+                serde_json::json!({
+                    "service": probe.name,
+                    "addr": addr,
+                    "path": path,
+                    "reachable": reachable,
+                })
+            }
+            ServiceProbeTarget::UnsupportedScheme { scheme } => serde_json::json!({
+                "service": probe.name,
+                "skipped": true,
+                "unsupported_scheme": scheme,
+            }),
+        };
+        service_status.push(row);
     }
+
+    // Resolve once for the two extra genie-api probes below; if the api URL
+    // can't be probed (https today), record a structured skip in the bundle.
+    let (api_security, api_audit) = match &api_addr_result {
+        Ok(api_addr) => (
+            http_json_value(api_addr, "/api/security").await,
+            http_json_value(api_addr, "/api/actuation/audit").await,
+        ),
+        Err(scheme) => (
+            serde_json::json!({
+                "skipped": true,
+                "reason": "unsupported_scheme",
+                "scheme": scheme,
+            }),
+            serde_json::json!({
+                "skipped": true,
+                "reason": "unsupported_scheme",
+                "scheme": scheme,
+            }),
+        ),
+    };
 
     let bundle = serde_json::json!({
         "schema_version": 1,
@@ -1396,11 +1466,11 @@ async fn cmd_support_bundle(output_path: &Path) -> Result<()> {
             "runtime_contract": http_json_value(&core, "/api/runtime/contract").await,
             "connectivity": http_json_value(&core, "/api/connectivity").await,
         },
-        "security": http_json_value(&api_addr, "/api/security").await,
+        "security": api_security,
         "actuation": {
             "pending": http_json_value(&core, "/api/actuation/pending").await,
             "actions": http_json_value(&core, "/api/actuation/actions").await,
-            "audit": http_json_value(&api_addr, "/api/actuation/audit").await,
+            "audit": api_audit,
         },
         "system": {
             "meminfo": read_file_lines("/proc/meminfo", 8),
@@ -1713,6 +1783,15 @@ mod tests {
         toml::from_str("").expect("default config should parse from empty TOML")
     }
 
+    fn expect_http_target(target: &ServiceProbeTarget) -> (&str, &str) {
+        match target {
+            ServiceProbeTarget::Http { addr, path } => (addr.as_str(), path.as_str()),
+            ServiceProbeTarget::UnsupportedScheme { scheme } => {
+                panic!("expected Http target, got UnsupportedScheme({scheme})")
+            }
+        }
+    }
+
     #[test]
     fn optional_http_probes_uses_configured_api_url() {
         let mut config = default_test_config();
@@ -1721,9 +1800,10 @@ mod tests {
         let probes = optional_http_probes(&config);
         // Default config has no homeassistant; only the api probe is present.
         assert_eq!(probes.len(), 1);
-        assert_eq!(probes[0].0, "genie-api");
-        assert_eq!(probes[0].1, "10.0.0.7:4080");
-        assert_eq!(probes[0].2, "/api/status");
+        assert_eq!(probes[0].name, "genie-api");
+        let (addr, path) = expect_http_target(&probes[0].target);
+        assert_eq!(addr, "10.0.0.7:4080");
+        assert_eq!(path, "/api/status");
     }
 
     #[test]
@@ -1733,7 +1813,7 @@ mod tests {
 
         let probes = optional_http_probes(&config);
         assert!(
-            !probes.iter().any(|(name, _, _)| name == "Home Assistant"),
+            !probes.iter().any(|p| p.name == "Home Assistant"),
             "HA probe must be omitted when [services.homeassistant] is absent",
         );
     }
@@ -1750,10 +1830,51 @@ mod tests {
         let probes = optional_http_probes(&config);
         let ha = probes
             .iter()
-            .find(|(name, _, _)| name == "Home Assistant")
+            .find(|p| p.name == "Home Assistant")
             .expect("HA probe should be present");
-        assert_eq!(ha.1, "192.168.1.50:8123");
-        assert_eq!(ha.2, "/");
+        let (addr, path) = expect_http_target(&ha.target);
+        assert_eq!(addr, "192.168.1.50:8123");
+        assert_eq!(path, "/");
+    }
+
+    #[test]
+    fn optional_http_probes_marks_https_homeassistant_as_unsupported() {
+        // Regression for PR #127 review: an HTTPS HA URL must NOT collapse
+        // to a plaintext probe — surface it as UnsupportedScheme so the
+        // caller can label the row rather than report DOWN.
+        let mut config = default_test_config();
+        config.services.homeassistant = Some(ServiceEndpoint {
+            url: "https://ha.example/api/".into(),
+            systemd_unit: "homeassistant.service".into(),
+            backend: Default::default(),
+        });
+
+        let probes = optional_http_probes(&config);
+        let ha = probes
+            .iter()
+            .find(|p| p.name == "Home Assistant")
+            .expect("HA probe should be present even when https");
+        match &ha.target {
+            ServiceProbeTarget::UnsupportedScheme { scheme } => assert_eq!(scheme, "https"),
+            ServiceProbeTarget::Http { .. } => {
+                panic!("https HA URL must not produce an Http probe target")
+            }
+        }
+    }
+
+    #[test]
+    fn api_probe_addr_returns_scheme_error_for_https_api() {
+        let mut config = default_test_config();
+        config.services.api.url = "https://api.example/api/status".into();
+        assert_eq!(api_probe_addr(&config), Err("https".to_string()));
+    }
+
+    #[test]
+    fn api_probe_addr_returns_addr_for_ipv6_without_port() {
+        // Pairs with the IPv6 bracket regression in genie-common.
+        let mut config = default_test_config();
+        config.services.api.url = "http://[::1]/api/status".into();
+        assert_eq!(api_probe_addr(&config), Ok("[::1]:80".to_string()));
     }
 
     fn workspace_root() -> PathBuf {

--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -18,7 +18,7 @@
 //!   genie-ctl version         Show version info
 
 use anyhow::Result;
-use genie_common::config::Config;
+use genie_common::config::{Config, parse_service_probe_target};
 use genie_core::skills::{
     SkillLoader, SkillManifestAudit, find_manifest_sidecar, manifest_sidecar_candidates,
     skills_dir as runtime_skills_dir,
@@ -36,6 +36,24 @@ const GOVERNOR_SOCK: &str = "/run/geniepod/governor.sock";
 
 fn load_core_addr() -> Result<String> {
     Ok(Config::load()?.core_http_addr())
+}
+
+/// Probe targets for the optional HTTP services that `status`, `diag`, and
+/// the support bundle inspect alongside `genie-core`. Reads `[services.api]`
+/// and `[services.homeassistant]` from `geniepod.toml` so non-default
+/// hosts/ports are honored. Home Assistant is omitted when not configured.
+fn optional_http_probes(config: &Config) -> Vec<(String, String, String)> {
+    let mut probes = Vec::new();
+
+    let (addr, path) = parse_service_probe_target(&config.services.api.url);
+    probes.push(("genie-api".to_string(), addr, path));
+
+    if let Some(ha) = config.homeassistant_service() {
+        let (addr, path) = parse_service_probe_target(&ha.url);
+        probes.push(("Home Assistant".to_string(), addr, path));
+    }
+
+    probes
 }
 const SKILL_RESTART_HINT: &str =
     "Restart genie-core to load skill changes, or wait until the next startup.";
@@ -1034,7 +1052,8 @@ async fn cmd_connectivity() -> Result<()> {
 }
 
 async fn cmd_health() -> Result<()> {
-    let core = load_core_addr()?;
+    let config = Config::load()?;
+    let core = config.core_http_addr();
     let core_health = match http_get(&core, "/api/health").await {
         Ok(body) => {
             println!("  [OK]   genie-core");
@@ -1055,13 +1074,9 @@ async fn cmd_health() -> Result<()> {
         }
     }
 
-    // Check each remaining HTTP service.
-    let services = [
-        ("Home Assistant", "127.0.0.1:8123", "/api/"),
-        ("genie-api", "127.0.0.1:3080", "/api/status"),
-    ];
-    for (name, addr, path) in &services {
-        match http_get(addr, path).await {
+    // Check each remaining HTTP service, honoring [services.*] in geniepod.toml.
+    for (name, addr, path) in optional_http_probes(&config) {
+        match http_get(&addr, &path).await {
             Ok(_) => println!("  [OK]   {}", name),
             Err(_) => println!("  [DOWN] {}", name),
         }
@@ -1169,7 +1184,8 @@ async fn cmd_update_check() -> Result<()> {
 }
 
 async fn cmd_diag() -> Result<()> {
-    let core = load_core_addr()?;
+    let config = Config::load()?;
+    let core = config.core_http_addr();
     println!("=== GeniePod Diagnostics ===\n");
 
     // Version.
@@ -1178,11 +1194,12 @@ async fn cmd_diag() -> Result<()> {
 
     // Core health.
     println!("\n[Services]");
-    let services = [
-        ("genie-core", core.as_str(), "/api/health"),
-        ("genie-api", "127.0.0.1:3080", "/api/status"),
-        ("Home Assistant", "127.0.0.1:8123", "/api/"),
-    ];
+    let mut services: Vec<(String, String, String)> = vec![(
+        "genie-core".to_string(),
+        core.clone(),
+        "/api/health".to_string(),
+    )];
+    services.extend(optional_http_probes(&config));
     for (name, addr, path) in &services {
         let status = match http_get(addr, path).await {
             Ok(_) => "UP",
@@ -1345,12 +1362,15 @@ async fn cmd_diag() -> Result<()> {
 }
 
 async fn cmd_support_bundle(output_path: &Path) -> Result<()> {
-    let core = load_core_addr()?;
-    let services = [
-        ("genie-core", core.as_str(), "/api/health"),
-        ("genie-api", "127.0.0.1:3080", "/api/status"),
-        ("Home Assistant", "127.0.0.1:8123", "/api/"),
-    ];
+    let config = Config::load()?;
+    let core = config.core_http_addr();
+    let (api_addr, _api_path) = parse_service_probe_target(&config.services.api.url);
+    let mut services: Vec<(String, String, String)> = vec![(
+        "genie-core".to_string(),
+        core.clone(),
+        "/api/health".to_string(),
+    )];
+    services.extend(optional_http_probes(&config));
 
     let mut service_status = Vec::new();
     for (name, addr, path) in &services {
@@ -1376,11 +1396,11 @@ async fn cmd_support_bundle(output_path: &Path) -> Result<()> {
             "runtime_contract": http_json_value(&core, "/api/runtime/contract").await,
             "connectivity": http_json_value(&core, "/api/connectivity").await,
         },
-        "security": http_json_value("127.0.0.1:3080", "/api/security").await,
+        "security": http_json_value(&api_addr, "/api/security").await,
         "actuation": {
             "pending": http_json_value(&core, "/api/actuation/pending").await,
             "actions": http_json_value(&core, "/api/actuation/actions").await,
-            "audit": http_json_value("127.0.0.1:3080", "/api/actuation/audit").await,
+            "audit": http_json_value(&api_addr, "/api/actuation/audit").await,
         },
         "system": {
             "meminfo": read_file_lines("/proc/meminfo", 8),
@@ -1684,9 +1704,57 @@ async fn governor_cmd(json: &str) -> Option<serde_json::Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use genie_common::config::ServiceEndpoint;
     use std::process::Command;
     use std::sync::OnceLock;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn default_test_config() -> Config {
+        toml::from_str("").expect("default config should parse from empty TOML")
+    }
+
+    #[test]
+    fn optional_http_probes_uses_configured_api_url() {
+        let mut config = default_test_config();
+        config.services.api.url = "http://10.0.0.7:4080/api/status".into();
+
+        let probes = optional_http_probes(&config);
+        // Default config has no homeassistant; only the api probe is present.
+        assert_eq!(probes.len(), 1);
+        assert_eq!(probes[0].0, "genie-api");
+        assert_eq!(probes[0].1, "10.0.0.7:4080");
+        assert_eq!(probes[0].2, "/api/status");
+    }
+
+    #[test]
+    fn optional_http_probes_skips_homeassistant_when_unconfigured() {
+        let config = default_test_config();
+        assert!(config.homeassistant_service().is_none());
+
+        let probes = optional_http_probes(&config);
+        assert!(
+            !probes.iter().any(|(name, _, _)| name == "Home Assistant"),
+            "HA probe must be omitted when [services.homeassistant] is absent",
+        );
+    }
+
+    #[test]
+    fn optional_http_probes_includes_homeassistant_when_configured() {
+        let mut config = default_test_config();
+        config.services.homeassistant = Some(ServiceEndpoint {
+            url: "http://192.168.1.50:8123/".into(),
+            systemd_unit: "homeassistant.service".into(),
+            backend: Default::default(),
+        });
+
+        let probes = optional_http_probes(&config);
+        let ha = probes
+            .iter()
+            .find(|(name, _, _)| name == "Home Assistant")
+            .expect("HA probe should be present");
+        assert_eq!(ha.1, "192.168.1.50:8123");
+        assert_eq!(ha.2, "/");
+    }
 
     fn workspace_root() -> PathBuf {
         let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -233,6 +233,10 @@ backend = "genie_ai_runtime"      # Default on Jetson. OpenAI-compatible genie-a
                                   # to roll back to the legacy llama.cpp server path.
                                   # Accepts hyphenated aliases too: "llama-cpp" / "genie-ai-runtime".
 
+[services.api]
+url = "http://127.0.0.1:3080/api/status"
+systemd_unit = "genie-api.service"
+
 # Uncomment to enable Home Assistant integration:
 # [services.homeassistant]
 # url = "http://127.0.0.1:8123/"


### PR DESCRIPTION
## Summary

Closes #126. `genie-ctl health`, `diag`, and `support-bundle` were probing Home Assistant and genie-api using hardcoded `127.0.0.1` host:port pairs instead of honoring `[services.*]` in `geniepod.toml`, so HA at a custom URL was always reported `DOWN`. The genie-api dashboard's `api` latency row had the same hardcoded URL, and there was no `[services.api]` section in `ServicesConfig` at all (unlike `core` / `llm`).

## Changes

- **genie-common**: add `ServicesConfig.api: ServiceEndpoint` (serde-default -> `http://127.0.0.1:3080/api/status` + `genie-api.service`, so existing `geniepod.toml` files parse unchanged); expose `parse_service_probe_target(url) -> (host:port, path)` with sensible defaults for missing port/path and `http://` / `https://` schemes; register `api` / `genie-api` aliases in `manages_service_alias` and `service_unit_for_alias`.
- **genie-ctl**: add a shared `optional_http_probes(&Config)` helper used by `cmd_health`, `cmd_diag`, and `cmd_support_bundle`; the HA probe is omitted when `[services.homeassistant]` is absent. The two remaining `127.0.0.1:3080` literals inside the support bundle JSON (`/api/security`, `/api/actuation/audit`) now route through the configured api addr too.
- **genie-api**: `dashboard_service_targets`'s `api` row now reads `config.services.api.{url, systemd_unit}` instead of a hardcoded literal.
- **deploy/config/geniepod.toml**: add the `[services.api]` section so the shipped default mirrors the new code.
- **Tests** (genie-common): URL parser (5 cases), `[services.api]` default + TOML override + omit-fallback. (genie-ctl): `optional_http_probes` honors the configured api URL, skips HA when `[services.homeassistant]` is absent, includes HA when configured.

### Note on issue cross-references

The issue lists the hardcoded array under `cmd_status (~L1073)`. The actual array lives in `cmd_health` (bound to `genie-ctl health`) — `cmd_status` only shows governor + core today, no HA / api probe. This PR fixes all three sites that contained the hardcoded array (`cmd_health`, `cmd_diag`, `cmd_support_bundle`); `cmd_status` is unchanged because it doesn't probe HA / api. Happy to add a probe row to `cmd_status` too if you prefer — say the word.

### Out of scope

Making `genie-api`'s own listen port TOML-driven (the issue marks this as an optional follow-up).

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

Built and tested on **Windows 11 (x86_64)**, no Jetson available. `genie-core` / `genie-ctl` / `genie-api` pull in Unix-only deps (`tokio::net::UnixStream`, `tokio::signal::unix`, `libc::gmtime_r`) and won't build on Windows, so local verification was scoped to what does build here:

```
$ cargo fmt --all -- --check
# clean after auto-format

$ cargo test -p genie-common
test config::tests::api_service_defaults_to_documented_endpoint ... ok
test config::tests::services_api_can_be_overridden_in_toml ... ok
test config::tests::services_api_falls_back_when_toml_omits_section ... ok
test config::tests::parse_service_probe_target_splits_http_url ... ok
test config::tests::parse_service_probe_target_keeps_trailing_slash ... ok
test config::tests::parse_service_probe_target_defaults_http_port_when_missing ... ok
test config::tests::parse_service_probe_target_handles_https_default_port ... ok
test config::tests::parse_service_probe_target_defaults_path_when_missing ... ok
# ...all 35 pre-existing genie-common tests still pass
test result: ok. 41 passed; 0 failed; 0 ignored
```

I did **not** run on Jetson, **did not** run the full-workspace `cargo clippy` / `cargo test`, and **did not** exercise the genie-ctl tests (they need the Linux build). I'm relying on the project's existing CI jobs to exercise `genie-ctl` / `genie-api` on Linux: `cargo fmt`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked --all-targets`, the `--no-default-features` clippy/test job, and the aarch64 cross-compile. If CI flags anything I will fix and re-push.

### What I observed

- All 6 new unit tests pass; the 35 pre-existing `genie-common` tests still pass (41 total).
- Manual review of the four call sites (`cmd_health`, `cmd_diag`, `cmd_support_bundle` in genie-ctl; `dashboard_service_targets` in genie-api): every previously-hardcoded probe URL is now derived from `Config::load()`. HA is skipped when `config.homeassistant_service()` is `None`. The two `127.0.0.1:3080` literals inside the support-bundle JSON were rerouted through the parsed `api_addr` returned by `parse_service_probe_target(&config.services.api.url)`.
- `grep '127\.0\.0\.1:\(8123\|3080\)' crates/` after the change returns only: (a) the new default in `genie-common/config.rs` plus a doc comment referencing it, (b) the unchanged `genie-api` `bind_addr` (out of scope), (c) a fixed-target test literal in `routes.rs`, and (d) two pre-existing `genie-core/ha/client.rs` references unrelated to this issue.

A maintainer with a Jetson can verify end-to-end by editing `geniepod.toml` to `[services.homeassistant].url = "http://<lan-ip>:8123/"` and running `genie-ctl health` — the HA row should now report `[OK]` instead of `[DOWN]`. Removing the section should drop the HA row entirely.

## Test plan

- [ ] CI green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `--no-default-features` clippy/test, aarch64 cross-compile.
- [ ] Jetson check (optional): point `[services.homeassistant].url` at a non-loopback HA, run `genie-ctl health` and `genie-ctl diag`, confirm HA is `[OK]` / `UP`. Remove the HA section, re-run; confirm the row is gone.
- [ ] Jetson check (optional): `genie-ctl support-bundle /tmp/bundle.json` and confirm `services[].addr` for `genie-api` reflects `[services.api].url`'s host:port.

## Notes for reviewers

- Backward-compatible TOML: `[services.api]` is serde-defaulted, so existing deployments without that section keep parsing. The shipped default `deploy/config/geniepod.toml` now includes the section explicitly so it's discoverable.
- When `[services.homeassistant]` is absent the HA probe is **omitted** entirely (matches one of the two options in the issue's acceptance criteria). Happy to switch to "label as not configured" if you prefer to keep the row visible.
- `crates/genie-api/src/main.rs`'s own listen `bind_addr` is untouched — issue marks that as out of scope.