### PR TITLE
test(home): regression for confirmed sensitive action at policy gate (closes #162)

### DIFF
--- a/crates/genie-core/src/tools/home.rs
+++ b/crates/genie-core/src/tools/home.rs
@@ -323,6 +323,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn control_confirmation_origin_executes_sensitive_action_when_confirmed() {
+        // Regression for #138 / #162: `confirm_pending_home_action` re-dispatches
+        // with `RequestOrigin::Confirmation` and `confirmed: true` — the policy
+        // gate must not mint another ConfirmationRequired token.
+        let home = StubHome {
+            domain: "lock",
+            voice_safe: false,
+        };
+
+        let result = control(
+            &home,
+            "Front door",
+            "unlock",
+            None,
+            &ActuationSafetyConfig::default(),
+            RequestOrigin::Confirmation,
+            true,
+        )
+        .await
+        .unwrap();
+
+        match result {
+            ControlOutcome::Executed(output, _) => assert!(output.contains("Unlock")),
+            ControlOutcome::ConfirmationRequired { .. } => {
+                panic!("Confirmation origin with confirmed=true must execute, not re-prompt")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn control_confirmation_origin_still_requires_confirm_when_unconfirmed() {
+        let home = StubHome {
+            domain: "lock",
+            voice_safe: false,
+        };
+
+        let result = control(
+            &home,
+            "Front door",
+            "unlock",
+            None,
+            &ActuationSafetyConfig::default(),
+            RequestOrigin::Confirmation,
+            false,
+        )
+        .await
+        .unwrap();
+
+        match result {
+            ControlOutcome::ConfirmationRequired { .. } => {}
+            ControlOutcome::Executed(_, _) => {
+                panic!("unconfirmed sensitive action must not execute at policy gate")
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn control_blocks_low_confidence_runtime_target() {
         struct LowConfidenceHome;
 


### PR DESCRIPTION
## Summary

- Add `control_confirmation_origin_executes_sensitive_action_when_confirmed` — covers the real `confirm_pending_home_action` re-dispatch path (`RequestOrigin::Confirmation`, `confirmed: true`).
- Add `control_confirmation_origin_still_requires_confirm_when_unconfirmed` — policy gate still returns `ConfirmationRequired` when `confirmed: false`.
- Complements existing `control_executes_sensitive_action_once_confirmed` (Telegram + confirmed), merged with #141 / #138 fix.

Closes #162

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
cargo test -p genie-core control_confirmation_origin
cargo fmt --all -- --check
```

### What I observed

Both new tests passed. No production code changes — tests only.

## Test plan

- [x] `cargo test -p genie-core control_confirmation_origin`
- [x] `cargo test -p genie-core control_executes_sensitive_action_once_confirmed`
- [x] `cargo fmt --all -- --check`