### PR TITLE
fix(config): derive core health URL from core port

### DIFF
--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -225,7 +225,7 @@ fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
         ServiceTarget {
             service: "core".into(),
             unit: config.services.core.systemd_unit.clone(),
-            latency_url: Some(config.services.core.url.clone()),
+            latency_url: Some(config.core_health_url()),
             disabled_reason: None,
         },
         ServiceTarget {
@@ -925,6 +925,24 @@ mod tests {
         let mut config = test_config();
         config.core.port = 3001;
         assert_eq!(config.core_http_addr(), "127.0.0.1:3001");
+    }
+
+    #[test]
+    fn dashboard_core_target_uses_derived_health_url() {
+        let mut config = test_config();
+        config.core.port = 3001;
+        config.services.core.url = "http://127.0.0.1:3000/api/health".into();
+
+        let targets = dashboard_service_targets(&config);
+        let core_target = targets
+            .iter()
+            .find(|target| target.service == "core")
+            .expect("core target should always be present");
+
+        assert_eq!(
+            core_target.latency_url.as_deref(),
+            Some("http://127.0.0.1:3001/api/health"),
+        );
     }
 
     #[test]

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -960,6 +960,16 @@ impl Config {
         format!("{host}:{}", self.core.port)
     }
 
+    /// Health-probe URL for genie-core, derived from `[core].bind_host` and
+    /// `[core].port` instead of `[services.core].url`.
+    ///
+    /// Local probes should follow where core actually listens. Reading
+    /// `[services.core].url` can drift when an operator changes `[core].port`
+    /// but leaves the service URL at its default, producing false DOWN signals.
+    pub fn core_health_url(&self) -> String {
+        format!("http://{}/api/health", self.core_http_addr())
+    }
+
     /// TCP `host:port` for `genie-api` to bind, derived from `[services.api].url`.
     ///
     /// Keeps the listen socket aligned with health probes and `genie-ctl` that
@@ -1556,6 +1566,42 @@ systemd_unit = "genie-ai-runtime.service"
         config.core.port = 3000;
         config.core.bind_host = "0.0.0.0".into();
         assert_eq!(config.core_http_addr(), "127.0.0.1:3000");
+    }
+
+    #[test]
+    fn core_health_url_uses_default_port() {
+        let config = test_config();
+        assert_eq!(config.core_health_url(), "http://127.0.0.1:3000/api/health");
+    }
+
+    #[test]
+    fn core_health_url_tracks_custom_core_port() {
+        let mut config = test_config();
+        config.core.port = 3001;
+        assert_eq!(config.core_health_url(), "http://127.0.0.1:3001/api/health");
+    }
+
+    #[test]
+    fn core_health_url_maps_listen_all_to_loopback() {
+        let mut config = test_config();
+        config.core.bind_host = "0.0.0.0".into();
+        assert_eq!(config.core_health_url(), "http://127.0.0.1:3000/api/health");
+    }
+
+    #[test]
+    fn core_health_url_honors_custom_bind_host() {
+        let mut config = test_config();
+        config.core.bind_host = "10.0.0.5".into();
+        config.core.port = 4000;
+        assert_eq!(config.core_health_url(), "http://10.0.0.5:4000/api/health");
+    }
+
+    #[test]
+    fn core_health_url_ignores_stale_services_core_url() {
+        let mut config = test_config();
+        config.core.port = 3001;
+        config.services.core.url = "http://127.0.0.1:3000/api/health".into();
+        assert_eq!(config.core_health_url(), "http://127.0.0.1:3001/api/health");
     }
 
     #[test]

--- a/crates/genie-health/src/checker.rs
+++ b/crates/genie-health/src/checker.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use genie_common::config::{Config, ServiceEndpoint};
+use genie_common::config::Config;
 use rusqlite::Connection;
 use tokio::net::TcpStream;
 use tokio::signal::unix::{SignalKind, signal};
@@ -22,6 +22,29 @@ pub struct HealthMonitor {
     db: Connection,
     /// Track consecutive failures per service for alert dedup.
     failure_counts: std::collections::HashMap<String, u32>,
+}
+
+/// Materialize `(name, probe_url)` pairs for every service the health monitor
+/// owns. Core's probe is derived from `[core].bind_host` and `[core].port` so it
+/// tracks where core actually listens even if `[services.core].url` is stale.
+fn collect_endpoints(config: &Config) -> Vec<(String, String)> {
+    let mut endpoints = vec![
+        ("core".into(), config.core_health_url()),
+        ("llm".into(), config.services.llm.url.clone()),
+    ];
+
+    if let Some(ref ha) = config.services.homeassistant {
+        endpoints.push(("homeassistant".into(), ha.url.clone()));
+    }
+
+    if let Some(ref nc) = config.services.nextcloud {
+        endpoints.push(("nextcloud".into(), nc.url.clone()));
+    }
+    if let Some(ref jf) = config.services.jellyfin {
+        endpoints.push(("jellyfin".into(), jf.url.clone()));
+    }
+
+    endpoints
 }
 
 impl HealthMonitor {
@@ -83,11 +106,7 @@ impl HealthMonitor {
         let ts_ms = now_ms();
 
         // Collect endpoints as owned data to avoid borrowing self in the loop.
-        let services: Vec<(String, String)> = self
-            .collect_endpoints()
-            .into_iter()
-            .map(|(name, ep)| (name, ep.url.clone()))
-            .collect();
+        let services = collect_endpoints(&self.config);
 
         for (name, url) in &services {
             let status = check_http(name, url).await;
@@ -131,26 +150,6 @@ impl HealthMonitor {
         let _ = self
             .db
             .execute("DELETE FROM health_log WHERE ts_ms < ?1", [cutoff]);
-    }
-
-    fn collect_endpoints(&self) -> Vec<(String, &ServiceEndpoint)> {
-        let mut endpoints = vec![
-            ("core".into(), &self.config.services.core),
-            ("llm".into(), &self.config.services.llm),
-        ];
-
-        if let Some(ref ha) = self.config.services.homeassistant {
-            endpoints.push(("homeassistant".into(), ha));
-        }
-
-        if let Some(ref nc) = self.config.services.nextcloud {
-            endpoints.push(("nextcloud".into(), nc));
-        }
-        if let Some(ref jf) = self.config.services.jellyfin {
-            endpoints.push(("jellyfin".into(), jf));
-        }
-
-        endpoints
     }
 
     async fn send_alert(&self, status: &ServiceStatus) {
@@ -330,12 +329,42 @@ mod tests {
 
     #[test]
     fn collect_endpoints_skips_unconfigured_homeassistant() {
-        let monitor = HealthMonitor::new(test_config()).unwrap();
-        let endpoints = monitor.collect_endpoints();
+        let endpoints = collect_endpoints(&test_config());
         let names: Vec<&str> = endpoints.iter().map(|(name, _)| name.as_str()).collect();
 
         assert!(names.contains(&"core"));
         assert!(names.contains(&"llm"));
         assert!(!names.contains(&"homeassistant"));
+    }
+
+    #[test]
+    fn core_endpoint_url_tracks_configured_core_port() {
+        let mut config = test_config();
+        config.core.port = 3001;
+        config.services.core.url = "http://127.0.0.1:3000/api/health".into();
+
+        let endpoints = collect_endpoints(&config);
+        let core_url = endpoints
+            .iter()
+            .find(|(name, _)| name == "core")
+            .map(|(_, url)| url.as_str())
+            .expect("core endpoint should always be present");
+
+        assert_eq!(core_url, "http://127.0.0.1:3001/api/health");
+    }
+
+    #[test]
+    fn llm_endpoint_url_still_sources_from_services_config() {
+        let mut config = test_config();
+        config.services.llm.url = "http://127.0.0.1:9999/v1/health".into();
+
+        let endpoints = collect_endpoints(&config);
+        let llm_url = endpoints
+            .iter()
+            .find(|(name, _)| name == "llm")
+            .map(|(_, url)| url.as_str())
+            .expect("llm endpoint should always be present");
+
+        assert_eq!(llm_url, "http://127.0.0.1:9999/v1/health");
     }
 }


### PR DESCRIPTION
## Summary

Ports the valid #122 fix onto current main and closes #121. The original PR is closed, conflicting, and has maintainer edits disabled, so this carries the same repaired behavior on an ai-hpc branch.

## Changes

- Adds `Config::core_health_url()` derived from `[core].bind_host` and `[core].port`.
- Makes genie-health and the dashboard Services core row use the derived core health URL.
- Keeps LLM and optional service probes sourced from `[services.<name>].url`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

No Jetson available in this shell; this is config/probe routing logic with focused unit coverage.

- `$HOME/.cargo/bin/cargo fmt --check`
- `$HOME/.cargo/bin/cargo test -p genie-common core_health_url`
- `$HOME/.cargo/bin/cargo test -p genie-api dashboard_core_target_uses_derived_health_url`
- `$HOME/.cargo/bin/cargo test -p genie-health endpoint`
- `$HOME/.cargo/bin/cargo clippy -p genie-common -p genie-api -p genie-health --all-targets -- -D warnings`

### What I observed

All commands passed locally. The revived health tests call endpoint collection without opening the SQLite health DB, so the old #122 database-lock review blocker is not present.

## Test plan

- Re-run the commands above.
- With `[core].port = 3001` and stale `[services.core].url` on `:3000`, confirm core probes use `http://127.0.0.1:3001/api/health`.

## Notes for reviewers

Supersedes #122.

Closes #121.