### PR TITLE
fix(api): bind genie-api from [services.api].url (closes #140)

### DIFF
--- a/crates/genie-api/src/main.rs
+++ b/crates/genie-api/src/main.rs
@@ -29,9 +29,9 @@ async fn main() -> Result<()> {
         .init();
 
     let config = Config::load()?;
-    let bind_addr = "127.0.0.1:3080";
+    let bind_addr = config.api_http_addr()?;
 
-    tracing::info!(addr = bind_addr, "GeniePod API server starting");
+    tracing::info!(addr = %bind_addr, "GeniePod API server starting");
 
-    http::serve(bind_addr, config).await
+    http::serve(&bind_addr, config).await
 }

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -1272,20 +1272,14 @@ systemd_unit = "genie-ai-runtime.service"
     #[test]
     fn api_http_addr_defaults_to_documented_port() {
         let config = test_config();
-        assert_eq!(
-            config.api_http_addr().unwrap(),
-            "127.0.0.1:3080"
-        );
+        assert_eq!(config.api_http_addr().unwrap(), "127.0.0.1:3080");
     }
 
     #[test]
     fn api_http_addr_follows_services_api_url() {
         let mut config = test_config();
         config.services.api.url = "http://127.0.0.1:4080/api/status".into();
-        assert_eq!(
-            config.api_http_addr().unwrap(),
-            "127.0.0.1:4080"
-        );
+        assert_eq!(config.api_http_addr().unwrap(), "127.0.0.1:4080");
     }
 
     #[test]

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -803,6 +803,20 @@ impl Config {
         format!("{host}:{}", self.core.port)
     }
 
+    /// TCP `host:port` for `genie-api` to bind, derived from `[services.api].url`.
+    ///
+    /// Keeps the listen socket aligned with health probes and `genie-ctl` that
+    /// already read the same configured URL (issue #140).
+    pub fn api_http_addr(&self) -> anyhow::Result<String> {
+        match parse_service_probe_target(&self.services.api.url) {
+            ServiceProbeTarget::Http { addr, .. } => Ok(addr),
+            ServiceProbeTarget::UnsupportedScheme { scheme } => anyhow::bail!(
+                "genie-api cannot bind from [services.api].url: unsupported scheme \
+                 \"{scheme}\" (use http://)"
+            ),
+        }
+    }
+
     /// Resolve the configured Home Assistant endpoint, if this deployment uses one.
     pub fn homeassistant_service(&self) -> Option<&ServiceEndpoint> {
         self.services.homeassistant.as_ref()
@@ -1253,6 +1267,36 @@ systemd_unit = "genie-ai-runtime.service"
         config.core.port = 3000;
         config.core.bind_host = "0.0.0.0".into();
         assert_eq!(config.core_http_addr(), "127.0.0.1:3000");
+    }
+
+    #[test]
+    fn api_http_addr_defaults_to_documented_port() {
+        let config = test_config();
+        assert_eq!(
+            config.api_http_addr().unwrap(),
+            "127.0.0.1:3080"
+        );
+    }
+
+    #[test]
+    fn api_http_addr_follows_services_api_url() {
+        let mut config = test_config();
+        config.services.api.url = "http://127.0.0.1:4080/api/status".into();
+        assert_eq!(
+            config.api_http_addr().unwrap(),
+            "127.0.0.1:4080"
+        );
+    }
+
+    #[test]
+    fn api_http_addr_rejects_https_url() {
+        let mut config = test_config();
+        config.services.api.url = "https://api.example/api/status".into();
+        let err = config.api_http_addr().unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported scheme"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `Config::api_http_addr()` in `genie-common`, parsing `[services.api].url` the same way as `genie-ctl` status/diag probes.
- `genie-api` binds to that address instead of hardcoded `127.0.0.1:3080`, so listen port stays aligned with health probes and the dashboard Services row when operators customize the API URL.
- Unit tests cover the default `:3080` port, a custom port (`4080`), and rejection of `https://` URLs.

Closes #140

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
cargo test -p genie-common api_http_addr
cargo test -p genie-api
```

### What I observed

All tests passed: 3 new `api_http_addr` tests in `genie-common` and existing `genie-api` route tests (6 tests).

## Test plan

- [x] `cargo test -p genie-common api_http_addr`
- [x] `cargo test -p genie-api`
- [ ] Manual: set `[services.api].url = "http://127.0.0.1:4080/api/status"`, start `genie-api`, confirm `ss` shows listen on `:4080` and `curl http://127.0.0.1:4080/api/status` succeeds