### PR TITLE
docs: split voice pipeline ownership into genie-voice-runtime

### DIFF
--- a/.github/ISSUE_TEMPLATE/voice_pipeline.yml
+++ b/.github/ISSUE_TEMPLATE/voice_pipeline.yml
@@ -1,14 +1,19 @@
 name: Voice pipeline issue
-description: Wake word, VAD, STT (Whisper), LLM, TTS (Piper), or first-reply latency banner — anything in the voice loop.
+description: Wake word, VAD, STT (Whisper), LLM, TTS (Piper), or first-reply latency banner — transitional voice issues in GenieClaw.
 title: "[voice] "
 labels: ["bug", "voice"]
 body:
   - type: markdown
     attributes:
       value: |
-        Use this template for any issue in the **wake → VAD → STT → LLM → TTS**
-        loop. The structured fields collect the context needed to diagnose
-        latency, accuracy, or routing problems without a back-and-forth.
+        Use this template for current GenieClaw issues in the **wake → VAD → STT
+        → LLM → TTS** loop. The structured fields collect the context needed to
+        diagnose latency, accuracy, or routing problems without a back-and-forth.
+
+        New voice-runtime implementation work belongs in
+        https://github.com/GeniePod/genie-voice-runtime. GenieClaw should remain
+        the agent layer: transcript in, policy/tools/memory/home intent,
+        response text out.
 
   - type: textarea
     id: summary

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,6 +6,7 @@ This repository should be understood as the Rust agent runtime that sits above:
 
 - custom Jetson hardware
 - GenieOS, the custom L4T and system image layer
+- `genie-voice-runtime`, the external voice runtime for wake/VAD/STT/TTS/audio
 - `genie-home-runtime`, the future AI-native home automation runtime
 - `genie-ai-runtime`, the future Jetson-only LLM inference runtime
 
@@ -25,9 +26,10 @@ Application Layer
   Web app, mobile app, dashboard, setup, memory manager, confirmations
 
 GenieClaw Agent Layer
-  Offline voice, memory, tools, skills, channel adapters, agent policy
+  Agent policy, memory, tools, skills, channel adapters, spoken behavior
 
 Runtime Layer
+  genie-voice-runtime: wake, VAD, STT, TTS, audio streaming
   genie-home-runtime: device graph, automations, actuation safety, MCP
   genie-ai-runtime: Jetson-only LLM inference, CUDA kernels, model serving
 
@@ -42,7 +44,7 @@ Hardware Layer
 
 GenieClaw owns the human-facing intelligence loop:
 
-- wake/speech interaction and spoken response behavior
+- spoken response behavior and voice-session policy
 - prompt construction and reasoning-mode selection
 - memory capture, policy, recall, and dashboard management
 - skill and tool routing
@@ -68,6 +70,7 @@ These responsibilities belong in lower or upper layers:
 - Matter/Thread/Zigbee/BLE device graph and automation engine: `genie-home-runtime`
 - final physical actuation safety checks: `genie-home-runtime`
 - llama.cpp fork, CUDA kernels, model memory planner: `genie-ai-runtime`
+- wake word, VAD, STT, TTS, ALSA/audio-device handling, denoise, and AEC: `genie-voice-runtime`
 - full product app, account UX, mobile push, installer workflows: application layer
 
 This repo can keep transitional implementations while those layers are still forming, but the code should be structured so those boundaries can be replaced by stable clients.
@@ -79,6 +82,7 @@ The current repo still contains pragmatic adapters used to ship on Jetson now.
 | Current adapter | Long-term replacement | Notes |
 | --- | --- | --- |
 | `genie-ai-runtime` OpenAI-compatible client (default on Jetson) | `llama.cpp` client (selectable fallback) | Both backends ship behind the `LlmClient` facade; per-deployment selection via `[services.llm].backend` in `geniepod.toml`. Backend identity surfaces in `/api/health`, startup logs, and `genie-ctl status`. |
+| In-repo voice pipeline under `crates/genie-core/src/voice/` and `voice_loop.rs` | [`genie-voice-runtime`](https://github.com/GeniePod/genie-voice-runtime) | Keep current code as a transitional Jetson bring-up path. New wake/VAD/STT/TTS/audio ownership should move to the external runtime. GenieClaw should consume transcripts and issue speak commands. |
 | Home Assistant provider | `genie-home-runtime` MCP/API client | Keep HA-specific behavior behind `ha/` and tools/home boundaries. |
 | Actuation safety in `genie-core` | final safety in `genie-home-runtime` | Keep current safety as an agent-side guard and confirmation layer. |
 | `genie-api` dashboard | application layer | Keep it operational and lightweight; avoid making it the long-term product app. |
@@ -94,7 +98,7 @@ The repo should trend toward these conceptual modules, even if existing file nam
 | Agent orchestration | `crates/genie-core/src/server.rs`, `repl.rs`, `voice_loop.rs`, `reasoning.rs`, `prompt.rs` |
 | AI runtime client | `crates/genie-core/src/llm/` |
 | Home runtime client | `crates/genie-core/src/ha/`, `tools/home.rs` |
-| Voice pipeline | `crates/genie-core/src/voice/`, `voice_loop.rs` |
+| Voice runtime client | transitional `crates/genie-core/src/voice/`, `voice_loop.rs`; target external client for `genie-voice-runtime` |
 | Memory system | `crates/genie-core/src/memory/`, `conversation.rs` |
 | Tool and skill routing | `crates/genie-core/src/tools/`, `skills/` |
 | Channel adapters | `server.rs`, `repl.rs`, `telegram.rs`, `genie-ctl` |
@@ -110,6 +114,11 @@ runtime clients -> lower runtimes or transitional external systems
 ```
 
 Code in memory, voice, prompt, and channels should not learn Home Assistant internals. Code in agent orchestration should not learn model-server implementation details beyond the `LlmClient` contract.
+
+Voice code has one additional rule: GenieClaw may own spoken agent behavior,
+but it should not own the long-term audio pipeline. Wake word, VAD, STT, TTS,
+audio-device handling, denoise, AEC, and streaming voice events belong in
+`genie-voice-runtime`.
 
 ## Process Topology Today
 
@@ -138,10 +147,12 @@ Target deployment:
 genie-ai-runtime
         ^
         |
+genie-voice-runtime ---- transcript/speak events
+        ^                         |
+        |                         v
 genie-claw
         |
         +---- web/mobile apps
-        +---- local voice pipeline
         +---- skills and channels
         v
 genie-home-runtime
@@ -215,6 +226,7 @@ Short-term rule:
 Long-term direction:
 
 - `genie-claw`: agent layer repository and product brain
+- `genie-voice-runtime`: voice I/O runtime for wake, VAD, STT, TTS, and audio streaming
 - `genie-home-runtime`: home automation and physical actuation runtime
 - `genie-ai-runtime`: Jetson-only inference runtime
 - `genie-os`: custom L4T image and hardware bring-up layer
@@ -227,6 +239,7 @@ The clean architecture path is incremental:
 2. Keep Home Assistant and LLM backends behind narrow adapter traits (LLM side resolved via the `LlmClient` facade in `crates/genie-core/src/llm/`).
 3. Move physical actuation authority downward into `genie-home-runtime` when it exists.
 4. Move Jetson model-server specialization downward into `genie-ai-runtime`.
-5. Keep GenieClaw focused on voice, memory, skills, tools, channels, and household interaction.
+5. Move voice/audio pipeline ownership downward into `genie-voice-runtime`.
+6. Keep GenieClaw focused on agent policy, memory, skills, tools, channels, and household interaction.
 
 This prevents the agent repo from becoming a single large mixed runtime while still allowing today’s Jetson appliance to keep working.

--- a/README.md
+++ b/README.md
@@ -91,10 +91,13 @@ The only network egress GenieClaw makes by default is the optional
 no account, no telemetry). Disable it via `[web_search] enabled = false`
 and the appliance is fully air-gappable.
 
-GenieClaw owns the **agent layer**: prompts, memory, tool routing, voice
-orchestration, channel adapters. It does **not** own the LLM kernels (see
-[`genie-ai-runtime`](https://github.com/GeniePod/genie-ai-runtime)) or the
-eventual device-control runtime (`genie-home-runtime`, planned). See
+GenieClaw owns the **agent layer**: prompts, memory, tool routing, smart-home
+intent, spoken response behavior, and channel adapters. It does **not** own the
+LLM kernels (see
+[`genie-ai-runtime`](https://github.com/GeniePod/genie-ai-runtime)), the
+long-term voice pipeline (see
+[`genie-voice-runtime`](https://github.com/GeniePod/genie-voice-runtime)), or
+the eventual device-control runtime (`genie-home-runtime`, planned). See
 [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full stack.
 
 ## Roadmap
@@ -169,7 +172,7 @@ world for the home.
 This repo is the Rust agent runtime for a very specific product shape:
 
 - a Jetson-first home AI appliance
-- a full local voice pipeline: wake word, STT, LLM orchestration, tools, and TTS
+- spoken interaction through a transitional local voice adapter while the pipeline moves to `genie-voice-runtime`
 - a local household memory system
 - safe handoff to a home-control runtime
 - transitional Home Assistant support while `genie-home-runtime` is not yet split out
@@ -189,9 +192,10 @@ components:
 
 - custom Jetson hardware
 - `genie-os`: custom L4T image, drivers, OTA, and service supervision
+- `genie-voice-runtime`: wake word, VAD, STT, TTS, audio streaming, and voice session protocol
 - `genie-home-runtime`: Rust AI-native home automation runtime and final actuation safety layer
 - `genie-ai-runtime`: Jetson-only C++ LLM runtime customized from `llama.cpp`
-- `genie-claw`: this repo, the Rust agent layer for voice, memory, tools, skills, and channels
+- `genie-claw`: this repo, the Rust agent layer for prompt policy, memory, tools, skills, smart-home intent, and channels
 - application layer: web and mobile app surfaces
 
 This repo should not become all five layers. It can keep transitional adapters
@@ -202,7 +206,7 @@ OS bring-up, and product apps behind explicit boundaries.
 
 Today, the system can:
 
-- run a local LLM-backed chat and voice loop
+- run local LLM-backed chat and the current transitional voice loop
 - stay flexible around local model choice inside the Jetson deployment
 - expose a local HTTP API and web UI
 - store conversation history and household memory in SQLite
@@ -244,6 +248,7 @@ agent operation:
 - a general-purpose agent platform
 - a messaging-bot framework
 - the custom Jetson OS layer
+- the long-term voice/audio runtime
 - the final home automation and actuation runtime
 - the Jetson CUDA inference runtime
 - the whole product UI or mobile app
@@ -296,7 +301,7 @@ assistant that still feels fast and reliable on 8 GB unified memory.
 
 | Crate | Purpose |
 |-------|---------|
-| `genie-core` | Main runtime: prompt building, tools, memory, voice loop, HTTP API |
+| `genie-core` | Main runtime: prompt building, tools, memory, HTTP API, and transitional voice adapter |
 | `genie-common` | Shared config, mode types, and tegrastats parsing |
 | `genie-ctl` | Local CLI for chat, status, tools, health, and diagnostics |
 | `genie-governor` | Resource governor and service lifecycle controller |

--- a/doc/README.md
+++ b/doc/README.md
@@ -11,7 +11,7 @@ repo boundary inside the larger Genie ecosystem:
 - core subsystems such as memory, voice, security, and connectivity
 - deployment assets and operational guidance
 - repository layout and code ownership map
-- long-term boundary with `genie-os`, `genie-home-runtime`, `genie-ai-runtime`, and app layers
+- long-term boundary with `genie-os`, `genie-voice-runtime`, `genie-home-runtime`, `genie-ai-runtime`, and app layers
 
 Where current code is transitional, the docs call that out explicitly.
 
@@ -36,7 +36,7 @@ Where current code is transitional, the docs call that out explicitly.
 GenieClaw is a local-first home AI runtime centered on `genie-core`.
 
 - `genie-core` is the main orchestrator.
-  It serves the chat API on port `3000`, can run a local REPL on stdin, and can run the voice loop.
+  It serves the chat API on port `3000`, can run a local REPL on stdin, and currently runs the transitional voice adapter.
 - `genie-api` is a separate dashboard/status service.
   It exposes dashboard HTML and system status backed by governor and health databases.
 - `genie-governor` manages mode changes, memory-pressure reactions, and service lifecycle decisions.
@@ -68,4 +68,4 @@ There are a few intentional limits:
 
 - Hardware behavior that depends on a specific Jetson image, kernel, or manual systemd override is documented as operational guidance, not as a stable code contract.
 - `llama.cpp`, Home Assistant, Piper, Whisper, and Telegram Bot API internals are external dependencies. This repo documents how GenieClaw integrates with them, not their full upstream behavior.
-- `genie-os`, `genie-home-runtime`, and `genie-ai-runtime` are documented as architectural boundaries unless code in this repo already implements a transitional adapter.
+- `genie-os`, `genie-voice-runtime`, `genie-home-runtime`, and `genie-ai-runtime` are documented as architectural boundaries unless code in this repo already implements a transitional adapter.

--- a/doc/core-subsystems.md
+++ b/doc/core-subsystems.md
@@ -191,23 +191,34 @@ Responsibilities:
 - ingest TOML and text sources into memory
 - normalize and deduplicate profile facts
 
-## Voice Stack
+## Voice Runtime Boundary
 
-Source:
+Current transitional source:
 
 - `crates/genie-core/src/voice_loop.rs`
 - `crates/genie-core/src/voice/*.rs`
 
-Responsibilities:
+Long-term owner:
 
-- audio recording and wake-word integration
-- STT client/CLI execution
-- conservative voice intent gating for shared-room wake flows
-- speaker-identity provider boundary, including optional local biometric profile matching and memory-context plumbing into voice read paths
-- language detection and language-specific TTS model selection
-- output formatting for speech
-- streaming spoken responses
-- basic DSP, gating, echo cancellation, and VAD support
+- [`genie-voice-runtime`](https://github.com/GeniePod/genie-voice-runtime)
+
+GenieClaw should own:
+
+- spoken agent behavior
+- transcript-to-agent routing
+- response text generation
+- memory/tool/home-intent policy for voice-origin requests
+- shared-room safety policy
+
+`genie-voice-runtime` should own:
+
+- wake word
+- VAD
+- STT
+- TTS
+- capture/playback device handling
+- denoise and acoustic echo control
+- voice session streaming events
 
 Notable modules:
 
@@ -222,6 +233,10 @@ Notable modules:
 - `dsp.rs`
 - `aec.rs`
 - `vad.rs`
+
+These modules remain a Jetson alpha bring-up path until the external runtime is
+production-ready. New voice-pipeline implementation should target
+`genie-voice-runtime` unless it is strictly an agent-layer behavior change.
 
 ## Security And Guardrails
 

--- a/doc/implementation-status.md
+++ b/doc/implementation-status.md
@@ -28,7 +28,7 @@ Status labels:
 | Home action safety in agent layer | Implemented | `crates/genie-core/src/tools/actuation.rs`, `crates/genie-core/src/ha/policy.rs` | Origin allowlist, target confidence thresholds, sensitive-action confirmation tokens, rate limits, action ledger, bounded undo, and append-only audit log. |
 | Runtime contract | Implemented | `crates/genie-core/src/runtime_contract.rs`, `crates/genie-core/src/server.rs` | Prompt/tool/policy/hydration fingerprints, optional drift detection, and boot contract log. |
 | Household security posture | Implemented | `crates/genie-api/src/routes.rs`, `crates/genie-core/src/security/*` | Dashboard exposes redacted posture instead of raw config. Security helpers include audit, credential isolation, env sanitization, injection scanning, loop guard, sandbox helpers, and taint tracking. |
-| Voice pipeline modules | Implemented | `crates/genie-core/src/voice_loop.rs`, `crates/genie-core/src/voice/*` | ALSA recording path, STT client/CLI boundary, language detection, intent gating, formatting, TTS, streaming, VAD/DSP/noise/AEC modules. Production quality depends on installed audio hardware and models. |
+| Voice pipeline modules | Transitional | `crates/genie-core/src/voice_loop.rs`, `crates/genie-core/src/voice/*` | Current Jetson alpha bring-up path. Long-term ownership belongs in `genie-voice-runtime`; GenieClaw should consume transcripts and issue speak commands rather than own wake/VAD/STT/TTS/audio. |
 | Optional local speaker identity | Implemented | `crates/genie-core/src/voice/identity.rs`, `crates/genie-ctl/src/main.rs` | Local WAV-derived profile enrollment/matching and voice memory-context routing. This is household routing, not hostile-user authentication. |
 | Native skill loading | Implemented | `crates/genie-core/src/skills/*`, `crates/genie-skill-sdk/*` | Loads native `.so` skills through a narrow ABI, exposes skills as tools, and audits sidecar manifest metadata. |
 | Skill policy | Implemented | `crates/genie-common/src/config.rs`, `crates/genie-core/src/skills/loader.rs` | Can require manifests, require signature material presence, and deny permission labels. Cryptographic signature verification is not implemented. |
@@ -57,6 +57,7 @@ Status labels:
 | --- | --- | --- |
 | `genie-home-runtime` | Planned / separate repo | Rust AI-native home automation engine, device graph, automations, MCP server, deterministic final physical safety layer. |
 | `genie-ai-runtime` | Planned / separate repo | Jetson-only C++ inference runtime customized from `llama.cpp`, optimized CUDA kernels, and memory planner. |
+| `genie-voice-runtime` | Initial / separate repo | External voice runtime for wake, VAD, STT, TTS, audio streaming, and voice session protocol. |
 | `genie-os` | Planned / separate repo | Custom L4T image, board bring-up, drivers, OTA base image, service supervision, ESP-Hosted-NG OS integration. |
 | Full Matter/Thread/Zigbee/BLE production stack | Planned outside this repo | Lower connectivity/home-runtime layers. |
 | Full vector/cuVS semantic memory backend | Planned design only | `VECTOR_MEMORY.md` describes the rollout. Current runtime uses SQLite FTS, not embeddings/vector search. |

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -20,9 +20,10 @@ The long-term Genie stack is split by responsibility:
 
 - custom Jetson hardware
 - `genie-os` for custom L4T, drivers, OTA, diagnostics, and service supervision
+- `genie-voice-runtime` for wake/VAD/STT/TTS/audio streaming and voice session events
 - `genie-home-runtime` for device graph, automations, MCP, and final actuation safety
 - `genie-ai-runtime` for Jetson-only LLM inference optimization
-- `genie-claw` for voice, memory, tools, skills, and agent interaction
+- `genie-claw` for agent policy, memory, tools, skills, smart-home intent, and interaction
 - web/mobile apps for setup, control, memory management, and confirmations
 
 This repository is `genie-claw`. Some current integrations still live here as
@@ -31,10 +32,10 @@ should keep those behind narrow boundaries.
 
 For the exact implemented/partial/planned breakdown, use
 [implementation-status.md](implementation-status.md). In short, this repo
-implements the agent runtime, memory, tools, voice pipeline boundaries, local
-HTTP/CLI surfaces, safety gates, and deploy assets. It does not implement the
-final `genie-home-runtime`, `genie-ai-runtime`, `genie-os`, or full
-Matter/Thread device stack.
+implements the agent runtime, memory, tools, a transitional voice adapter,
+local HTTP/CLI surfaces, safety gates, and deploy assets. It does not implement
+the final `genie-voice-runtime`, `genie-home-runtime`, `genie-ai-runtime`,
+`genie-os`, or full Matter/Thread device stack.
 
 ## Main Runtime Modes
 
@@ -47,8 +48,10 @@ Matter/Thread device stack.
    When stdin is interactive, `genie-core` starts a local text REPL instead of
    daemon-only behavior.
 3. Voice mode
-   Enabled by config, `--voice`, or `GENIEPOD_VOICE=1`. The voice loop runs a
-   microphone -> STT -> prompt/tool execution -> TTS pipeline.
+   Enabled by config, `--voice`, or `GENIEPOD_VOICE=1`. Today this still uses a
+   transitional in-repo voice path. Long term, `genie-voice-runtime` owns
+   microphone -> STT and TTS -> speaker, while GenieClaw owns transcript ->
+   prompt/tool execution -> response text.
 
 In daemon mode, Telegram can also be enabled as a side-channel adapter.
 
@@ -78,10 +81,13 @@ Target topology:
 genie-ai-runtime
         ^
         |
+genie-voice-runtime
+        ^
+        |
 genie-claw
         |
         +---- web/mobile apps and local channels
-        +---- voice, memory, tools, skills
+        +---- memory, tools, skills
         v
 genie-home-runtime
         |

--- a/doc/services-and-crates.md
+++ b/doc/services-and-crates.md
@@ -12,6 +12,7 @@ Jetson appliance deployment, but the long-term boundary is clear:
 - `genie-governor` and `genie-health` are appliance support services.
 - Home Assistant and `llama.cpp` are transitional lower-runtime adapters.
 - Future `genie-home-runtime` and `genie-ai-runtime` should replace those lower-runtime adapters.
+- `genie-voice-runtime` is the new external owner for wake/VAD/STT/TTS/audio behavior.
 
 For the current truth matrix, see
 [implementation-status.md](implementation-status.md).
@@ -41,14 +42,15 @@ Primary responsibilities:
 - select and execute built-in tools
 - load and execute native skills
 - integrate Home Assistant through a provider boundary
-- run the voice loop
+- run the transitional voice adapter until `genie-voice-runtime` is the production voice path
 - expose connectivity health from the coprocessor boundary
 - optionally run the Telegram adapter
 
 Boundary rule:
 
 `genie-core` may request model inference and physical actions, but it should not
-grow into the optimized model server or the final home automation engine.
+grow into the optimized model server, the final home automation engine, or the
+voice/audio runtime.
 
 Important source roots:
 
@@ -137,6 +139,7 @@ Key files:
 - `genie-core`: `:3000`
 - `llama-server`: `:8080` today; future replacement is `genie-ai-runtime`
 - Home Assistant: commonly `:8123` today; future replacement is `genie-home-runtime`
+- `genie-voice-runtime`: external voice runtime; protocol and port are still stabilizing
 - `genie-api`: separate dashboard service port, depending on deploy setup
 
 ### Local IPC


### PR DESCRIPTION
## Summary

Refs #136. Documents the new voice boundary after creating the external repository:

https://github.com/GeniePod/genie-voice-runtime

GenieClaw remains the agent layer: prompt policy, memory, tools, smart-home intent, safety, audit, channels, and spoken response behavior. `genie-voice-runtime` becomes the long-term owner for wake word, VAD, STT, TTS, audio-device handling, denoise, AEC, and streaming voice session events.

## Changes

- Update `ARCHITECTURE.md` to add `genie-voice-runtime` to the ecosystem stack and target topology
- Mark the current in-repo voice modules as transitional Jetson alpha bring-up code
- Update README ownership language so GenieClaw is not framed as the long-term voice/audio runtime
- Update docs overview, subsystem map, service/crate docs, and implementation status
- Update the voice issue template to direct new runtime implementation work to `genie-voice-runtime`

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
git diff --check
```

### What I observed

`git diff --check` completed with no output. This is a docs/template boundary change, so no Rust build or Jetson hardware run is needed.

## Test plan

- [x] Created `GeniePod/genie-voice-runtime`
- [x] Added initial voice runtime protocol scaffold and CI in the new repo
- [x] Opened tracking issue #136 for the staged split
- [x] Reviewed docs diff locally
- [x] Whitespace check passed
