### PR TITLE
feat(agent): send runtime cache hints on agent turns

### DIFF
--- a/crates/genie-core/src/llm/genie_ai_runtime.rs
+++ b/crates/genie-core/src/llm/genie_ai_runtime.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use super::openai_compat::{OpenAiCompatClient, RequestProfile};
-use super::{LlmBackendClient, Message, ResponseFormat};
+use super::{LlmBackendClient, LlmRequestHints, Message, ResponseFormat};
 
 /// Adapter for the `genie-ai-runtime` OpenAI-compatible chat API surface.
 pub struct GenieAiRuntimeBackend {
@@ -53,6 +53,18 @@ impl LlmBackendClient for GenieAiRuntimeBackend {
             .await
     }
 
+    async fn chat_with_format_and_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+        hints: Option<&LlmRequestHints>,
+    ) -> Result<String> {
+        self.inner
+            .chat_with_format_and_hints(messages, max_tokens, response_format, hints)
+            .await
+    }
+
     async fn chat_stream(
         &self,
         messages: &[Message],
@@ -60,5 +72,17 @@ impl LlmBackendClient for GenieAiRuntimeBackend {
         on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
     ) -> Result<String> {
         self.inner.chat_stream(messages, max_tokens, on_token).await
+    }
+
+    async fn chat_stream_with_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        hints: Option<&LlmRequestHints>,
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String> {
+        self.inner
+            .chat_stream_with_hints(messages, max_tokens, hints, on_token)
+            .await
     }
 }

--- a/crates/genie-core/src/llm/llama_cpp.rs
+++ b/crates/genie-core/src/llm/llama_cpp.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use super::openai_compat::OpenAiCompatClient;
-use super::{LlmBackendClient, Message, ResponseFormat};
+use super::{LlmBackendClient, LlmRequestHints, Message, ResponseFormat};
 
 /// llama.cpp `--server` adapter for the OpenAI-compatible chat API.
 pub struct LlamaCppBackend {
@@ -44,12 +44,36 @@ impl LlmBackendClient for LlamaCppBackend {
             .await
     }
 
+    async fn chat_with_format_and_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+        hints: Option<&LlmRequestHints>,
+    ) -> Result<String> {
+        let _ = hints;
+        self.inner
+            .chat_with_format(messages, max_tokens, response_format)
+            .await
+    }
+
     async fn chat_stream(
         &self,
         messages: &[Message],
         max_tokens: Option<u32>,
         on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
     ) -> Result<String> {
+        self.inner.chat_stream(messages, max_tokens, on_token).await
+    }
+
+    async fn chat_stream_with_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        hints: Option<&LlmRequestHints>,
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String> {
+        let _ = hints;
         self.inner.chat_stream(messages, max_tokens, on_token).await
     }
 }

--- a/crates/genie-core/src/llm/mod.rs
+++ b/crates/genie-core/src/llm/mod.rs
@@ -30,12 +30,72 @@ pub trait LlmBackendClient: Send + Sync {
         response_format: Option<ResponseFormat>,
     ) -> Result<String>;
 
+    async fn chat_with_format_and_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+        hints: Option<&LlmRequestHints>,
+    ) -> Result<String> {
+        let _ = hints;
+        self.chat_with_format(messages, max_tokens, response_format)
+            .await
+    }
+
     async fn chat_stream(
         &self,
         messages: &[Message],
         max_tokens: Option<u32>,
         on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
     ) -> Result<String>;
+
+    async fn chat_stream_with_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        hints: Option<&LlmRequestHints>,
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String> {
+        let _ = hints;
+        self.chat_stream(messages, max_tokens, on_token).await
+    }
+}
+
+/// Harness-visible inference metadata for cache-aware local runtimes.
+///
+/// This mirrors the small Dynamo-style surface that matters to GenieClaw:
+/// stable session identity, expected output length, request priority, and
+/// short-lived cache retention. Generic backends ignore it; `genie-ai-runtime`
+/// serializes it as `conversation_id` plus `nvext.agent_hints`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LlmRequestHints {
+    pub session_id: Option<String>,
+    pub priority: Option<i32>,
+    pub output_sequence_length: Option<u32>,
+    pub speculative_prefill: bool,
+    pub cache_ttl_secs: Option<u32>,
+}
+
+impl LlmRequestHints {
+    pub fn agent_turn(session_id: impl Into<String>, output_sequence_length: u32) -> Self {
+        Self {
+            session_id: Some(session_id.into()),
+            priority: Some(50),
+            output_sequence_length: Some(output_sequence_length),
+            speculative_prefill: false,
+            cache_ttl_secs: Some(15 * 60),
+        }
+    }
+
+    pub fn tool_summary(session_id: impl Into<String>, output_sequence_length: u32) -> Self {
+        Self {
+            session_id: Some(session_id.into()),
+            priority: Some(30),
+            output_sequence_length: Some(output_sequence_length),
+            speculative_prefill: false,
+            cache_ttl_secs: Some(2 * 60),
+        }
+    }
 }
 
 /// LLM client facade used by agent orchestration.
@@ -135,6 +195,28 @@ impl LlmClient {
             .await
     }
 
+    pub async fn chat_with_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        hints: &LlmRequestHints,
+    ) -> Result<String> {
+        self.chat_with_format_and_hints(messages, max_tokens, None, Some(hints))
+            .await
+    }
+
+    pub async fn chat_with_format_and_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+        hints: Option<&LlmRequestHints>,
+    ) -> Result<String> {
+        self.backend
+            .chat_with_format_and_hints(messages, max_tokens, response_format, hints)
+            .await
+    }
+
     pub async fn chat_stream<F>(
         &self,
         messages: &[Message],
@@ -146,6 +228,21 @@ impl LlmClient {
     {
         self.backend
             .chat_stream(messages, max_tokens, &mut on_token)
+            .await
+    }
+
+    pub async fn chat_stream_with_hints<F>(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        hints: &LlmRequestHints,
+        mut on_token: F,
+    ) -> Result<String>
+    where
+        F: FnMut(&str) + Send,
+    {
+        self.backend
+            .chat_stream_with_hints(messages, max_tokens, Some(hints), &mut on_token)
             .await
     }
 }

--- a/crates/genie-core/src/llm/openai_compat.rs
+++ b/crates/genie-core/src/llm/openai_compat.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
+use super::LlmRequestHints;
+
 /// Raw HTTP client for local OpenAI-compatible chat completion backends.
 ///
 /// Supports both blocking completion and streaming (SSE).
@@ -36,11 +38,42 @@ pub(crate) struct ChatRequest {
     pub(crate) temperature: Option<f32>,
     pub(crate) stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) conversation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) think: Option<bool>,
     /// JSON schema constraint for backends that support OpenAI-compatible
     /// `response_format`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) response_format: Option<ResponseFormat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) nvext: Option<NvExt>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct NvExt {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) agent_hints: Option<AgentHints>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AgentHints {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) priority: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) osl: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) speculative_prefill: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CacheControl {
+    #[serde(rename = "type")]
+    pub(crate) cache_type: &'static str,
+    pub(crate) ttl: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -113,8 +146,10 @@ impl RequestProfile {
         max_tokens: Option<u32>,
         stream: bool,
         response_format: Option<ResponseFormat>,
+        hints: Option<&LlmRequestHints>,
     ) -> Result<PreparedChatBody> {
-        let body = self.serialize_body(messages, max_tokens, stream, response_format.clone())?;
+        let body =
+            self.serialize_body(messages, max_tokens, stream, response_format.clone(), hints)?;
         if !matches!(self, Self::GenieAiRuntime) || body.len() <= GENIE_RUNTIME_MAX_BODY_BYTES {
             return Ok(PreparedChatBody {
                 body,
@@ -123,8 +158,13 @@ impl RequestProfile {
         }
 
         let compacted_messages = self.compact_messages(messages, GENIE_RUNTIME_MAX_BODY_BYTES);
-        let compacted_body =
-            self.serialize_body(&compacted_messages, max_tokens, stream, response_format)?;
+        let compacted_body = self.serialize_body(
+            &compacted_messages,
+            max_tokens,
+            stream,
+            response_format,
+            hints,
+        )?;
         Ok(PreparedChatBody {
             body: compacted_body,
             compacted: true,
@@ -137,15 +177,19 @@ impl RequestProfile {
         max_tokens: Option<u32>,
         stream: bool,
         response_format: Option<ResponseFormat>,
+        hints: Option<&LlmRequestHints>,
     ) -> Result<String> {
+        let conversation_id = self.runtime_session_id(hints);
         let request = ChatRequest {
             model: self.model().into(),
             messages: messages.to_vec(),
             max_tokens,
             temperature: Some(0.7),
             stream,
+            conversation_id,
             think: self.think_override(),
             response_format,
+            nvext: self.nvext(hints),
         };
         Ok(serde_json::to_string(&request)?)
     }
@@ -168,6 +212,22 @@ impl RequestProfile {
         match self {
             Self::Generic => messages.to_vec(),
             Self::GenieAiRuntime => compact_genie_runtime_messages(messages, max_body_bytes),
+        }
+    }
+
+    fn runtime_session_id(&self, hints: Option<&LlmRequestHints>) -> Option<String> {
+        match self {
+            Self::Generic => None,
+            Self::GenieAiRuntime => hints
+                .and_then(|h| h.session_id.as_deref())
+                .and_then(normalize_runtime_session_id),
+        }
+    }
+
+    fn nvext(&self, hints: Option<&LlmRequestHints>) -> Option<NvExt> {
+        match self {
+            Self::Generic => None,
+            Self::GenieAiRuntime => hints.and_then(build_nvext),
         }
     }
 }
@@ -263,9 +323,55 @@ impl OpenAiCompatClient {
         max_tokens: Option<u32>,
         response_format: Option<ResponseFormat>,
     ) -> Result<String> {
-        let prepared =
-            self.request_profile
-                .prepare_body(messages, max_tokens, false, response_format)?;
+        let prepared = self.request_profile.prepare_body(
+            messages,
+            max_tokens,
+            false,
+            response_format,
+            None,
+        )?;
+        self.chat_with_prepared_body(prepared).await
+    }
+
+    pub async fn chat_with_format_and_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+        hints: Option<&LlmRequestHints>,
+    ) -> Result<String> {
+        match self
+            .chat_with_format_once_and_hints(messages, max_tokens, response_format.clone(), hints)
+            .await
+        {
+            Ok(content) => Ok(content),
+            Err(err) if should_retry_without_system_role(messages, &err.to_string()) => {
+                let flattened = flatten_system_into_first_user(messages);
+                self.chat_with_format_once_and_hints(&flattened, max_tokens, response_format, hints)
+                    .await
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn chat_with_format_once_and_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+        hints: Option<&LlmRequestHints>,
+    ) -> Result<String> {
+        let prepared = self.request_profile.prepare_body(
+            messages,
+            max_tokens,
+            false,
+            response_format,
+            hints,
+        )?;
+        self.chat_with_prepared_body(prepared).await
+    }
+
+    async fn chat_with_prepared_body(&self, prepared: PreparedChatBody) -> Result<String> {
         if prepared.compacted {
             tracing::debug!(
                 backend = self.backend_name,
@@ -321,7 +427,30 @@ impl OpenAiCompatClient {
     ) -> Result<String> {
         let prepared = self
             .request_profile
-            .prepare_body(messages, max_tokens, true, None)?;
+            .prepare_body(messages, max_tokens, true, None, None)?;
+        self.chat_stream_with_prepared_body(prepared, on_token)
+            .await
+    }
+
+    pub async fn chat_stream_with_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        hints: Option<&LlmRequestHints>,
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String> {
+        let prepared = self
+            .request_profile
+            .prepare_body(messages, max_tokens, true, None, hints)?;
+        self.chat_stream_with_prepared_body(prepared, on_token)
+            .await
+    }
+
+    async fn chat_stream_with_prepared_body(
+        &self,
+        prepared: PreparedChatBody,
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String> {
         if prepared.compacted {
             tracing::debug!(
                 backend = self.backend_name,
@@ -500,6 +629,67 @@ impl OpenAiCompatClient {
 
         tokio::io::AsyncReadExt::read_to_string(&mut buf_reader, &mut body).await?;
         Ok(HttpResponse { status, body })
+    }
+}
+
+fn build_nvext(hints: &LlmRequestHints) -> Option<NvExt> {
+    let session_id = hints
+        .session_id
+        .as_deref()
+        .and_then(normalize_runtime_session_id);
+    let agent_hints = if session_id.is_some()
+        || hints.priority.is_some()
+        || hints.output_sequence_length.is_some()
+        || hints.speculative_prefill
+    {
+        Some(AgentHints {
+            session_id,
+            priority: hints.priority,
+            osl: hints.output_sequence_length,
+            speculative_prefill: hints.speculative_prefill.then_some(true),
+        })
+    } else {
+        None
+    };
+
+    let cache_control = hints.cache_ttl_secs.map(|ttl| CacheControl {
+        cache_type: "ephemeral",
+        ttl: format_ttl(ttl),
+    });
+
+    if agent_hints.is_some() || cache_control.is_some() {
+        Some(NvExt {
+            agent_hints,
+            cache_control,
+        })
+    } else {
+        None
+    }
+}
+
+fn normalize_runtime_session_id(raw: &str) -> Option<String> {
+    let mut out = String::with_capacity(raw.len().min(64));
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            out.push(ch);
+        } else if !out.ends_with('_') {
+            out.push('_');
+        }
+        if out.len() == 64 {
+            break;
+        }
+    }
+    let out = out.trim_matches('_').to_string();
+    if out.is_empty() { None } else { Some(out) }
+}
+
+fn format_ttl(secs: u32) -> String {
+    if secs >= 3600 && secs % 3600 == 0 {
+        format!("{}h", secs / 3600)
+    } else if secs >= 60 && secs % 60 == 0 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{secs}s")
     }
 }
 
@@ -797,12 +987,75 @@ mod tests {
             max_tokens: Some(256),
             temperature: Some(0.7),
             stream: false,
+            conversation_id: None,
             think: None,
             response_format: None,
+            nvext: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("nemotron-4b"));
         assert!(json.contains("turn on the lights"));
+    }
+
+    #[test]
+    fn generic_request_profile_omits_runtime_hints() {
+        let profile = RequestProfile::generic();
+        let hints = LlmRequestHints::agent_turn("conv-abc", 256);
+        let prepared = profile
+            .prepare_body(
+                &[Message {
+                    role: "user".into(),
+                    content: "hello".into(),
+                }],
+                Some(64),
+                false,
+                None,
+                Some(&hints),
+            )
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&prepared.body).unwrap();
+
+        assert!(json.get("conversation_id").is_none());
+        assert!(json.get("nvext").is_none());
+    }
+
+    #[test]
+    fn genie_runtime_profile_serializes_session_and_cache_hints() {
+        let profile = RequestProfile::genie_ai_runtime();
+        let hints = LlmRequestHints::agent_turn("conv-abc", 512);
+        let prepared = profile
+            .prepare_body(
+                &[Message {
+                    role: "user".into(),
+                    content: "turn on the lights".into(),
+                }],
+                Some(512),
+                false,
+                None,
+                Some(&hints),
+            )
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&prepared.body).unwrap();
+
+        assert_eq!(json["conversation_id"], "conv-abc");
+        assert_eq!(json["nvext"]["agent_hints"]["session_id"], "conv-abc");
+        assert_eq!(json["nvext"]["agent_hints"]["priority"], 50);
+        assert_eq!(json["nvext"]["agent_hints"]["osl"], 512);
+        assert_eq!(json["nvext"]["cache_control"]["type"], "ephemeral");
+        assert_eq!(json["nvext"]["cache_control"]["ttl"], "15m");
+    }
+
+    #[test]
+    fn runtime_session_ids_are_sanitized_for_cache_files() {
+        assert_eq!(
+            normalize_runtime_session_id("voice/session 1").as_deref(),
+            Some("voice_session_1")
+        );
+        assert_eq!(normalize_runtime_session_id("///"), None);
+        assert_eq!(
+            normalize_runtime_session_id(&"x".repeat(80)).unwrap().len(),
+            64
+        );
     }
 
     #[test]
@@ -820,7 +1073,7 @@ mod tests {
         ];
 
         let prepared = profile
-            .prepare_body(&messages, Some(64), false, None)
+            .prepare_body(&messages, Some(64), false, None, None)
             .unwrap();
         let json: serde_json::Value = serde_json::from_str(&prepared.body).unwrap();
 
@@ -856,7 +1109,7 @@ mod tests {
         ];
 
         let prepared = profile
-            .prepare_body(&messages, Some(64), false, None)
+            .prepare_body(&messages, Some(64), false, None, None)
             .unwrap();
         let json: serde_json::Value = serde_json::from_str(&prepared.body).unwrap();
         let serialized_messages = json["messages"].to_string();
@@ -889,7 +1142,7 @@ mod tests {
         ];
 
         let prepared = profile
-            .prepare_body(&messages, Some(64), false, None)
+            .prepare_body(&messages, Some(64), false, None, None)
             .unwrap();
         let json: serde_json::Value = serde_json::from_str(&prepared.body).unwrap();
         let serialized_messages = json["messages"].to_string();

--- a/crates/genie-core/src/repl.rs
+++ b/crates/genie-core/src/repl.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::conversation::ConversationStore;
-use crate::llm::{LlmClient, Message};
+use crate::llm::{LlmClient, LlmRequestHints, Message};
 use crate::memory::{self, Memory};
 use crate::prompt::ModelFamily;
 use crate::reasoning::InteractionKind;
@@ -134,8 +134,9 @@ pub async fn run(
 
         // Stream LLM response.
         eprint!("\nGeniePod: ");
+        let request_hints = LlmRequestHints::agent_turn(&conv_id, 512);
         match llm
-            .chat_stream(&messages, Some(512), |token| {
+            .chat_stream_with_hints(&messages, Some(512), &request_hints, |token| {
                 eprint!("{}", token);
             })
             .await
@@ -197,8 +198,11 @@ pub async fn run(
                         );
 
                         eprint!("GeniePod: ");
+                        let summary_hints = LlmRequestHints::tool_summary(&conv_id, 128);
                         match llm
-                            .chat_stream(&summary_msgs, Some(128), |t| eprint!("{}", t))
+                            .chat_stream_with_hints(&summary_msgs, Some(128), &summary_hints, |t| {
+                                eprint!("{}", t)
+                            })
                             .await
                         {
                             Ok(summary) => {

--- a/crates/genie-core/src/server.rs
+++ b/crates/genie-core/src/server.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex;
 
 use crate::connectivity::{ConnectivityController, ConnectivityHealth, ConnectivityState};
 use crate::conversation::ConversationStore;
-use crate::llm::{LlmClient, Message};
+use crate::llm::{LlmClient, LlmRequestHints, Message};
 use crate::memory::Memory;
 use crate::prompt::ModelFamily;
 use crate::reasoning::InteractionKind;
@@ -582,9 +582,11 @@ async fn handle_chat_stream(
     // their mutable borrow on `writer` released — before we write the final
     // "done" event below.
     let (llm_result, mut state) = {
-        let producer = llm.chat_stream(&messages, Some(512), move |token| {
-            let _ = tx.send(token.to_string());
-        });
+        let request_hints = LlmRequestHints::agent_turn(&conv_id, 512);
+        let producer =
+            llm.chat_stream_with_hints(&messages, Some(512), &request_hints, move |token| {
+                let _ = tx.send(token.to_string());
+            });
 
         let consumer = async {
             let mut state = StreamState {
@@ -772,7 +774,10 @@ pub async fn process_chat_turn(
         "applied reasoning mode for chat turn"
     );
 
-    let llm_response = llm.chat(&messages, Some(512)).await?;
+    let request_hints = LlmRequestHints::agent_turn(conv_id, 512);
+    let llm_response = llm
+        .chat_with_hints(&messages, Some(512), &request_hints)
+        .await?;
 
     let mut tool_name: Option<String> = None;
     let final_response = if let Some(tool_result) = crate::tools::try_tool_call_with_context(
@@ -871,7 +876,8 @@ async fn finalize_tool_turn(
             InteractionKind::ToolSummary,
         );
 
-        llm.chat(&summary_msgs, Some(128))
+        let summary_hints = LlmRequestHints::tool_summary(conv_id, 128);
+        llm.chat_with_hints(&summary_msgs, Some(128), &summary_hints)
             .await
             .unwrap_or_else(|_| tool_result.output.clone())
     } else {
@@ -1693,8 +1699,16 @@ async fn handle_openai_chat(
         "applied reasoning mode for OpenAI bridge"
     );
 
+    let bridge_hints = llm_hints_from_openai_body(&parsed, max_tokens);
+
     // Call LLM.
-    let llm_response = match llm.chat(&llm_messages, Some(max_tokens)).await {
+    let llm_response_result = if let Some(hints) = bridge_hints.as_ref() {
+        llm.chat_with_hints(&llm_messages, Some(max_tokens), hints)
+            .await
+    } else {
+        llm.chat(&llm_messages, Some(max_tokens)).await
+    };
+    let llm_response = match llm_response_result {
         Ok(r) => r,
         Err(e) => {
             tracing::error!(error = %e, "LLM error in OpenAI bridge");
@@ -1748,9 +1762,19 @@ async fn handle_openai_chat(
                 InteractionKind::ToolSummary,
             );
 
-            llm.chat(&summary_msgs, Some(128))
-                .await
-                .unwrap_or_else(|_| tool_result.output.clone())
+            if let Some(hints) = bridge_hints.as_ref() {
+                let summary_hints = LlmRequestHints::tool_summary(
+                    hints.session_id.clone().unwrap_or_default(),
+                    128,
+                );
+                llm.chat_with_hints(&summary_msgs, Some(128), &summary_hints)
+                    .await
+                    .unwrap_or_else(|_| tool_result.output.clone())
+            } else {
+                llm.chat(&summary_msgs, Some(128))
+                    .await
+                    .unwrap_or_else(|_| tool_result.output.clone())
+            }
         } else {
             tool_result.output
         }
@@ -1794,6 +1818,55 @@ fn openai_chat_response(model: &str, content: &str) -> (u16, &'static str, Strin
     });
 
     (200, "application/json", response.to_string())
+}
+
+fn llm_hints_from_openai_body(
+    parsed: &serde_json::Value,
+    max_tokens: u32,
+) -> Option<LlmRequestHints> {
+    let session_id = parsed
+        .get("conversation_id")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            parsed
+                .get("nvext")
+                .and_then(|v| v.get("agent_hints"))
+                .and_then(|v| v.get("session_id"))
+                .and_then(|v| v.as_str())
+        })?
+        .trim();
+
+    if session_id.is_empty() {
+        return None;
+    }
+
+    let mut hints = LlmRequestHints::agent_turn(session_id, max_tokens);
+    if let Some(priority) = parsed
+        .get("nvext")
+        .and_then(|v| v.get("agent_hints"))
+        .and_then(|v| v.get("priority"))
+        .and_then(|v| v.as_i64())
+    {
+        hints.priority = Some(priority.clamp(i32::MIN as i64, i32::MAX as i64) as i32);
+    }
+    if let Some(osl) = parsed
+        .get("nvext")
+        .and_then(|v| v.get("agent_hints"))
+        .and_then(|v| v.get("osl"))
+        .and_then(|v| v.as_u64())
+    {
+        hints.output_sequence_length = Some(osl.min(u32::MAX as u64) as u32);
+    }
+    if let Some(speculative_prefill) = parsed
+        .get("nvext")
+        .and_then(|v| v.get("agent_hints"))
+        .and_then(|v| v.get("speculative_prefill"))
+        .and_then(|v| v.as_bool())
+    {
+        hints.speculative_prefill = speculative_prefill;
+    }
+
+    Some(hints)
 }
 
 fn parse_openai_messages(messages: &[serde_json::Value], max_history: usize) -> Vec<Message> {

--- a/crates/genie-core/src/voice/streaming.rs
+++ b/crates/genie-core/src/voice/streaming.rs
@@ -39,6 +39,17 @@ pub async fn stream_and_speak(
     max_tokens: u32,
     tts_engine: Arc<TtsEngine>,
 ) -> Result<String> {
+    stream_and_speak_with_hints(llm, messages, max_tokens, tts_engine, None).await
+}
+
+/// Stream the LLM response with optional runtime cache/scheduling hints.
+pub async fn stream_and_speak_with_hints(
+    llm: &crate::llm::LlmClient,
+    messages: &[crate::llm::Message],
+    max_tokens: u32,
+    tts_engine: Arc<TtsEngine>,
+    hints: Option<&crate::llm::LlmRequestHints>,
+) -> Result<String> {
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
 
     let tts_for_task = Arc::clone(&tts_engine);
@@ -59,14 +70,21 @@ pub async fn stream_and_speak(
     let mut full_response = String::new();
     let mut streamer = SentenceStreamer::new(MAX_SPOKEN_SENTENCES);
 
-    let stream_result = llm
-        .chat_stream(messages, Some(max_tokens), |token| {
+    let stream_result = {
+        let mut on_token = |token: &str| {
             full_response.push_str(token);
             for sentence in streamer.feed(token) {
                 let _ = tx.send(sentence);
             }
-        })
-        .await;
+        };
+        if let Some(hints) = hints {
+            llm.chat_stream_with_hints(messages, Some(max_tokens), hints, &mut on_token)
+                .await
+        } else {
+            llm.chat_stream(messages, Some(max_tokens), &mut on_token)
+                .await
+        }
+    };
 
     // Always flush and close the channel so the TTS task exits cleanly,
     // whether the LLM stream succeeded or errored partway through.

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -19,7 +19,7 @@ use tokio::process::Command;
 static FIRST_REPLY_BANNER_PRINTED: AtomicBool = AtomicBool::new(false);
 
 use crate::conversation::ConversationStore;
-use crate::llm::LlmClient;
+use crate::llm::{LlmClient, LlmRequestHints};
 use crate::memory::Memory;
 use crate::memory::{extract, inject};
 use crate::prompt::ModelFamily;
@@ -420,11 +420,13 @@ async fn run_with_wakeword(
                                 audio_device,
                                 response_language.as_deref(),
                             ));
-                            match streaming::stream_and_speak(
+                            let request_hints = LlmRequestHints::agent_turn(conv_id, 256);
+                            match streaming::stream_and_speak_with_hints(
                                 llm,
                                 &messages,
                                 256,
                                 Arc::clone(&tts_engine),
+                                Some(&request_hints),
                             )
                             .await
                             {
@@ -1091,31 +1093,42 @@ pub async fn process_transcript(
         None => tts_engine_for_language(voice_cfg, audio_device, response_language.as_deref()),
     });
 
-    let response =
-        match streaming::stream_and_speak(llm, &messages, 256, Arc::clone(&tts_engine)).await {
-            Ok(r) => r,
-            Err(e) => {
-                // Fallback: try non-streaming if streaming fails.
-                eprintln!(
-                    "[voice] Streaming failed for {} backend ({}), trying blocking...",
-                    llm.backend_name(),
-                    e
-                );
-                match llm.chat(&messages, Some(256)).await {
-                    Ok(r) => {
-                        let voice_text = format::for_voice(&r);
-                        if !voice_text.is_empty() {
-                            let _ = tts_engine.speak(&voice_text).await;
-                        }
-                        r
+    let request_hints = LlmRequestHints::agent_turn(conv_id, 256);
+    let response = match streaming::stream_and_speak_with_hints(
+        llm,
+        &messages,
+        256,
+        Arc::clone(&tts_engine),
+        Some(&request_hints),
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            // Fallback: try non-streaming if streaming fails.
+            eprintln!(
+                "[voice] Streaming failed for {} backend ({}), trying blocking...",
+                llm.backend_name(),
+                e
+            );
+            match llm
+                .chat_with_hints(&messages, Some(256), &request_hints)
+                .await
+            {
+                Ok(r) => {
+                    let voice_text = format::for_voice(&r);
+                    if !voice_text.is_empty() {
+                        let _ = tts_engine.speak(&voice_text).await;
                     }
-                    Err(e2) => {
-                        eprintln!("[voice] LLM backend error ({}): {}", llm.backend_name(), e2);
-                        return true;
-                    }
+                    r
+                }
+                Err(e2) => {
+                    eprintln!("[voice] LLM backend error ({}): {}", llm.backend_name(), e2);
+                    return true;
                 }
             }
-        };
+        }
+    };
 
     let llm_tts_ms = llm_start.elapsed().as_millis();
 
@@ -1172,23 +1185,29 @@ pub async fn process_transcript(
             InteractionKind::ToolSummary,
         );
 
-        let summary =
-            match streaming::stream_and_speak(llm, &summary_msgs, 128, Arc::clone(&tts_engine))
-                .await
-            {
-                Ok(s) => s,
-                Err(_) => {
-                    let s = llm
-                        .chat(&summary_msgs, Some(128))
-                        .await
-                        .unwrap_or_else(|_| tool_result.output.clone());
-                    let voice_text = format::for_voice(&s);
-                    if !voice_text.is_empty() {
-                        let _ = tts_engine.speak(&voice_text).await;
-                    }
-                    s
+        let summary_hints = LlmRequestHints::tool_summary(conv_id, 128);
+        let summary = match streaming::stream_and_speak_with_hints(
+            llm,
+            &summary_msgs,
+            128,
+            Arc::clone(&tts_engine),
+            Some(&summary_hints),
+        )
+        .await
+        {
+            Ok(s) => s,
+            Err(_) => {
+                let s = llm
+                    .chat_with_hints(&summary_msgs, Some(128), &summary_hints)
+                    .await
+                    .unwrap_or_else(|_| tool_result.output.clone());
+                let voice_text = format::for_voice(&s);
+                if !voice_text.is_empty() {
+                    let _ = tts_engine.speak(&voice_text).await;
                 }
-            };
+                s
+            }
+        };
 
         let _ = conversations.append(conv_id, "assistant", &summary, None);
         (summary, Some(tool_result.tool))


### PR DESCRIPTION
Refs #152
Depends on #153.

## Summary

- pass stable `LlmRequestHints` through `/api/chat`, `/api/chat/stream`, and the OpenAI-compatible bridge
- apply short-lived tool-summary hints so summary calls stay tied to the same cacheable session
- wire hint-aware streaming through REPL and voice paths
- preserve fallback behavior for runtimes that ignore hints

## Verification

- `cargo fmt --check`
- `cargo check -p genie-core`
- `cargo test -p genie-core llm::openai_compat --lib`