### PR TITLE
fix(dashboard): derive api Services latency_url from api_http_addr (closes #164)

### DIFF
--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -237,7 +237,7 @@ fn dashboard_service_targets(config: &Config) -> Vec<ServiceTarget> {
         ServiceTarget {
             service: "api".into(),
             unit: config.services.api.systemd_unit.clone(),
-            latency_url: Some(config.services.api.url.clone()),
+            latency_url: config.api_status_url().ok(),
             disabled_reason: None,
         },
         ServiceTarget {
@@ -942,6 +942,23 @@ mod tests {
         assert_eq!(
             core_target.latency_url.as_deref(),
             Some("http://127.0.0.1:3001/api/health"),
+        );
+    }
+
+    #[test]
+    fn dashboard_api_target_uses_derived_status_url() {
+        let mut config = test_config();
+        config.services.api.url = "127.0.0.1:4080/api/status".into();
+
+        let targets = dashboard_service_targets(&config);
+        let api_target = targets
+            .iter()
+            .find(|target| target.service == "api")
+            .expect("api target should always be present");
+
+        assert_eq!(
+            api_target.latency_url.as_deref(),
+            Some("http://127.0.0.1:4080/api/status"),
         );
     }
 

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -984,6 +984,14 @@ impl Config {
         }
     }
 
+    /// Status-probe URL for genie-api, derived from `[services.api].url` host:port.
+    ///
+    /// Normalizes bare authorities (e.g. `127.0.0.1:4080/api/status`) to a full
+    /// `http://…/api/status` URL for dashboard latency probes.
+    pub fn api_status_url(&self) -> anyhow::Result<String> {
+        Ok(format!("http://{}/api/status", self.api_http_addr()?))
+    }
+
     /// Resolve the configured Home Assistant endpoint, if this deployment uses one.
     pub fn homeassistant_service(&self) -> Option<&ServiceEndpoint> {
         self.services.homeassistant.as_ref()
@@ -1625,6 +1633,25 @@ systemd_unit = "genie-ai-runtime.service"
         assert!(
             err.to_string().contains("unsupported scheme"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn api_status_url_defaults_to_documented_endpoint() {
+        let config = test_config();
+        assert_eq!(
+            config.api_status_url().unwrap(),
+            "http://127.0.0.1:3080/api/status"
+        );
+    }
+
+    #[test]
+    fn api_status_url_normalizes_bare_authority() {
+        let mut config = test_config();
+        config.services.api.url = "127.0.0.1:4080/api/status".into();
+        assert_eq!(
+            config.api_status_url().unwrap(),
+            "http://127.0.0.1:4080/api/status"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `Config::api_status_url()` in `genie-common` → `http://{api_http_addr()}/api/status`.
- Dashboard `dashboard_service_targets()` uses `api_status_url()` for the **api** row instead of raw `[services.api].url` (core already uses `core_health_url()` from #121).
- Unit tests for bare-authority TOML (`127.0.0.1:4080/api/status`) and dashboard target URL.

Closes #164

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
cargo test -p genie-common api_status_url
cargo test -p genie-api dashboard_api_target
cargo fmt --all -- --check
```

### What I observed

All tests passed. With `[services.api].url = "127.0.0.1:4080/api/status"`, dashboard latency probe uses `http://127.0.0.1:4080/api/status` instead of the raw TOML string.

## Test plan

- [x] `cargo test -p genie-common api_status_url`
- [x] `cargo test -p genie-api dashboard_api_target dashboard_core_target`
- [x] `cargo fmt --all -- --check`
- [ ] Optional: dev TOML with custom API port, `curl` dashboard `/api/services`, api row healthy when genie-api listens