### PR TITLE
fix(audit): surface IO failures in AuditLogger and ToolAuditLogger

### DIFF
--- a/crates/genie-core/src/tools/actuation.rs
+++ b/crates/genie-core/src/tools/actuation.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::fs::{File, OpenOptions};
+use std::io;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -284,6 +286,57 @@ pub struct AuditEvent {
     pub undo_of: Option<u64>,
 }
 
+/// Errors that can occur while appending an event to an on-disk audit log.
+///
+/// Each variant identifies which underlying step failed so callers can
+/// distinguish e.g. a misconfigured path (`CreateDir` / `Open`) from a
+/// disk-pressure failure (`Write`). The inner errors are preserved so the
+/// `io::ErrorKind` and serde detail remain available for structured logging.
+#[derive(Debug)]
+pub enum AuditError {
+    CreateDir(io::Error),
+    Open(io::Error),
+    Serialize(serde_json::Error),
+    Write(io::Error),
+}
+
+impl fmt::Display for AuditError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CreateDir(err) => write!(f, "audit log: create parent directory: {err}"),
+            Self::Open(err) => write!(f, "audit log: open file for append: {err}"),
+            Self::Serialize(err) => write!(f, "audit log: serialize event: {err}"),
+            Self::Write(err) => write!(f, "audit log: write line: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for AuditError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CreateDir(err) | Self::Open(err) | Self::Write(err) => Some(err),
+            Self::Serialize(err) => Some(err),
+        }
+    }
+}
+
+/// Append a single JSON-encoded line to `path`, creating parent directories
+/// as needed. Returns the specific `AuditError` for the failed step so the
+/// caller can surface it to logs / metrics. Shared by `AuditLogger` and
+/// `ToolAuditLogger` so both have identical behavior under IO failure.
+pub(crate) fn append_json_line<T: Serialize>(path: &Path, payload: &T) -> Result<(), AuditError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(AuditError::CreateDir)?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(AuditError::Open)?;
+    let line = serde_json::to_string(payload).map_err(AuditError::Serialize)?;
+    writeln!(file, "{line}").map_err(AuditError::Write)
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct AuditLogger {
     path: Option<PathBuf>,
@@ -302,21 +355,31 @@ impl AuditLogger {
         }
     }
 
-    pub fn append(&self, event: AuditEvent) {
+    /// Append an audit event. Returns the specific failure kind on IO or
+    /// serialization error so callers can log structured detail (or refuse
+    /// to proceed if their security posture is "no audit, no action").
+    ///
+    /// When the logger is `disabled()`, returns `Ok(())` without doing any IO.
+    pub fn append(&self, event: AuditEvent) -> Result<(), AuditError> {
         let Some(path) = &self.path else {
-            return;
+            return Ok(());
         };
         let _guard = self.lock.lock().expect("audit logger lock");
-        if let Some(parent) = path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+        append_json_line(path, &event)
+    }
+
+    /// Convenience wrapper for callers that have no recovery path: appends
+    /// the event and, on failure, emits a `tracing::error!` with the path and
+    /// underlying error. The error is intentionally swallowed — use [`append`]
+    /// directly if you need to react to the failure.
+    pub fn append_or_log(&self, event: AuditEvent) {
+        if let Err(err) = self.append(event) {
+            tracing::error!(
+                error = %err,
+                path = ?self.path,
+                "audit event dropped due to IO failure"
+            );
         }
-        let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) else {
-            return;
-        };
-        let Ok(line) = serde_json::to_string(&event) else {
-            return;
-        };
-        let _ = writeln!(file, "{line}");
     }
 
     pub fn path(&self) -> Option<&Path> {
@@ -522,37 +585,121 @@ mod tests {
         let _ = std::fs::remove_file(&path);
         let logger = AuditLogger::new(&path);
 
-        logger.append(AuditEvent {
-            ts_ms: 100,
-            status: AuditStatus::Executed,
-            origin: RequestOrigin::Voice,
-            entity: "kitchen light".into(),
-            action: "turn_on".into(),
-            value: None,
-            reason: "home action executed".into(),
-            token: None,
-            confidence: Some(0.9),
-            action_id: Some(1),
-            undo_of: None,
-        });
-        logger.append(AuditEvent {
-            ts_ms: 200,
-            status: AuditStatus::ConfirmationIssued,
-            origin: RequestOrigin::Voice,
-            entity: "front door".into(),
-            action: "unlock".into(),
-            value: None,
-            reason: "needs confirmation".into(),
-            token: Some("act-test".into()),
-            confidence: None,
-            action_id: None,
-            undo_of: None,
-        });
+        logger
+            .append(AuditEvent {
+                ts_ms: 100,
+                status: AuditStatus::Executed,
+                origin: RequestOrigin::Voice,
+                entity: "kitchen light".into(),
+                action: "turn_on".into(),
+                value: None,
+                reason: "home action executed".into(),
+                token: None,
+                confidence: Some(0.9),
+                action_id: Some(1),
+                undo_of: None,
+            })
+            .expect("append should succeed against a writable temp path");
+        logger
+            .append(AuditEvent {
+                ts_ms: 200,
+                status: AuditStatus::ConfirmationIssued,
+                origin: RequestOrigin::Voice,
+                entity: "front door".into(),
+                action: "unlock".into(),
+                value: None,
+                reason: "needs confirmation".into(),
+                token: Some("act-test".into()),
+                confidence: None,
+                action_id: None,
+                undo_of: None,
+            })
+            .expect("append should succeed against a writable temp path");
 
         let actions = logger.read_recent_executed_actions(10);
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].entity, "kitchen light");
         assert_eq!(actions[0].inverse_action.as_deref(), Some("turn_off"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    fn sample_audit_event() -> AuditEvent {
+        AuditEvent {
+            ts_ms: 1,
+            status: AuditStatus::Executed,
+            origin: RequestOrigin::Repl,
+            entity: "kitchen light".into(),
+            action: "turn_on".into(),
+            value: None,
+            reason: "test".into(),
+            token: None,
+            confidence: None,
+            action_id: Some(1),
+            undo_of: None,
+        }
+    }
+
+    #[test]
+    fn append_returns_ok_when_logger_is_disabled() {
+        let logger = AuditLogger::disabled();
+        // Disabled loggers must succeed silently — they have no path to fail on.
+        assert!(logger.append(sample_audit_event()).is_ok());
+        // The append_or_log wrapper must also be a no-op without panicking.
+        logger.append_or_log(sample_audit_event());
+    }
+
+    #[test]
+    fn append_returns_error_when_parent_path_is_a_file() {
+        // Force a deterministic IO failure: place a regular file where the
+        // audit log's parent directory would be. `create_dir_all` and
+        // `OpenOptions::open` will both refuse, producing `CreateDir` (Unix)
+        // or `Open` (Windows) depending on platform; we accept either.
+        let dir = std::env::temp_dir().join(format!(
+            "geniepod-audit-blocked-parent-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("setup: create temp dir");
+        let blocking_file = dir.join("blocking_file");
+        std::fs::write(&blocking_file, "not a directory")
+            .expect("setup: create blocking regular file");
+        let audit_path = blocking_file.join("audit.jsonl");
+
+        let logger = AuditLogger::new(&audit_path);
+        let err = logger
+            .append(sample_audit_event())
+            .expect_err("append must surface the IO failure");
+        assert!(
+            matches!(err, AuditError::CreateDir(_) | AuditError::Open(_)),
+            "expected CreateDir or Open variant, got {err:?}"
+        );
+        // And the convenience wrapper must swallow the same error without
+        // panicking — that contract is what callers depend on.
+        logger.append_or_log(sample_audit_event());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn append_writes_jsonl_line_with_event_fields() {
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-audit-roundtrip-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let logger = AuditLogger::new(&path);
+
+        logger
+            .append(sample_audit_event())
+            .expect("append should succeed against a writable temp path");
+
+        let contents = std::fs::read_to_string(&path).expect("read back audit file");
+        let line = contents.lines().next().expect("at least one line written");
+        let parsed: AuditEvent =
+            serde_json::from_str(line).expect("written line round-trips as AuditEvent");
+        assert_eq!(parsed.entity, "kitchen light");
+        assert_eq!(parsed.status, AuditStatus::Executed);
+
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -4,15 +4,13 @@ use genie_common::config::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use super::actuation::{
-    ActionLedger, AuditEvent, AuditLogger, AuditStatus, ConfirmationManager, PendingConfirmation,
-    RecordedAction, RequestOrigin, now_ms,
+    ActionLedger, AuditError, AuditEvent, AuditLogger, AuditStatus, ConfirmationManager,
+    PendingConfirmation, RecordedAction, RequestOrigin, append_json_line, now_ms,
 };
 use super::home;
 use super::timer;
@@ -103,21 +101,28 @@ impl ToolAuditLogger {
         }
     }
 
-    fn append(&self, event: ToolAuditEvent) {
+    /// Append a tool-audit event. Mirrors `AuditLogger::append` — see that
+    /// method for the failure semantics. Returns `Ok(())` when the logger is
+    /// disabled.
+    fn append(&self, event: ToolAuditEvent) -> Result<(), AuditError> {
         let Some(path) = &self.path else {
-            return;
+            return Ok(());
         };
         let _guard = self.lock.lock().expect("tool audit logger lock");
-        if let Some(parent) = path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+        append_json_line(path, &event)
+    }
+
+    /// Append-and-log-on-failure wrapper. Use this from sites with no
+    /// recovery path; use [`append`] when the caller needs to react to the
+    /// failure (e.g. a "no audit, no action" code path).
+    fn append_or_log(&self, event: ToolAuditEvent) {
+        if let Err(err) = self.append(event) {
+            tracing::error!(
+                error = %err,
+                path = ?self.path,
+                "tool-audit event dropped due to IO failure"
+            );
         }
-        let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) else {
-            return;
-        };
-        let Ok(line) = serde_json::to_string(&event) else {
-            return;
-        };
-        let _ = writeln!(file, "{line}");
     }
 
     fn path(&self) -> Option<&std::path::Path> {
@@ -551,7 +556,7 @@ impl ToolDispatcher {
         started: Instant,
         result: &ToolResult,
     ) {
-        self.tool_audit_logger.append(ToolAuditEvent {
+        self.tool_audit_logger.append_or_log(ToolAuditEvent {
             ts_ms: now_ms(),
             tool: call.name.clone(),
             origin: exec_ctx.request_origin,
@@ -591,7 +596,7 @@ impl ToolDispatcher {
                 "actuation from '{}' is not allowed by channel policy",
                 exec_ctx.request_origin.as_policy_key()
             );
-            self.audit_logger.append(AuditEvent {
+            self.audit_logger.append_or_log(AuditEvent {
                 ts_ms: now_ms(),
                 status: AuditStatus::BlockedPolicy,
                 origin: exec_ctx.request_origin,
@@ -611,7 +616,7 @@ impl ToolDispatcher {
             .check_and_record(&self.actuation_safety, exec_ctx.request_origin)
         {
             let reason = err.to_string();
-            self.audit_logger.append(AuditEvent {
+            self.audit_logger.append_or_log(AuditEvent {
                 ts_ms: now_ms(),
                 status: AuditStatus::BlockedRuntime,
                 origin: exec_ctx.request_origin,
@@ -658,7 +663,7 @@ impl ToolDispatcher {
                         confidence,
                     )
                 };
-                self.audit_logger.append(AuditEvent {
+                self.audit_logger.append_or_log(AuditEvent {
                     ts_ms: now_ms(),
                     status: AuditStatus::Executed,
                     origin: exec_ctx.request_origin,
@@ -681,7 +686,7 @@ impl ToolDispatcher {
                     &reason,
                     exec_ctx.request_origin,
                 );
-                self.audit_logger.append(AuditEvent {
+                self.audit_logger.append_or_log(AuditEvent {
                     ts_ms: now_ms(),
                     status: AuditStatus::ConfirmationIssued,
                     origin: exec_ctx.request_origin,
@@ -708,7 +713,7 @@ impl ToolDispatcher {
                 } else {
                     AuditStatus::Failed
                 };
-                self.audit_logger.append(AuditEvent {
+                self.audit_logger.append_or_log(AuditEvent {
                     ts_ms: now_ms(),
                     status,
                     origin: exec_ctx.request_origin,
@@ -2242,5 +2247,54 @@ mod tests {
         assert!(output.contains("Person-scoped memories: 0"));
         assert!(output.contains("Private memories: 0"));
         assert!(output.contains("Restricted memories: 0"));
+    }
+
+    fn sample_tool_audit_event() -> ToolAuditEvent {
+        ToolAuditEvent {
+            ts_ms: 1,
+            tool: "calc".into(),
+            origin: RequestOrigin::Repl,
+            success: true,
+            duration_ms: 1,
+            argument_keys: vec!["expr".into()],
+            output_chars: 3,
+        }
+    }
+
+    #[test]
+    fn tool_audit_logger_disabled_appends_ok() {
+        // Disabled mirror of the actuation logger test: no path → no IO → Ok.
+        let logger = ToolAuditLogger::default();
+        assert!(logger.append(sample_tool_audit_event()).is_ok());
+        logger.append_or_log(sample_tool_audit_event());
+    }
+
+    #[test]
+    fn tool_audit_logger_surfaces_blocked_parent_error() {
+        // Same parent-is-a-file trick used for the actuation logger; ensures
+        // ToolAuditLogger now reports IO failures instead of silently dropping
+        // the event.
+        let dir = std::env::temp_dir().join(format!(
+            "geniepod-tool-audit-blocked-parent-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("setup: create temp dir");
+        let blocking_file = dir.join("blocking_file");
+        std::fs::write(&blocking_file, "not a directory")
+            .expect("setup: create blocking regular file");
+        let audit_path = blocking_file.join("tool-audit.jsonl");
+
+        let logger = ToolAuditLogger::new(&audit_path);
+        let err = logger
+            .append(sample_tool_audit_event())
+            .expect_err("append must surface the IO failure");
+        assert!(
+            matches!(err, AuditError::CreateDir(_) | AuditError::Open(_)),
+            "expected CreateDir or Open variant, got {err:?}"
+        );
+        logger.append_or_log(sample_tool_audit_event());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #131. `AuditLogger::append` and `ToolAuditLogger::append` previously returned `()` and silently swallowed four IO failure modes each (mkdir, open, serialize, write). A disk-full or permission-denied condition produced gaps in the audit log with no log line, no metric, and no return signal — defeating the log's forensic purpose. Both methods now return `Result<(), AuditError>`, and a new `append_or_log` wrapper preserves today's log-and-continue caller behaviour while routing failures through `tracing::error!`.

## Changes

- Added `pub enum AuditError { CreateDir, Open, Serialize, Write }` with `Display` + `std::error::Error` impls in `crates/genie-core/src/tools/actuation.rs`. Variants are deliberately narrow (one per failure step) so structured-log filters and future metric labels can distinguish them.
- Extracted `pub(crate) fn append_json_line<T: Serialize>(path, payload) -> Result<(), AuditError>` so both loggers share a single, tested IO path.
- Changed `AuditLogger::append` and `ToolAuditLogger::append` to return `Result<(), AuditError>`. Disabled loggers continue to return `Ok(())` without doing IO.
- Added `append_or_log` on both loggers. Emits `tracing::error!` on failure with the path and underlying error, then continues. Callers use the bare `append` when they need to react to the failure (e.g. a future "no audit, no action" code path).
- Converted the six fire-and-forget call sites in `tools/dispatch.rs` to `append_or_log`, preserving the prior log-and-continue behaviour while making failures visible in `journalctl -u genie-core`.
- Added unit tests covering: disabled-logger Ok path, JSONL round-trip, and a cross-platform `AuditError::CreateDir | AuditError::Open` surfacing test (uses a regular file at the parent path to force a deterministic IO failure on both Unix and Windows). Updated `audit_logger_reads_recent_executed_actions` to consume the new `Result`.

No new dependencies. A metrics counter (`audit_writes_failed_total`) would be a natural follow-up once the workspace introduces a metrics infrastructure — deliberately out of scope here per CONTRIBUTING.md's stance on new runtime deps.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

No Jetson hardware available. Dev host is Windows 11 + WSL2 Ubuntu 26.04 LTS (Rust 1.95.0 / cargo 1.95.0, matching the repo's pinned toolchain). The workspace doesn't compile directly on the Windows host because `genie-core` uses unconditional Unix-only APIs (`libc::gmtime_r`, `tokio::net::UnixStream`), so I ran every gate inside WSL Linux against the same on-disk worktree via `/mnt/c`:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo clippy -p genie-core -p genie-ctl --no-default-features --all-targets --locked -- -D warnings
cargo test --workspace --locked --all-targets
cargo test --workspace --locked --doc
```

I also re-read each of the six caller sites in `tools/dispatch.rs` to confirm none of them depend on `append` returning early on a soft-failure path — they're all fire-and-forget, so the `append_or_log` rename is behaviour-preserving for the happy path and behaviour-improving for the failure path.

### What I observed

`cargo fmt --all -- --check`: clean (no output).

`cargo clippy --workspace --all-targets --locked -- -D warnings`:

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 53.62s
```

`cargo clippy -p genie-core -p genie-ctl --no-default-features --all-targets --locked -- -D warnings`:

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 39.98s
```

`cargo test --workspace --locked --all-targets` — the new and updated tests that exercise the changed code paths:

```
test tools::actuation::tests::append_returns_ok_when_logger_is_disabled ... ok
test tools::actuation::tests::append_returns_error_when_parent_path_is_a_file ... ok
test tools::actuation::tests::append_writes_jsonl_line_with_event_fields ... ok
test tools::actuation::tests::audit_logger_reads_recent_executed_actions ... ok
test tools::dispatch::tests::tool_audit_logger_disabled_appends_ok ... ok
test tools::dispatch::tests::tool_audit_logger_surfaces_blocked_parent_error ... ok
```

Workspace-wide summary across the four test binaries that ran in this run: `6 passed; 33 passed; 423 passed; 2 passed`, plus `17 passed; 1 failed` in the `tool_dispatch_test` integration target.

The single failure is **environment-only and unrelated to this change** — `jetson_lifecycle_scripts_are_valid_shell`, which does `bash -n` against `deploy/scripts/*.sh`. The files on `origin/main` are LF in the git index (verified via `git show origin/main:deploy/scripts/start_all.sh | od -c`) but Git-for-Windows' `core.autocrlf` rewrites them to CRLF on checkout, and bash on Linux chokes on `\r`. The Linux CI runners check out with LF and this test passes on every PR — and `git diff --stat origin/main` confirms this branch touches zero shell scripts (only `actuation.rs` and `dispatch.rs`).

`cargo test --workspace --locked --doc`:

```
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s   (genie_common)
test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s   (genie_core)
test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s   (genie_skill_sdk)
```

## Test plan

For a reviewer with Jetson hardware who wants to confirm the runtime behaviour end-to-end: point `[actuation].audit_path` at a read-only directory (e.g. `sudo install -d -m 0555 /var/lib/geniepod/audit-readonly`, then set `audit_path = "/var/lib/geniepod/audit-readonly/actuation.jsonl"`) and issue any actuation via the dashboard or voice. Without this fix the audit file silently stays empty; with this fix `journalctl -u genie-core` shows `audit event dropped due to IO failure error="audit log: open file for append: Permission denied" path=Some("/var/lib/geniepod/audit-readonly/actuation.jsonl")` per attempt, and the actuation itself still completes (log-and-continue behaviour preserved).

## Notes for reviewers

- `pub enum AuditError` is the only new public API surface in `genie-core`.
- I left `append` itself `pub` (returning `Result`) rather than crate-private, because a future evidence-trail caller (#24) may want a "no audit, no action" posture, which requires the error to be visible. Easy to demote if you'd prefer.
- `append_json_line` is `pub(crate)` only — purely a dedup helper between the two loggers in the same crate.
- I did not change behaviour at the six existing call sites beyond "now logs when it fails". Open to feedback if any of them should instead refuse to proceed when the audit cannot be recorded.
