### PR TITLE
fix(core): satisfy current clippy TTL multiple checks

### DIFF
--- a/crates/genie-core/src/llm/openai_compat.rs
+++ b/crates/genie-core/src/llm/openai_compat.rs
@@ -684,9 +684,9 @@ fn normalize_runtime_session_id(raw: &str) -> Option<String> {
 }
 
 fn format_ttl(secs: u32) -> String {
-    if secs >= 3600 && secs % 3600 == 0 {
+    if secs >= 3600 && secs.is_multiple_of(3600) {
         format!("{}h", secs / 3600)
-    } else if secs >= 60 && secs % 60 == 0 {
+    } else if secs >= 60 && secs.is_multiple_of(60) {
         format!("{}m", secs / 60)
     } else {
         format!("{secs}s")


### PR DESCRIPTION
## Summary

Fixes current Rust 1.95 clippy failures on main by using `is_multiple_of` in TTL formatting. This repairs the clippy failures seen after #156 merged.

## Changes

- Replaces manual modulo multiple checks in `format_ttl` with `u32::is_multiple_of`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

No Jetson available in this shell; this is a pure Rust clippy repair.

- `$HOME/.cargo/bin/cargo fmt --check`
- `$HOME/.cargo/bin/cargo clippy -p genie-core --all-targets --all-features -- -D warnings`
- `$HOME/.cargo/bin/cargo clippy -p genie-core --no-default-features --all-targets -- -D warnings`
- `$HOME/.cargo/bin/cargo test -p genie-core --no-default-features`

### What I observed

All commands passed locally. The no-default test run passed 357 lib tests, 38 integration tests, and doctests.

## Test plan

- Re-run the commands above.

## Notes for reviewers

This is a current-toolchain clippy-only repair for main after #156.