### PR TITLE
feat(agent): add limited-context architecture harness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,6 +19,16 @@ It sits below:
 
 The purpose of this repo is to make the local home AI useful, private, safe, and understandable. It should not grow into the OS, the full home automation engine, the CUDA inference runtime, or the product app.
 
+The architectural invariant is now enforced in code as well as docs:
+
+- `genie_core::runtime_boundary` names the AI, voice, and home runtime owners.
+- `genie_core::agent_harness` validates prompt, tool, memory, response reserve,
+  and optional-provider context against the Jetson 4096-token baseline.
+- `[agent]` selects the deployment profile while keeping `jetson` as the
+  flagship default.
+- `[optional_ai_provider]` is opt-in and cannot become a production candidate
+  unless it remains limited-context compatible.
+
 ## Ecosystem Stack
 
 ```text
@@ -184,6 +194,39 @@ Long-term safety responsibilities in `genie-home-runtime`:
 - recovery and rollback behavior
 
 The agent may propose or request actions. The home runtime decides whether physical execution is allowed.
+
+## Portable Profiles
+
+GenieClaw supports portable development without changing the native product
+shape. `[agent].runtime_profile` describes where the same agent harness is
+running:
+
+| Profile | Purpose |
+| --- | --- |
+| `jetson` | Flagship GeniePod Home path; 4096-token baseline and local runtime default |
+| `raspberry_pi` | SBC development profile for headless agent and provider work |
+| `portable_sbc` | Generic SBC profile where voice/home runtimes may be absent |
+| `laptop` | Developer profile for local tests, docs, and provider integration |
+| `mac` | macOS developer profile; no Jetson-specific runtime assumptions |
+
+Profiles do not change ownership. They only make the same limited-context agent
+contract portable enough for development and review on non-Jetson hardware.
+
+## Optional Providers
+
+API-key AI providers are optional provider boundaries, not the default product
+runtime. They must satisfy all of these before being treated as production
+paths:
+
+- configured under `[optional_ai_provider]`, disabled by default
+- API key comes from an environment variable, not the TOML value itself
+- `context_window_tokens <= [agent].context_window_tokens`
+- remote endpoints require `allow_remote_base_url = true`
+- prompt/tool/memory budget passes `genie_core::agent_harness`
+
+The flagship path remains local `genie-ai-runtime` on Jetson. Optional providers
+exist to make development, CI, and non-Jetson deployments easier without
+weakening the limited-context home-agent contract.
 
 ## Memory Ownership
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ and channel/session adapters.
 GenieClaw is not the voice pipeline, the LLM runtime, the OS, the final
 home-control runtime, or the product app layer.
 
+The default agent contract is intentionally small: the Jetson profile uses
+`[agent].context_window_tokens = 4096`. Larger adaptive contexts can exist for
+stronger models, but provider/runtime paths must pass the 4096-token harness
+first.
+
 ## Boundary
 
 | Layer | Owner | Notes |
@@ -62,6 +67,21 @@ Current workspace version: `v1.0.0-alpha.9`.
 - keep Home Assistant behind a provider boundary until `genie-home-runtime`
 - allow optional API-key providers only when they pass the same limited-context harness
 - keep development usable on SBCs, laptops, and Macs without making Jetson less native
+
+## Agent Contract
+
+The repo now has explicit code-level contract surfaces for the new direction:
+
+- `genie_core::runtime_boundary` declares the AI, voice, and home runtime
+  boundaries so GenieClaw remains the agent layer.
+- `genie_core::agent_harness` checks prompt, tool manifest, memory hydration,
+  response reserve, and optional provider context against the Jetson 4096-token
+  baseline.
+- `[agent]` in `geniepod.toml` selects the runtime profile:
+  `jetson`, `raspberry_pi`, `portable_sbc`, `laptop`, or `mac`.
+- `[optional_ai_provider]` is disabled by default. API-key providers must keep
+  their configured context at or below `[agent].context_window_tokens` before
+  they are production candidates.
 
 ## Quick Start
 

--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -909,6 +909,8 @@ mod tests {
         Config {
             data_dir: PathBuf::from("/tmp/geniepod-api-test"),
             core: CoreConfig::default(),
+            agent: Default::default(),
+            optional_ai_provider: Default::default(),
             governor: GovernorConfig::default(),
             health: HealthConfig::default(),
             services: ServicesConfig::default(),

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -15,6 +15,12 @@ pub struct Config {
     pub core: CoreConfig,
 
     #[serde(default)]
+    pub agent: AgentConfig,
+
+    #[serde(default)]
+    pub optional_ai_provider: OptionalAiProviderConfig,
+
+    #[serde(default)]
     pub governor: GovernorConfig,
 
     #[serde(default)]
@@ -220,6 +226,157 @@ impl Default for CoreConfig {
             actuation_safety: ActuationSafetyConfig::default(),
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct AgentConfig {
+    /// Primary deployment profile. Jetson stays the flagship default, but the
+    /// agent contract must also run on portable dev hosts and SBCs.
+    #[serde(default)]
+    pub runtime_profile: AgentRuntimeProfile,
+
+    /// Non-negotiable context budget for the Jetson baseline. Stronger models
+    /// may adapt upward later, but production paths must pass this budget first.
+    #[serde(default = "defaults::agent_context_window_tokens")]
+    pub context_window_tokens: u32,
+
+    /// AI runtime boundary owned below GenieClaw.
+    #[serde(default = "defaults::agent_ai_boundary")]
+    pub ai_runtime_boundary: RuntimeBoundaryMode,
+
+    /// Voice runtime boundary. The in-repo path is transitional only.
+    #[serde(default = "defaults::agent_voice_boundary")]
+    pub voice_runtime_boundary: RuntimeBoundaryMode,
+
+    /// Home runtime boundary. Home Assistant is a transitional provider today.
+    #[serde(default = "defaults::agent_home_boundary")]
+    pub home_runtime_boundary: RuntimeBoundaryMode,
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            runtime_profile: AgentRuntimeProfile::Jetson,
+            context_window_tokens: defaults::agent_context_window_tokens(),
+            ai_runtime_boundary: defaults::agent_ai_boundary(),
+            voice_runtime_boundary: defaults::agent_voice_boundary(),
+            home_runtime_boundary: defaults::agent_home_boundary(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRuntimeProfile {
+    #[default]
+    Jetson,
+    RaspberryPi,
+    PortableSbc,
+    Laptop,
+    Mac,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeBoundaryMode {
+    /// Stable external runtime contract. This is the target shape.
+    #[default]
+    ExternalRuntime,
+    /// In-repo adapter kept only until the external runtime takes ownership.
+    TransitionalAdapter,
+    /// Disabled on this profile.
+    Disabled,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct OptionalAiProviderConfig {
+    /// API-key provider support is opt-in and must not change the default
+    /// Jetson local binary path.
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(default)]
+    pub provider: OptionalAiProviderKind,
+
+    /// Base URL or endpoint identifier for provider clients. Empty while
+    /// disabled. Remote endpoints require allow_remote_base_url = true.
+    #[serde(default)]
+    pub base_url: String,
+
+    /// Environment variable that contains the API key. The key value itself is
+    /// never stored in config and is not included in support summaries.
+    #[serde(default = "defaults::optional_ai_provider_api_key_env")]
+    pub api_key_env: String,
+
+    /// Provider path must pass the same limited-context harness before it is
+    /// promoted. Keep this at or below [agent].context_window_tokens.
+    #[serde(default = "defaults::agent_context_window_tokens")]
+    pub context_window_tokens: u32,
+
+    /// Explicit opt-in for non-local endpoints.
+    #[serde(default)]
+    pub allow_remote_base_url: bool,
+}
+
+impl OptionalAiProviderConfig {
+    pub fn limited_context_compatible(&self, agent: &AgentConfig) -> bool {
+        !self.enabled || self.context_window_tokens <= agent.context_window_tokens
+    }
+
+    pub fn production_candidate(&self, agent: &AgentConfig) -> bool {
+        self.enabled
+            && self.limited_context_compatible(agent)
+            && !self.api_key_env.trim().is_empty()
+            && (!is_remote_url(&self.base_url) || self.allow_remote_base_url)
+    }
+}
+
+impl Default for OptionalAiProviderConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            provider: OptionalAiProviderKind::OpenAiCompatible,
+            base_url: String::new(),
+            api_key_env: defaults::optional_ai_provider_api_key_env(),
+            context_window_tokens: defaults::agent_context_window_tokens(),
+            allow_remote_base_url: false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OptionalAiProviderKind {
+    /// Generic OpenAI-compatible API surface. Concrete providers can map into
+    /// this without adding a heavyweight SDK dependency.
+    #[default]
+    #[serde(alias = "openai_compatible")]
+    OpenAiCompatible,
+    #[serde(alias = "openai")]
+    OpenAi,
+    Anthropic,
+    Gemini,
+    Custom,
+}
+
+fn is_remote_url(url: &str) -> bool {
+    let url = url.trim();
+    if url.is_empty() {
+        return false;
+    }
+    let stripped = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+        .unwrap_or(url);
+    let authority = stripped.split('/').next().unwrap_or(stripped);
+    let host = if let Some(rest) = authority.strip_prefix('[') {
+        rest.find(']')
+            .map(|idx| &authority[..=idx + 1])
+            .unwrap_or(authority)
+    } else {
+        authority.split(':').next().unwrap_or(authority)
+    };
+    !matches!(host, "127.0.0.1" | "localhost" | "::1" | "[::1]")
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -915,6 +1072,22 @@ impl Config {
         if self.telegram.enabled && !self.telegram.bot_token.trim().is_empty() {
             risk_flags.push("telegram_token_in_config_file");
         }
+        if self.optional_ai_provider.enabled {
+            risk_flags.push("optional_ai_provider_enabled");
+        }
+        if self.optional_ai_provider.enabled
+            && !self
+                .optional_ai_provider
+                .limited_context_compatible(&self.agent)
+        {
+            risk_flags.push("optional_ai_provider_context_exceeds_agent_budget");
+        }
+        if self.optional_ai_provider.enabled
+            && is_remote_url(&self.optional_ai_provider.base_url)
+            && !self.optional_ai_provider.allow_remote_base_url
+        {
+            risk_flags.push("optional_ai_provider_remote_url_blocked");
+        }
         if !self.core.skill_policy.require_manifest {
             risk_flags.push("skill_manifest_not_required");
         }
@@ -926,6 +1099,14 @@ impl Config {
             "trust_model": "single_household_operator_boundary",
             "raw_config_exposed": false,
             "raw_config_policy": "local_operator_file_only",
+            "agent": {
+                "runtime_profile": format!("{:?}", self.agent.runtime_profile),
+                "context_window_tokens": self.agent.context_window_tokens,
+                "ai_runtime_boundary": format!("{:?}", self.agent.ai_runtime_boundary),
+                "voice_runtime_boundary": format!("{:?}", self.agent.voice_runtime_boundary),
+                "home_runtime_boundary": format!("{:?}", self.agent.home_runtime_boundary),
+                "agent_layer_only": true
+            },
             "shared_memory": {
                 "mode": "household_shared_by_default",
                 "dashboard_manager_enabled": true,
@@ -944,7 +1125,18 @@ impl Config {
                 "telegram_enabled": self.telegram.enabled,
                 "telegram_allowlist_enabled": self.telegram.enabled && !self.telegram.allow_all_chats && !self.telegram.allowed_chat_ids.is_empty(),
                 "homeassistant_bridge_configured": self.services.homeassistant.is_some(),
-                "connectivity_coprocessor_enabled": self.connectivity_enabled()
+                "connectivity_coprocessor_enabled": self.connectivity_enabled(),
+                "optional_ai_provider_enabled": self.optional_ai_provider.enabled
+            },
+            "optional_ai_provider": {
+                "enabled": self.optional_ai_provider.enabled,
+                "provider": format!("{:?}", self.optional_ai_provider.provider),
+                "context_window_tokens": self.optional_ai_provider.context_window_tokens,
+                "limited_context_compatible": self.optional_ai_provider.limited_context_compatible(&self.agent),
+                "allow_remote_base_url": self.optional_ai_provider.allow_remote_base_url,
+                "api_key_env_configured": !self.optional_ai_provider.api_key_env.trim().is_empty(),
+                "base_url_configured": !self.optional_ai_provider.base_url.trim().is_empty(),
+                "api_key_value_exposed": false
             },
             "policy": {
                 "tool_policy_enabled": self.core.tool_policy.enabled,
@@ -1081,6 +1273,8 @@ mod tests {
         Config {
             data_dir: defaults::data_dir(),
             core: CoreConfig::default(),
+            agent: AgentConfig::default(),
+            optional_ai_provider: OptionalAiProviderConfig::default(),
             governor: GovernorConfig::default(),
             health: HealthConfig::default(),
             services: ServicesConfig::default(),
@@ -1095,6 +1289,93 @@ mod tests {
         let config = test_config();
         assert!(config.homeassistant_service().is_none());
         assert!(!config.manages_service_alias("homeassistant"));
+    }
+
+    #[test]
+    fn agent_profile_defaults_to_jetson_limited_context() {
+        let config = test_config();
+        assert_eq!(config.agent.runtime_profile, AgentRuntimeProfile::Jetson);
+        assert_eq!(config.agent.context_window_tokens, 4096);
+        assert_eq!(
+            config.agent.ai_runtime_boundary,
+            RuntimeBoundaryMode::ExternalRuntime
+        );
+        assert_eq!(
+            config.agent.voice_runtime_boundary,
+            RuntimeBoundaryMode::TransitionalAdapter
+        );
+        assert_eq!(
+            config.agent.home_runtime_boundary,
+            RuntimeBoundaryMode::TransitionalAdapter
+        );
+    }
+
+    #[test]
+    fn portable_agent_profile_parses() {
+        let config: AgentConfig = toml::from_str(
+            r#"
+runtime_profile = "portable_sbc"
+context_window_tokens = 4096
+ai_runtime_boundary = "external_runtime"
+voice_runtime_boundary = "disabled"
+home_runtime_boundary = "external_runtime"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.runtime_profile, AgentRuntimeProfile::PortableSbc);
+        assert_eq!(config.context_window_tokens, 4096);
+        assert_eq!(config.voice_runtime_boundary, RuntimeBoundaryMode::Disabled);
+    }
+
+    #[test]
+    fn optional_ai_provider_is_disabled_and_limited_context_by_default() {
+        let config = test_config();
+        assert!(!config.optional_ai_provider.enabled);
+        assert_eq!(
+            config.optional_ai_provider.provider,
+            OptionalAiProviderKind::OpenAiCompatible
+        );
+        assert!(config.optional_ai_provider.limited_context_compatible(&config.agent));
+        assert!(!config.optional_ai_provider.production_candidate(&config.agent));
+    }
+
+    #[test]
+    fn optional_ai_provider_must_fit_limited_context() {
+        let agent = AgentConfig::default();
+        let provider: OptionalAiProviderConfig = toml::from_str(
+            r#"
+enabled = true
+provider = "open_ai"
+base_url = "https://api.openai.com/v1"
+api_key_env = "OPENAI_API_KEY"
+context_window_tokens = 8192
+allow_remote_base_url = true
+"#,
+        )
+        .unwrap();
+
+        assert!(!provider.limited_context_compatible(&agent));
+        assert!(!provider.production_candidate(&agent));
+    }
+
+    #[test]
+    fn optional_ai_provider_remote_requires_explicit_allow() {
+        let agent = AgentConfig::default();
+        let provider: OptionalAiProviderConfig = toml::from_str(
+            r#"
+enabled = true
+provider = "custom"
+base_url = "https://provider.example/v1"
+api_key_env = "GENIE_PROVIDER_KEY"
+context_window_tokens = 4096
+allow_remote_base_url = false
+"#,
+        )
+        .unwrap();
+
+        assert!(provider.limited_context_compatible(&agent));
+        assert!(!provider.production_candidate(&agent));
     }
 
     #[test]
@@ -1643,7 +1924,7 @@ device_path = "/dev/spidev1.0"
 }
 
 mod defaults {
-    use super::{LlmBackendKind, ServiceEndpoint};
+    use super::{LlmBackendKind, RuntimeBoundaryMode, ServiceEndpoint};
     use std::path::PathBuf;
 
     pub fn api_service() -> ServiceEndpoint {
@@ -1692,6 +1973,21 @@ mod defaults {
     }
     pub fn core_bind_host() -> String {
         "127.0.0.1".into()
+    }
+    pub fn agent_context_window_tokens() -> u32 {
+        4096
+    }
+    pub fn agent_ai_boundary() -> RuntimeBoundaryMode {
+        RuntimeBoundaryMode::ExternalRuntime
+    }
+    pub fn agent_voice_boundary() -> RuntimeBoundaryMode {
+        RuntimeBoundaryMode::TransitionalAdapter
+    }
+    pub fn agent_home_boundary() -> RuntimeBoundaryMode {
+        RuntimeBoundaryMode::TransitionalAdapter
+    }
+    pub fn optional_ai_provider_api_key_env() -> String {
+        "GENIEPOD_AI_PROVIDER_API_KEY".into()
     }
     pub fn llm_model_name() -> String {
         "phi".into()

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -1336,8 +1336,16 @@ home_runtime_boundary = "external_runtime"
             config.optional_ai_provider.provider,
             OptionalAiProviderKind::OpenAiCompatible
         );
-        assert!(config.optional_ai_provider.limited_context_compatible(&config.agent));
-        assert!(!config.optional_ai_provider.production_candidate(&config.agent));
+        assert!(
+            config
+                .optional_ai_provider
+                .limited_context_compatible(&config.agent)
+        );
+        assert!(
+            !config
+                .optional_ai_provider
+                .production_candidate(&config.agent)
+        );
     }
 
     #[test]

--- a/crates/genie-core/src/agent_harness.rs
+++ b/crates/genie-core/src/agent_harness.rs
@@ -1,0 +1,206 @@
+//! Limited-context harness checks for GenieClaw agent contracts.
+//!
+//! The goal is to keep prompt, tools, memory hydration, safety, and optional
+//! provider paths usable inside the Jetson 4096-token baseline before any
+//! deployment opts into a larger adaptive context.
+
+use genie_common::config::{AgentConfig, OptionalAiProviderConfig};
+use serde::Serialize;
+
+use crate::runtime_boundary::JETSON_BASELINE_CONTEXT_TOKENS;
+use crate::tools::dispatch::ToolDef;
+
+pub const RESPONSE_RESERVE_TOKENS: usize = 512;
+pub const TOOL_MANIFEST_BUDGET_TOKENS: usize = 900;
+pub const MEMORY_HYDRATION_BUDGET_TOKENS: usize = 900;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HarnessCheck {
+    pub name: &'static str,
+    pub pass: bool,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct LimitedContextHarnessReport {
+    pub pass: bool,
+    pub context_window_tokens: usize,
+    pub estimated_prompt_tokens: usize,
+    pub estimated_tool_manifest_tokens: usize,
+    pub estimated_memory_tokens: usize,
+    pub estimated_total_tokens: usize,
+    pub response_reserve_tokens: usize,
+    pub checks: Vec<HarnessCheck>,
+}
+
+pub fn validate_limited_context_agent(
+    system_prompt: &str,
+    tools: &[ToolDef],
+    memory_context: &str,
+    agent: &AgentConfig,
+    provider: &OptionalAiProviderConfig,
+) -> LimitedContextHarnessReport {
+    let context_window_tokens = agent.context_window_tokens.max(1) as usize;
+    let tool_manifest = serde_json::to_string(tools).unwrap_or_else(|_| "[]".into());
+    let estimated_prompt_tokens = estimate_tokens(system_prompt);
+    let estimated_tool_manifest_tokens = estimate_tokens(&tool_manifest);
+    let estimated_memory_tokens = estimate_tokens(memory_context);
+    let estimated_total_tokens =
+        estimated_prompt_tokens + estimated_tool_manifest_tokens + estimated_memory_tokens;
+
+    let mut checks = Vec::new();
+    checks.push(HarnessCheck {
+        name: "jetson_baseline_context",
+        pass: context_window_tokens <= JETSON_BASELINE_CONTEXT_TOKENS as usize,
+        detail: format!(
+            "{} tokens configured; Jetson baseline is {}",
+            context_window_tokens, JETSON_BASELINE_CONTEXT_TOKENS
+        ),
+    });
+    checks.push(HarnessCheck {
+        name: "prompt_tool_memory_budget",
+        pass: estimated_total_tokens + RESPONSE_RESERVE_TOKENS <= context_window_tokens,
+        detail: format!(
+            "{} estimated input tokens + {} reserved response tokens <= {}",
+            estimated_total_tokens, RESPONSE_RESERVE_TOKENS, context_window_tokens
+        ),
+    });
+    checks.push(HarnessCheck {
+        name: "tool_manifest_budget",
+        pass: estimated_tool_manifest_tokens <= TOOL_MANIFEST_BUDGET_TOKENS,
+        detail: format!(
+            "{} estimated tool tokens <= {}",
+            estimated_tool_manifest_tokens, TOOL_MANIFEST_BUDGET_TOKENS
+        ),
+    });
+    checks.push(HarnessCheck {
+        name: "memory_hydration_budget",
+        pass: estimated_memory_tokens <= MEMORY_HYDRATION_BUDGET_TOKENS,
+        detail: format!(
+            "{} estimated memory tokens <= {}",
+            estimated_memory_tokens, MEMORY_HYDRATION_BUDGET_TOKENS
+        ),
+    });
+    checks.push(HarnessCheck {
+        name: "provider_limited_context",
+        pass: provider.limited_context_compatible(agent),
+        detail: format!(
+            "provider enabled={} context={} agent_context={}",
+            provider.enabled, provider.context_window_tokens, agent.context_window_tokens
+        ),
+    });
+
+    let pass = checks.iter().all(|check| check.pass);
+    LimitedContextHarnessReport {
+        pass,
+        context_window_tokens,
+        estimated_prompt_tokens,
+        estimated_tool_manifest_tokens,
+        estimated_memory_tokens,
+        estimated_total_tokens,
+        response_reserve_tokens: RESPONSE_RESERVE_TOKENS,
+        checks,
+    }
+}
+
+pub fn estimate_tokens(text: &str) -> usize {
+    let bytes = text.len();
+    if bytes == 0 {
+        0
+    } else {
+        (bytes + 3) / 4
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use genie_common::config::OptionalAiProviderKind;
+
+    fn sample_tool(name: &str) -> ToolDef {
+        ToolDef {
+            name: name.into(),
+            description: format!("{name} test tool"),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"}
+                }
+            }),
+        }
+    }
+
+    #[test]
+    fn compact_agent_contract_passes_4096_token_budget() {
+        let agent = AgentConfig::default();
+        let provider = OptionalAiProviderConfig::default();
+        let tools = vec![
+            sample_tool("get_time"),
+            sample_tool("memory_recall"),
+            sample_tool("home_control"),
+        ];
+
+        let report = validate_limited_context_agent(
+            "You are GeniePod Home. Use tools only when needed.",
+            &tools,
+            "Household context: kitchen light is in the kitchen.",
+            &agent,
+            &provider,
+        );
+
+        assert!(report.pass, "{:?}", report.checks);
+        assert!(report.estimated_total_tokens < 4096);
+    }
+
+    #[test]
+    fn oversized_memory_hydration_fails_the_harness() {
+        let agent = AgentConfig::default();
+        let provider = OptionalAiProviderConfig::default();
+        let memory_context = "remembered household detail. ".repeat(500);
+
+        let report = validate_limited_context_agent(
+            "You are GeniePod Home.",
+            &[sample_tool("memory_recall")],
+            &memory_context,
+            &agent,
+            &provider,
+        );
+
+        assert!(!report.pass);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "memory_hydration_budget" && !check.pass)
+        );
+    }
+
+    #[test]
+    fn optional_provider_over_context_budget_fails_the_harness() {
+        let agent = AgentConfig::default();
+        let provider = OptionalAiProviderConfig {
+            enabled: true,
+            provider: OptionalAiProviderKind::OpenAiCompatible,
+            base_url: "https://provider.example/v1".into(),
+            api_key_env: "GENIE_PROVIDER_KEY".into(),
+            context_window_tokens: 8192,
+            allow_remote_base_url: true,
+        };
+
+        let report = validate_limited_context_agent(
+            "You are GeniePod Home.",
+            &[sample_tool("get_time")],
+            "",
+            &agent,
+            &provider,
+        );
+
+        assert!(!report.pass);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "provider_limited_context" && !check.pass)
+        );
+    }
+}

--- a/crates/genie-core/src/agent_harness.rs
+++ b/crates/genie-core/src/agent_harness.rs
@@ -104,12 +104,7 @@ pub fn validate_limited_context_agent(
 }
 
 pub fn estimate_tokens(text: &str) -> usize {
-    let bytes = text.len();
-    if bytes == 0 {
-        0
-    } else {
-        (bytes + 3) / 4
-    }
+    text.len().div_ceil(4)
 }
 
 #[cfg(test)]

--- a/crates/genie-core/src/lib.rs
+++ b/crates/genie-core/src/lib.rs
@@ -16,6 +16,7 @@
 //!
 //! | Module | What it does |
 //! |--------|-------------|
+//! | [`agent_harness`] | Limited-context prompt/tool/memory/provider contract checks |
 //! | [`llm`] | OpenAI-compatible local LLM client (llama.cpp, Ollama, any API) |
 //! | [`ha`] | Home Assistant provider boundary, structure cache, and REST client |
 //! | [`tools`] | Compiled tool dispatch + parser for LLM JSON output |
@@ -24,6 +25,7 @@
 //! | [`connectivity`] | Boundary for an ESP32-C6 UART Thread/Matter coprocessor |
 //! | [`context`] | LLM context window management with summarization |
 //! | [`prompt`] | Model-aware system prompt builder (6 LLM families) |
+//! | [`runtime_boundary`] | Explicit AI/voice/home lower-runtime ownership contracts |
 //! | [`voice`] | STT/TTS subprocess management + voice output formatter (feature `voice`, default-on) |
 //! | [`ota`] | OTA update checker via GitHub Releases |
 //! | [`server`] | HTTP chat API server |
@@ -40,6 +42,7 @@
 #![allow(dead_code, unused_variables, unused_assignments)]
 #![allow(clippy::too_many_arguments, clippy::empty_line_after_doc_comments)]
 
+pub mod agent_harness;
 pub mod connectivity;
 pub mod context;
 pub mod conversation;
@@ -51,6 +54,7 @@ pub mod profile;
 pub mod prompt;
 pub mod reasoning;
 pub mod repl;
+pub mod runtime_boundary;
 pub mod runtime_contract;
 pub mod runtime_mode;
 pub mod security;

--- a/crates/genie-core/src/llm/mod.rs
+++ b/crates/genie-core/src/llm/mod.rs
@@ -2,6 +2,7 @@ mod genie_ai_runtime;
 mod llama_cpp;
 mod mock;
 mod openai_compat;
+mod provider;
 mod retry;
 
 use anyhow::Result;
@@ -12,6 +13,7 @@ pub use genie_ai_runtime::GenieAiRuntimeBackend;
 pub use llama_cpp::LlamaCppBackend;
 pub use mock::MockLlmBackend;
 pub use openai_compat::{Message, ResponseFormat};
+pub use provider::{OptionalProviderPlan, ProviderReadiness};
 #[allow(unused_imports)]
 pub use retry::RetryLlmClient;
 

--- a/crates/genie-core/src/llm/provider.rs
+++ b/crates/genie-core/src/llm/provider.rs
@@ -1,0 +1,132 @@
+//! Optional API-provider planning for non-default LLM paths.
+//!
+//! This module intentionally does not add provider SDKs or change the local
+//! Jetson default. It validates whether an API-key provider is eligible to be
+//! wired behind the existing LLM facade without violating the limited-context
+//! agent contract.
+
+use genie_common::config::{
+    AgentConfig, OptionalAiProviderConfig, OptionalAiProviderKind,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderReadiness {
+    Disabled,
+    Ready,
+    Blocked(Vec<&'static str>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OptionalProviderPlan {
+    pub provider: OptionalAiProviderKind,
+    pub base_url: String,
+    pub api_key_env: String,
+    pub context_window_tokens: u32,
+    pub remote_allowed: bool,
+}
+
+impl OptionalProviderPlan {
+    pub fn from_config(config: &OptionalAiProviderConfig) -> Option<Self> {
+        if !config.enabled {
+            return None;
+        }
+
+        Some(Self {
+            provider: config.provider,
+            base_url: config.base_url.clone(),
+            api_key_env: config.api_key_env.clone(),
+            context_window_tokens: config.context_window_tokens,
+            remote_allowed: config.allow_remote_base_url,
+        })
+    }
+
+    pub fn readiness(&self, agent: &AgentConfig) -> ProviderReadiness {
+        let mut reasons = Vec::new();
+        if self.context_window_tokens > agent.context_window_tokens {
+            reasons.push("context_window_exceeds_agent_budget");
+        }
+        if self.api_key_env.trim().is_empty() {
+            reasons.push("missing_api_key_env");
+        }
+        if self.base_url.trim().is_empty() {
+            reasons.push("missing_base_url");
+        }
+        if remote_url(&self.base_url) && !self.remote_allowed {
+            reasons.push("remote_base_url_not_allowed");
+        }
+
+        if reasons.is_empty() {
+            ProviderReadiness::Ready
+        } else {
+            ProviderReadiness::Blocked(reasons)
+        }
+    }
+}
+
+fn remote_url(url: &str) -> bool {
+    let url = url.trim();
+    if url.is_empty() {
+        return false;
+    }
+    let stripped = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+        .unwrap_or(url);
+    let authority = stripped.split('/').next().unwrap_or(stripped);
+    let host = if let Some(rest) = authority.strip_prefix('[') {
+        rest.find(']')
+            .map(|idx| &authority[..=idx + 1])
+            .unwrap_or(authority)
+    } else {
+        authority.split(':').next().unwrap_or(authority)
+    };
+    !matches!(host, "127.0.0.1" | "localhost" | "::1" | "[::1]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_provider_has_no_plan() {
+        assert!(
+            OptionalProviderPlan::from_config(&OptionalAiProviderConfig::default()).is_none()
+        );
+    }
+
+    #[test]
+    fn remote_provider_requires_explicit_allow_and_budget_fit() {
+        let provider = OptionalAiProviderConfig {
+            enabled: true,
+            provider: OptionalAiProviderKind::OpenAiCompatible,
+            base_url: "https://provider.example/v1".into(),
+            api_key_env: "GENIE_PROVIDER_KEY".into(),
+            context_window_tokens: 8192,
+            allow_remote_base_url: false,
+        };
+        let plan = OptionalProviderPlan::from_config(&provider).unwrap();
+
+        assert_eq!(
+            plan.readiness(&AgentConfig::default()),
+            ProviderReadiness::Blocked(vec![
+                "context_window_exceeds_agent_budget",
+                "remote_base_url_not_allowed"
+            ])
+        );
+    }
+
+    #[test]
+    fn local_openai_compatible_provider_can_be_ready() {
+        let provider = OptionalAiProviderConfig {
+            enabled: true,
+            provider: OptionalAiProviderKind::OpenAiCompatible,
+            base_url: "http://127.0.0.1:11434/v1".into(),
+            api_key_env: "LOCAL_PROVIDER_KEY".into(),
+            context_window_tokens: 4096,
+            allow_remote_base_url: false,
+        };
+        let plan = OptionalProviderPlan::from_config(&provider).unwrap();
+
+        assert_eq!(plan.readiness(&AgentConfig::default()), ProviderReadiness::Ready);
+    }
+}

--- a/crates/genie-core/src/llm/provider.rs
+++ b/crates/genie-core/src/llm/provider.rs
@@ -5,9 +5,7 @@
 //! wired behind the existing LLM facade without violating the limited-context
 //! agent contract.
 
-use genie_common::config::{
-    AgentConfig, OptionalAiProviderConfig, OptionalAiProviderKind,
-};
+use genie_common::config::{AgentConfig, OptionalAiProviderConfig, OptionalAiProviderKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProviderReadiness {
@@ -89,9 +87,7 @@ mod tests {
 
     #[test]
     fn disabled_provider_has_no_plan() {
-        assert!(
-            OptionalProviderPlan::from_config(&OptionalAiProviderConfig::default()).is_none()
-        );
+        assert!(OptionalProviderPlan::from_config(&OptionalAiProviderConfig::default()).is_none());
     }
 
     #[test]
@@ -127,6 +123,9 @@ mod tests {
         };
         let plan = OptionalProviderPlan::from_config(&provider).unwrap();
 
-        assert_eq!(plan.readiness(&AgentConfig::default()), ProviderReadiness::Ready);
+        assert_eq!(
+            plan.readiness(&AgentConfig::default()),
+            ProviderReadiness::Ready
+        );
     }
 }

--- a/crates/genie-core/src/runtime_boundary.rs
+++ b/crates/genie-core/src/runtime_boundary.rs
@@ -1,0 +1,134 @@
+//! Runtime boundary contracts for the GenieClaw agent layer.
+//!
+//! GenieClaw owns agent policy, prompt assembly, memory, tools, channels, and
+//! audit. It consumes lower runtime contracts for inference, voice I/O, and
+//! physical home control; it should not grow into those runtimes.
+
+use genie_common::config::{
+    AgentConfig, AgentRuntimeProfile, OptionalAiProviderConfig, RuntimeBoundaryMode,
+};
+use serde::Serialize;
+
+pub const JETSON_BASELINE_CONTEXT_TOKENS: u32 = 4096;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeBoundaryContract {
+    pub layer: &'static str,
+    pub owner: &'static str,
+    pub mode: String,
+    pub contract: &'static str,
+    pub local_default: bool,
+}
+
+pub trait AiRuntimeBoundary {
+    fn provider_name(&self) -> &str;
+    fn context_window_tokens(&self) -> u32;
+    fn local_default(&self) -> bool;
+}
+
+pub trait VoiceRuntimeBoundary {
+    fn boundary_mode(&self) -> RuntimeBoundaryMode;
+    fn owns_audio_pipeline(&self) -> bool;
+}
+
+pub trait HomeRuntimeBoundary {
+    fn boundary_mode(&self) -> RuntimeBoundaryMode;
+    fn owns_final_actuation(&self) -> bool;
+}
+
+pub fn runtime_boundaries(agent: &AgentConfig) -> Vec<RuntimeBoundaryContract> {
+    vec![
+        RuntimeBoundaryContract {
+            layer: "ai_runtime",
+            owner: "genie-ai-runtime",
+            mode: format!("{:?}", agent.ai_runtime_boundary),
+            contract: "OpenAI-compatible chat plus limited-context request compaction",
+            local_default: true,
+        },
+        RuntimeBoundaryContract {
+            layer: "voice_runtime",
+            owner: "genie-voice-runtime",
+            mode: format!("{:?}", agent.voice_runtime_boundary),
+            contract: "transcript-in and speak-out session protocol",
+            local_default: matches!(
+                agent.voice_runtime_boundary,
+                RuntimeBoundaryMode::ExternalRuntime | RuntimeBoundaryMode::TransitionalAdapter
+            ),
+        },
+        RuntimeBoundaryContract {
+            layer: "home_runtime",
+            owner: "genie-home-runtime",
+            mode: format!("{:?}", agent.home_runtime_boundary),
+            contract: "intent handoff plus final physical actuation gate",
+            local_default: matches!(
+                agent.home_runtime_boundary,
+                RuntimeBoundaryMode::ExternalRuntime | RuntimeBoundaryMode::TransitionalAdapter
+            ),
+        },
+    ]
+}
+
+pub fn profile_label(profile: AgentRuntimeProfile) -> &'static str {
+    match profile {
+        AgentRuntimeProfile::Jetson => "jetson",
+        AgentRuntimeProfile::RaspberryPi => "raspberry_pi",
+        AgentRuntimeProfile::PortableSbc => "portable_sbc",
+        AgentRuntimeProfile::Laptop => "laptop",
+        AgentRuntimeProfile::Mac => "mac",
+    }
+}
+
+pub fn provider_respects_agent_context(
+    provider: &OptionalAiProviderConfig,
+    agent: &AgentConfig,
+) -> bool {
+    provider.limited_context_compatible(agent)
+}
+
+pub fn is_jetson_baseline(agent: &AgentConfig) -> bool {
+    agent.runtime_profile == AgentRuntimeProfile::Jetson
+        && agent.context_window_tokens <= JETSON_BASELINE_CONTEXT_TOKENS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use genie_common::config::OptionalAiProviderKind;
+
+    #[test]
+    fn default_agent_contract_is_jetson_limited_context() {
+        let agent = AgentConfig::default();
+
+        assert!(is_jetson_baseline(&agent));
+        assert_eq!(profile_label(agent.runtime_profile), "jetson");
+        assert_eq!(agent.context_window_tokens, JETSON_BASELINE_CONTEXT_TOKENS);
+    }
+
+    #[test]
+    fn boundaries_make_genie_claw_an_agent_layer() {
+        let agent = AgentConfig::default();
+        let boundaries = runtime_boundaries(&agent);
+
+        assert_eq!(boundaries.len(), 3);
+        assert_eq!(boundaries[0].owner, "genie-ai-runtime");
+        assert_eq!(boundaries[1].owner, "genie-voice-runtime");
+        assert_eq!(boundaries[2].owner, "genie-home-runtime");
+        assert!(boundaries.iter().all(|boundary| !boundary.layer.is_empty()));
+    }
+
+    #[test]
+    fn provider_context_must_not_exceed_agent_budget() {
+        let agent = AgentConfig::default();
+        let provider = OptionalAiProviderConfig {
+            enabled: true,
+            provider: OptionalAiProviderKind::OpenAi,
+            base_url: "https://api.openai.com/v1".into(),
+            api_key_env: "OPENAI_API_KEY".into(),
+            context_window_tokens: 8192,
+            allow_remote_base_url: true,
+        };
+
+        assert!(!provider_respects_agent_context(&provider, &agent));
+        assert!(!provider.production_candidate(&agent));
+    }
+}

--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -1951,6 +1951,8 @@ mod tests {
                 bind_host: "127.0.0.1".into(),
                 ..CoreConfig::default()
             },
+            agent: Default::default(),
+            optional_ai_provider: Default::default(),
             governor: GovernorConfig::default(),
             health: HealthConfig::default(),
             services: ServicesConfig::default(),
@@ -1976,6 +1978,8 @@ mod tests {
                 bind_host: "0.0.0.0".into(),
                 ..CoreConfig::default()
             },
+            agent: Default::default(),
+            optional_ai_provider: Default::default(),
             governor: GovernorConfig::default(),
             health: HealthConfig::default(),
             services: ServicesConfig::default(),

--- a/crates/genie-governor/src/governor.rs
+++ b/crates/genie-governor/src/governor.rs
@@ -326,6 +326,8 @@ mod tests {
         Config {
             data_dir: PathBuf::from("/tmp/geniepod-test"),
             core: CoreConfig::default(),
+            agent: AgentConfig::default(),
+            optional_ai_provider: OptionalAiProviderConfig::default(),
             governor: GovernorConfig {
                 poll_interval_ms: 1000,
                 night_start_hour: 23,

--- a/crates/genie-health/src/checker.rs
+++ b/crates/genie-health/src/checker.rs
@@ -311,6 +311,8 @@ mod tests {
         Config {
             data_dir: PathBuf::from("/tmp/geniepod-health-test"),
             core: CoreConfig::default(),
+            agent: Default::default(),
+            optional_ai_provider: Default::default(),
             governor: GovernorConfig {
                 poll_interval_ms: 1000,
                 night_start_hour: 23,

--- a/deploy/config/geniepod.dev.toml
+++ b/deploy/config/geniepod.dev.toml
@@ -4,6 +4,21 @@
 
 data_dir = "./data"
 
+[agent]
+runtime_profile = "laptop"         # Dev default; Jetson production uses "jetson".
+context_window_tokens = 4096       # Keep provider/harness tests honest on non-Jetson hosts.
+ai_runtime_boundary = "external_runtime"
+voice_runtime_boundary = "disabled"
+home_runtime_boundary = "transitional_adapter"
+
+[optional_ai_provider]
+enabled = false
+provider = "open_ai_compatible"
+base_url = ""
+api_key_env = "GENIEPOD_AI_PROVIDER_API_KEY"
+context_window_tokens = 4096
+allow_remote_base_url = false
+
 [core]
 port = 3000
 bind_host = "127.0.0.1"

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -3,6 +3,24 @@
 
 data_dir = "/opt/geniepod/data"
 
+[agent]
+runtime_profile = "jetson"        # "jetson", "raspberry_pi", "portable_sbc", "laptop", or "mac".
+context_window_tokens = 4096      # Non-negotiable Jetson baseline before any adaptive larger context.
+ai_runtime_boundary = "external_runtime"       # genie-ai-runtime owns inference.
+voice_runtime_boundary = "transitional_adapter" # In-repo voice path is temporary; target is genie-voice-runtime.
+home_runtime_boundary = "transitional_adapter"  # HA provider today; target is genie-home-runtime.
+
+# Optional API-key provider path. Disabled by default so the local Jetson image
+# and binary stay focused on genie-ai-runtime. Enable only after the provider
+# passes the same 4096-token home-agent harness.
+[optional_ai_provider]
+enabled = false
+provider = "open_ai_compatible"   # "open_ai_compatible", "open_ai", "anthropic", "gemini", or "custom".
+base_url = ""
+api_key_env = "GENIEPOD_AI_PROVIDER_API_KEY"
+context_window_tokens = 4096
+allow_remote_base_url = false
+
 [core]
 port = 3000
 bind_host = "127.0.0.1"           # Safer default. Use "0.0.0.0" only behind a trusted gateway/firewall.


### PR DESCRIPTION
## Summary

Combines the five urgent direction changes into one PR:

- clarifies GenieClaw as the agent layer, not the voice/audio/runtime/device-control owner
- adds explicit AI, voice, and home runtime boundary contracts in `genie_core::runtime_boundary`
- adds a limited-context agent harness in `genie_core::agent_harness` for prompt, tool manifest, memory hydration, response reserve, and optional provider checks
- adds disabled-by-default optional API-key provider config plus `llm::OptionalProviderPlan` readiness checks
- adds portable `[agent].runtime_profile` config for Jetson, Raspberry Pi, generic SBC, laptop, and Mac profiles while keeping Jetson + 4096 tokens as the default production baseline

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
git diff --check
which cargo || true
which rustc || true
which rustfmt || true
```

### What I observed

- `git diff --check` passed.
- This host does not have `cargo`, `rustc`, or `rustfmt`, so local Rust fmt/clippy/tests could not be run here.
- The change is structured to be validated by GitHub Actions: Rust fmt, clippy, workspace tests, and aarch64 cross-compile.

## Test plan

Expected CI coverage:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked --all-targets`
- `cargo clippy --no-default-features`
- `cargo test --no-default-features`
- aarch64/Jetson cross-compile
