### PR TITLE
fix(skills): verify Ed25519 signature of .so bytes before dlopen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,10 +53,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -93,6 +108,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +188,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -130,6 +241,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -180,6 +297,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "genie-api"
 version = "1.0.0-alpha.9"
 dependencies = [
@@ -210,6 +337,8 @@ version = "1.0.0-alpha.9"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
+ "ed25519-dalek",
  "genie-common",
  "genie-skill-sdk",
  "libc",
@@ -698,6 +827,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,7 +946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -817,7 +956,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -921,6 +1069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1123,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1032,6 +1195,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1259,16 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -1377,6 +1570,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -379,19 +379,39 @@ fn is_remote_url(url: &str) -> bool {
     !matches!(host, "127.0.0.1" | "localhost" | "::1" | "[::1]")
 }
 
-#[derive(Debug, Deserialize, Clone, Default)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct SkillPolicyConfig {
     /// Reject skills without a valid sidecar manifest.
     #[serde(default)]
     pub require_manifest: bool,
 
-    /// Reject skills whose manifest does not declare signature material.
+    /// Reject skills whose `.so` bytes are not verified by a detached Ed25519
+    /// signature against a trusted key in `signature_key_dir`. The signature
+    /// is cryptographically checked before the library is loaded; a non-empty
+    /// `signature` field alone does not satisfy this.
     #[serde(default)]
     pub require_signature: bool,
+
+    /// Directory of trusted Ed25519 public keys (`<key_id>.pub`, base64) used
+    /// to verify skill signatures. Lives outside the skills directory so a
+    /// party who can drop a `.so` cannot also add a trusting key.
+    #[serde(default = "defaults::skill_signature_key_dir")]
+    pub signature_key_dir: PathBuf,
 
     /// Reject skills requesting any of these permission labels.
     #[serde(default)]
     pub denied_permissions: Vec<String>,
+}
+
+impl Default for SkillPolicyConfig {
+    fn default() -> Self {
+        Self {
+            require_manifest: false,
+            require_signature: false,
+            signature_key_dir: defaults::skill_signature_key_dir(),
+            denied_permissions: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -878,6 +898,20 @@ fn split_scheme(url: &str) -> Option<(&'static str, &str)> {
     None
 }
 
+/// True if `dir` holds at least one `*.pub` trusted-key file. Used only for
+/// the security-posture report — the loader does the real key parsing — so a
+/// cheap presence check is enough to tell an operator whether
+/// `require_signature` is actually usable as configured.
+fn has_trusted_skill_keys(dir: &Path) -> bool {
+    std::fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .any(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("pub"))
+        })
+        .unwrap_or(false)
+}
+
 /// Split `authority[path]` into (authority, path). IPv6 brackets are
 /// respected: the first `/` *after* a closing `]` is the path delimiter,
 /// not any earlier slash that might appear inside `[…]` (it can't today,
@@ -1117,6 +1151,11 @@ impl Config {
         }
         if !self.core.skill_policy.require_signature {
             risk_flags.push("skill_signature_not_required");
+        } else if !has_trusted_skill_keys(&self.core.skill_policy.signature_key_dir) {
+            // require_signature is on but no trusted keys are installed: the
+            // loader fails closed (no skill can load), so flag the misconfig
+            // rather than silently rejecting every skill.
+            risk_flags.push("skill_signature_required_but_no_trusted_keys");
         }
 
         serde_json::json!({
@@ -1168,7 +1207,10 @@ impl Config {
                 "sensitive_multi_target_denied": self.core.actuation_safety.deny_multi_target_sensitive,
                 "available_state_required": self.core.actuation_safety.require_available_state,
                 "skill_manifest_required": self.core.skill_policy.require_manifest,
-                "skill_signature_required": self.core.skill_policy.require_signature
+                "skill_signature_required": self.core.skill_policy.require_signature,
+                "skill_signature_scheme": "ed25519_detached_over_so_bytes",
+                "skill_signature_key_dir": self.core.skill_policy.signature_key_dir.display().to_string(),
+                "skill_signature_trusted_keys_present": has_trusted_skill_keys(&self.core.skill_policy.signature_key_dir)
             },
             "secret_presence": {
                 "homeassistant_token_configured": self.homeassistant_token().is_some(),
@@ -1855,6 +1897,46 @@ denied_permissions = ["network.raw", "filesystem.write"]
             config.denied_permissions,
             vec!["network.raw", "filesystem.write"]
         );
+        // Defaults to the distribution key dir when not overridden.
+        assert_eq!(
+            config.signature_key_dir,
+            PathBuf::from("/etc/geniepod/skill-keys")
+        );
+    }
+
+    #[test]
+    fn skill_policy_signature_key_dir_overridable() {
+        let config: SkillPolicyConfig = toml::from_str(
+            r#"
+require_signature = true
+signature_key_dir = "/custom/keys"
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.signature_key_dir, PathBuf::from("/custom/keys"));
+    }
+
+    #[test]
+    fn security_posture_flags_require_signature_without_keys() {
+        let mut config = test_config();
+        config.core.skill_policy.require_signature = true;
+        // Point at a directory with no trusted keys → loader fails closed.
+        config.core.skill_policy.signature_key_dir =
+            PathBuf::from("/nonexistent/geniepod-skill-keys");
+
+        let posture = config.household_security_summary();
+        let flags = posture["risk_flags"].as_array().unwrap();
+        let has = |name: &str| flags.iter().any(|f| f == name);
+        assert!(has("skill_signature_required_but_no_trusted_keys"));
+        assert!(!has("skill_signature_not_required"));
+        assert_eq!(
+            posture["policy"]["skill_signature_required"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            posture["policy"]["skill_signature_trusted_keys_present"],
+            serde_json::json!(false)
+        );
     }
 
     #[test]
@@ -2153,6 +2235,9 @@ mod defaults {
     }
     pub fn speaker_identity_min_score() -> f32 {
         0.82
+    }
+    pub fn skill_signature_key_dir() -> PathBuf {
+        PathBuf::from("/etc/geniepod/skill-keys")
     }
     pub fn tool_policy_enabled() -> bool {
         true

--- a/crates/genie-core/Cargo.toml
+++ b/crates/genie-core/Cargo.toml
@@ -47,6 +47,10 @@ toml = { workspace = true }
 genie-skill-sdk = { path = "../genie-skill-sdk" }
 async-trait = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
+# Detached Ed25519 verification of native skill `.so` bytes before dlopen.
+# Verification only — no RNG/key-generation features pulled into the runtime.
+ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
+base64 = "0.22"
 
 [dev-dependencies]
 toml = { workspace = true }

--- a/crates/genie-core/src/skills/loader.rs
+++ b/crates/genie-core/src/skills/loader.rs
@@ -12,10 +12,14 @@ use genie_skill_sdk::{ABI_VERSION, SkillVTable};
 use libloading::{Library, Symbol};
 use serde::{Deserialize, Serialize};
 
+use crate::skills::signature::TrustedKeys;
+
 /// Optional sidecar metadata for a native skill.
 ///
 /// A skill named `hello.so` can declare metadata in `hello.skill.json`.
-/// The loader treats this as audit metadata today, not as a signature check.
+/// `signature`/`key_id` are cryptographic material: a detached Ed25519
+/// signature over the `.so` bytes, verified by the loader against a trusted
+/// public key before the library is loaded.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct SkillManifest {
@@ -31,8 +35,12 @@ pub struct SkillManifest {
     pub capabilities: Vec<String>,
     /// Reviewer identity or process name.
     pub reviewed_by: String,
-    /// Signature material or signature reference. Presence only is reported.
+    /// Base64-encoded detached Ed25519 signature over the `.so` bytes. Verified
+    /// against the trusted key named by `key_id`; not trusted by presence.
     pub signature: String,
+    /// Id of the trusted public key that produced `signature` (the `.pub`
+    /// file stem in the trusted-key directory).
+    pub key_id: String,
 }
 
 /// Audit view of the manifest state for a loaded skill.
@@ -46,16 +54,34 @@ pub struct SkillManifestAudit {
     pub permissions: Vec<String>,
     pub capabilities: Vec<String>,
     pub reviewed_by: String,
+    /// Id of the trusted key claimed by the manifest (audit only).
+    pub key_id: String,
+    /// True only when a trusted key cryptographically verified the signature
+    /// over the `.so` bytes — never set by mere presence of a string.
     pub signed: bool,
     pub error: String,
 }
 
 /// Runtime load policy for native skills.
-#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct SkillLoadPolicy {
     pub require_manifest: bool,
     pub require_signature: bool,
     pub denied_permissions: Vec<String>,
+    /// Directory of trusted Ed25519 public keys used to verify skill
+    /// signatures. Lives outside the (attacker-writable) skills directory.
+    pub signature_key_dir: PathBuf,
+}
+
+impl Default for SkillLoadPolicy {
+    fn default() -> Self {
+        Self {
+            require_manifest: false,
+            require_signature: false,
+            denied_permissions: Vec::new(),
+            signature_key_dir: SkillPolicyConfig::default().signature_key_dir,
+        }
+    }
 }
 
 impl From<&SkillPolicyConfig> for SkillLoadPolicy {
@@ -64,6 +90,7 @@ impl From<&SkillPolicyConfig> for SkillLoadPolicy {
             require_manifest: config.require_manifest,
             require_signature: config.require_signature,
             denied_permissions: config.denied_permissions.clone(),
+            signature_key_dir: config.signature_key_dir.clone(),
         }
     }
 }
@@ -79,6 +106,7 @@ impl SkillManifestAudit {
             permissions: Vec::new(),
             capabilities: Vec::new(),
             reviewed_by: String::new(),
+            key_id: String::new(),
             signed: false,
             error: "no sidecar manifest found".into(),
         }
@@ -94,14 +122,20 @@ impl SkillManifestAudit {
             permissions: Vec::new(),
             capabilities: Vec::new(),
             reviewed_by: String::new(),
+            key_id: String::new(),
             signed: false,
             error,
         }
     }
 
+    /// Build an audit from a parsed manifest. `signed` is the result of
+    /// cryptographic verification performed by the loader against the `.so`
+    /// bytes — it is decided here, never from the presence of the signature
+    /// string.
     fn from_manifest(
         path: PathBuf,
         manifest: SkillManifest,
+        signed: bool,
         loaded_name: &str,
         loaded_version: &str,
     ) -> Self {
@@ -130,7 +164,6 @@ impl SkillManifestAudit {
         } else {
             "mismatch"
         };
-        let signed = !manifest.signature.trim().is_empty();
 
         Self {
             status: status.into(),
@@ -141,6 +174,7 @@ impl SkillManifestAudit {
             permissions: manifest.permissions,
             capabilities: manifest.capabilities,
             reviewed_by: manifest.reviewed_by,
+            key_id: manifest.key_id,
             signed,
             error: problems.join("; "),
         }
@@ -260,13 +294,24 @@ pub fn find_manifest_sidecar(skill_path: &Path) -> Option<PathBuf> {
         .find(|path| path.exists())
 }
 
-fn read_manifest_audit(
-    skill_path: &Path,
-    loaded_name: &str,
-    loaded_version: &str,
-) -> SkillManifestAudit {
+/// Parsed state of a skill's sidecar manifest, before it is matched against
+/// the loaded vtable. Kept separate from [`SkillManifestAudit`] so signature
+/// verification can run on the raw manifest *before* the `.so` is loaded.
+enum ManifestSource {
+    Missing,
+    Invalid {
+        path: PathBuf,
+        error: String,
+    },
+    Present {
+        path: PathBuf,
+        manifest: SkillManifest,
+    },
+}
+
+fn read_manifest_source(skill_path: &Path) -> ManifestSource {
     let Some(path) = find_manifest_sidecar(skill_path) else {
-        return SkillManifestAudit::missing();
+        return ManifestSource::Missing;
     };
 
     match std::fs::read_to_string(&path)
@@ -274,13 +319,49 @@ fn read_manifest_audit(
         .and_then(|content| {
             serde_json::from_str::<SkillManifest>(&content).map_err(|e| e.to_string())
         }) {
-        Ok(manifest) => {
-            SkillManifestAudit::from_manifest(path, manifest, loaded_name, loaded_version)
-        }
-        Err(error) => SkillManifestAudit::invalid(path, error),
+        Ok(manifest) => ManifestSource::Present { path, manifest },
+        Err(error) => ManifestSource::Invalid { path, error },
     }
 }
 
+/// Verify the sidecar's detached signature over the exact bytes of the `.so`
+/// that will be loaded. Returns `true` only when a trusted key validates the
+/// signature over the file contents; fails closed on any read or verification
+/// error. This must be evaluated on the bytes that will actually execute.
+fn verify_skill_signature(
+    skill_path: &Path,
+    manifest: &SkillManifest,
+    trusted_keys: &TrustedKeys,
+) -> bool {
+    match std::fs::read(skill_path) {
+        Ok(bytes) => trusted_keys.verify_detached(&manifest.key_id, &bytes, &manifest.signature),
+        Err(_) => false,
+    }
+}
+
+/// Build the audit view once the vtable's name/version are known. `signed`
+/// carries the verification result computed before load.
+fn build_manifest_audit(
+    source: ManifestSource,
+    signed: bool,
+    loaded_name: &str,
+    loaded_version: &str,
+) -> SkillManifestAudit {
+    match source {
+        ManifestSource::Missing => SkillManifestAudit::missing(),
+        ManifestSource::Invalid { path, error } => SkillManifestAudit::invalid(path, error),
+        ManifestSource::Present { path, manifest } => {
+            SkillManifestAudit::from_manifest(path, manifest, signed, loaded_name, loaded_version)
+        }
+    }
+}
+
+/// Post-load policy checks that depend on the loaded vtable (manifest
+/// name/version match and requested permissions).
+///
+/// The signature gate is enforced *before* `dlopen` in [`SkillLoader::load_skill`]
+/// — never here — because by the time this runs the native code has already
+/// been loaded.
 fn enforce_skill_policy(manifest: &SkillManifestAudit, policy: &SkillLoadPolicy) -> Result<()> {
     if policy.require_manifest && manifest.status != "ok" {
         anyhow::bail!(
@@ -288,10 +369,6 @@ fn enforce_skill_policy(manifest: &SkillManifestAudit, policy: &SkillLoadPolicy)
             manifest.status,
             manifest.error
         );
-    }
-
-    if policy.require_signature && !manifest.signed {
-        anyhow::bail!("skill signature required but manifest is unsigned");
     }
 
     let denied = manifest
@@ -311,6 +388,7 @@ fn enforce_skill_policy(manifest: &SkillManifestAudit, policy: &SkillLoadPolicy)
 pub struct SkillLoader {
     skills_dir: PathBuf,
     policy: SkillLoadPolicy,
+    trusted_keys: TrustedKeys,
     loaded: Vec<LoadedSkill>,
 }
 
@@ -320,9 +398,18 @@ impl SkillLoader {
     }
 
     pub fn new_with_policy(skills_dir: &Path, policy: SkillLoadPolicy) -> Self {
+        let trusted_keys = TrustedKeys::load_from_dir(&policy.signature_key_dir);
+        if policy.require_signature && trusted_keys.is_empty() {
+            tracing::warn!(
+                key_dir = %policy.signature_key_dir.display(),
+                "require_signature is enabled but no trusted skill keys were found; \
+                 every skill will be rejected (fail closed)"
+            );
+        }
         Self {
             skills_dir: skills_dir.to_path_buf(),
             policy,
+            trusted_keys,
             loaded: Vec::new(),
         }
     }
@@ -368,8 +455,32 @@ impl SkillLoader {
 
     /// Load a single skill from a `.so` file.
     pub fn load_skill(&mut self, path: &Path) -> Result<String> {
-        // Safety: loading a .so is inherently unsafe. We trust skills from
-        // the skills directory (like Linux trusts kernel modules from /lib/modules).
+        // Read the sidecar and verify its detached signature over the .so bytes
+        // BEFORE dlopen. Loading a .so executes arbitrary native code in the
+        // genie-core address space, so the authenticity gate must be decided on
+        // the exact bytes about to run — and an unverified skill must never be
+        // loaded at all when a signature is required.
+        let manifest_source = read_manifest_source(path);
+        let signed = match &manifest_source {
+            ManifestSource::Present { manifest, .. } => {
+                verify_skill_signature(path, manifest, &self.trusted_keys)
+            }
+            ManifestSource::Missing | ManifestSource::Invalid { .. } => false,
+        };
+
+        if self.policy.require_signature && !signed {
+            anyhow::bail!(
+                "skill signature required but not cryptographically verified for {} \
+                 (need a trusted key in {} and a matching detached signature)",
+                path.display(),
+                self.policy.signature_key_dir.display()
+            );
+        }
+
+        // Safety: loading a .so is inherently unsafe. With require_signature on,
+        // the bytes have been verified against a trusted key above; otherwise we
+        // trust skills from the skills directory (like Linux trusts kernel
+        // modules from /lib/modules).
         let lib = unsafe { Library::new(path) }
             .map_err(|e| anyhow::anyhow!("dlopen failed for {}: {}", path.display(), e))?;
 
@@ -419,7 +530,7 @@ impl SkillLoader {
             anyhow::bail!("skill '{}' already loaded", name);
         }
 
-        let manifest = read_manifest_audit(path, &name, &version);
+        let manifest = build_manifest_audit(manifest_source, signed, &name, &version);
         if manifest.status != "ok" {
             tracing::warn!(
                 skill = %name,
@@ -633,7 +744,9 @@ mod tests {
         assert_eq!(skill.manifest.status, "ok");
         assert_eq!(skill.manifest.permissions, vec!["speech.output"]);
         assert_eq!(skill.manifest.capabilities, vec!["demo.greeting"]);
-        assert!(skill.manifest.signed);
+        // An arbitrary "signature" string is NOT signed: `signed` is decided by
+        // cryptographic verification, not by the field being non-empty.
+        assert!(!skill.manifest.signed);
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -695,6 +808,275 @@ mod tests {
         );
         let err = loader.load_skill(&installed_path).unwrap_err();
         assert!(err.to_string().contains("denied permission"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // --- Signature enforcement (issue #175) -------------------------------
+
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    /// Skills dir + a sibling trusted-key dir with one installed key, plus the
+    /// sample `.so` copied in. Returns the directories, the installed `.so`
+    /// path, and the signing key whose public half is trusted under `key_id`.
+    fn signed_skill_dirs(case: &str, key_id: &str) -> (PathBuf, PathBuf, PathBuf, SigningKey) {
+        let dir =
+            std::env::temp_dir().join(format!("geniepod-skills-sig-{case}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let keys_dir = dir.join("keys");
+        std::fs::create_dir_all(&keys_dir).unwrap();
+
+        let so_path = dir.join("hello.so");
+        std::fs::copy(sample_skill_path(), &so_path).unwrap();
+
+        let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+        std::fs::write(
+            keys_dir.join(format!("{key_id}.pub")),
+            BASE64.encode(signing_key.verifying_key().to_bytes()),
+        )
+        .unwrap();
+
+        (dir, keys_dir, so_path, signing_key)
+    }
+
+    /// Detached base64 Ed25519 signature over the current bytes of `so_path`.
+    fn sign_file(key: &SigningKey, so_path: &Path) -> String {
+        let bytes = std::fs::read(so_path).unwrap();
+        BASE64.encode(key.sign(&bytes).to_bytes())
+    }
+
+    fn write_signed_manifest(dir: &Path, signature: &str, key_id: &str) {
+        std::fs::write(
+            dir.join("hello.skill.json"),
+            format!(
+                r#"{{
+                    "name": "hello_world",
+                    "version": "0.1.0",
+                    "description": "Sample hello skill",
+                    "reviewed_by": "test",
+                    "signature": "{signature}",
+                    "key_id": "{key_id}"
+                }}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    fn require_signature_policy(keys_dir: &Path) -> SkillLoadPolicy {
+        SkillLoadPolicy {
+            require_signature: true,
+            signature_key_dir: keys_dir.to_path_buf(),
+            ..SkillLoadPolicy::default()
+        }
+    }
+
+    /// The reported bug: `require_signature = true` + a junk `"signature"`
+    /// string must NOT load the skill.
+    #[test]
+    fn loader_rejects_required_signature_with_junk_string() {
+        let (dir, keys_dir, so_path, _key) = signed_skill_dirs("junk", "geniepod");
+        write_signed_manifest(&dir, "x", "geniepod");
+
+        let mut loader = SkillLoader::new_with_policy(&dir, require_signature_policy(&keys_dir));
+        let err = loader.load_skill(&so_path).unwrap_err();
+        assert!(
+            err.to_string().contains("signature required"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(loader.count(), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A valid detached signature by a trusted key over the exact `.so` loads
+    /// and is reported as verified.
+    #[test]
+    fn loader_accepts_valid_signature() {
+        let (dir, keys_dir, so_path, key) = signed_skill_dirs("valid", "geniepod");
+        let signature = sign_file(&key, &so_path);
+        write_signed_manifest(&dir, &signature, "geniepod");
+
+        let mut loader = SkillLoader::new_with_policy(&dir, require_signature_policy(&keys_dir));
+        let name = loader.load_skill(&so_path).unwrap();
+        assert_eq!(name, "hello_world");
+
+        let skill = loader.loaded().first().unwrap();
+        assert!(skill.manifest.signed);
+        assert_eq!(skill.manifest.status, "ok");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Flipping one byte of the `.so` after signing invalidates the signature:
+    /// tamper detection, load rejected.
+    #[test]
+    fn loader_rejects_tampered_so() {
+        let (dir, keys_dir, so_path, key) = signed_skill_dirs("tamper", "geniepod");
+        let signature = sign_file(&key, &so_path);
+        write_signed_manifest(&dir, &signature, "geniepod");
+
+        // Corrupt one byte after signing.
+        let mut bytes = std::fs::read(&so_path).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xff;
+        std::fs::write(&so_path, &bytes).unwrap();
+
+        let mut loader = SkillLoader::new_with_policy(&dir, require_signature_policy(&keys_dir));
+        assert!(loader.load_skill(&so_path).is_err());
+        assert_eq!(loader.count(), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A correct signature that names a key id we do not trust fails closed.
+    #[test]
+    fn loader_rejects_unknown_key_id() {
+        let (dir, keys_dir, so_path, key) = signed_skill_dirs("unknown", "geniepod");
+        let signature = sign_file(&key, &so_path);
+        // Signature is valid for the trusted key, but the manifest claims a
+        // different (untrusted) key id.
+        write_signed_manifest(&dir, &signature, "attacker");
+
+        let mut loader = SkillLoader::new_with_policy(&dir, require_signature_policy(&keys_dir));
+        assert!(loader.load_skill(&so_path).is_err());
+        assert_eq!(loader.count(), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// With no trusted keys installed, require_signature fails closed even for
+    /// a present manifest.
+    #[test]
+    fn loader_fails_closed_without_trusted_keys() {
+        let (dir, _keys_dir, so_path, _key) = signed_skill_dirs("nokeys", "geniepod");
+        write_signed_manifest(&dir, "x", "geniepod");
+
+        let empty_keys = dir.join("empty-keys");
+        std::fs::create_dir_all(&empty_keys).unwrap();
+        let mut loader = SkillLoader::new_with_policy(&dir, require_signature_policy(&empty_keys));
+        assert!(loader.load_skill(&so_path).is_err());
+        assert_eq!(loader.count(), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An unsigned native skill — no sidecar manifest at all — must be rejected
+    /// when a signature is required. The rejection is the signature gate, not a
+    /// later manifest/ABI failure.
+    #[test]
+    fn loader_rejects_unsigned_skill_with_no_manifest() {
+        let (dir, keys_dir, so_path, _key) = signed_skill_dirs("nomanifest", "geniepod");
+        // Deliberately write no manifest sidecar.
+
+        let mut loader = SkillLoader::new_with_policy(&dir, require_signature_policy(&keys_dir));
+        let err = loader.load_skill(&so_path).unwrap_err();
+        assert!(
+            err.to_string().contains("signature required"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(loader.count(), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A manifest present but carrying an empty `signature` field is unsigned:
+    /// it must be rejected, never treated as signed by the field's existence.
+    #[test]
+    fn loader_rejects_empty_signature_field() {
+        let (dir, keys_dir, so_path, _key) = signed_skill_dirs("emptysig", "geniepod");
+        write_signed_manifest(&dir, "", "geniepod");
+
+        let mut loader = SkillLoader::new_with_policy(&dir, require_signature_policy(&keys_dir));
+        let err = loader.load_skill(&so_path).unwrap_err();
+        assert!(
+            err.to_string().contains("signature required"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(loader.count(), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The signature gate runs *before* `dlopen`: an unsigned file whose bytes
+    /// are not even a loadable library is rejected with the signature error,
+    /// not a "dlopen failed" error. That proves the native code is never loaded
+    /// when the signature check fails — the whole point of verifying first.
+    #[test]
+    fn loader_rejects_before_dlopen() {
+        let dir = std::env::temp_dir().join(format!(
+            "geniepod-skills-sig-gatefirst-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let keys_dir = dir.join("keys");
+        std::fs::create_dir_all(&keys_dir).unwrap();
+
+        // Install a trusted key so the gate is genuinely active.
+        let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+        std::fs::write(
+            keys_dir.join("geniepod.pub"),
+            BASE64.encode(signing_key.verifying_key().to_bytes()),
+        )
+        .unwrap();
+
+        // A bogus, unsigned ".so" that dlopen would reject outright.
+        let so_path = dir.join("bogus.so");
+        std::fs::write(&so_path, b"this is not a loadable shared library").unwrap();
+
+        let mut loader = SkillLoader::new_with_policy(&dir, require_signature_policy(&keys_dir));
+        let err = loader.load_skill(&so_path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("signature required"),
+            "expected signature rejection before dlopen, got: {msg}"
+        );
+        assert!(
+            !msg.contains("dlopen"),
+            "dlopen must not be attempted before the signature gate, got: {msg}"
+        );
+        assert_eq!(loader.count(), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A malformed trusted key file must not produce a trusted posture: when the
+    /// key id the manifest names fails to parse, it never becomes a trust
+    /// anchor, so even a well-formed signature is rejected (fail closed). The
+    /// skill is neither loaded nor reported as signed.
+    #[test]
+    fn loader_malformed_trusted_key_is_not_trusted() {
+        let dir =
+            std::env::temp_dir().join(format!("geniepod-skills-sig-badkey-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let keys_dir = dir.join("keys");
+        std::fs::create_dir_all(&keys_dir).unwrap();
+
+        let so_path = dir.join("hello.so");
+        std::fs::copy(sample_skill_path(), &so_path).unwrap();
+
+        // The key the manifest references exists on disk but is garbage, so it
+        // is skipped at load time and never trusted.
+        std::fs::write(keys_dir.join("geniepod.pub"), "not a valid ed25519 key").unwrap();
+
+        // The signature itself is well-formed (real key over the real bytes);
+        // only the trust anchor is broken — which must still fail closed.
+        let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+        let signature = BASE64.encode(
+            signing_key
+                .sign(&std::fs::read(&so_path).unwrap())
+                .to_bytes(),
+        );
+        write_signed_manifest(&dir, &signature, "geniepod");
+
+        let mut loader = SkillLoader::new_with_policy(&dir, require_signature_policy(&keys_dir));
+        let err = loader.load_skill(&so_path).unwrap_err();
+        assert!(
+            err.to_string().contains("signature required"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(loader.count(), 0);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/genie-core/src/skills/mod.rs
+++ b/crates/genie-core/src/skills/mod.rs
@@ -6,11 +6,13 @@
 use std::path::PathBuf;
 
 pub mod loader;
+pub mod signature;
 
 pub use loader::{
     LoadedSkill, SkillLoadPolicy, SkillLoader, SkillManifest, SkillManifestAudit,
     find_manifest_sidecar, manifest_sidecar_candidates,
 };
+pub use signature::TrustedKeys;
 
 pub const DEFAULT_SKILLS_DIR: &str = "/opt/geniepod/skills";
 

--- a/crates/genie-core/src/skills/signature.rs
+++ b/crates/genie-core/src/skills/signature.rs
@@ -1,0 +1,286 @@
+//! Detached Ed25519 verification for native skill `.so` modules.
+//!
+//! Authenticity of a skill must be derived from a signature over the bytes
+//! that will actually be `dlopen`'d — never from the presence of a string the
+//! same party supplied. A trusted public key (shipped with the distribution,
+//! out of the attacker-writable skills directory) signs the `.so`; the loader
+//! verifies that signature against the exact file bytes before loading.
+//!
+//! Key files: `<key_id>.pub` in the trusted-key directory, each containing the
+//! base64-encoded 32-byte Ed25519 public key. The file stem is the key id.
+//! Manifests carry the base64-encoded 64-byte detached signature plus the
+//! `key_id` selecting which trusted key produced it.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use ed25519_dalek::{Signature, VerifyingKey};
+
+/// A set of trusted Ed25519 public keys, indexed by key id.
+///
+/// Verification fails closed: an unknown key id, a malformed signature, or a
+/// signature that does not validate over the supplied bytes all return
+/// `false`. An empty set rejects everything.
+#[derive(Debug, Default)]
+pub struct TrustedKeys {
+    keys: HashMap<String, VerifyingKey>,
+}
+
+impl TrustedKeys {
+    /// An empty key set. Verifies nothing (fail closed).
+    pub fn empty() -> Self {
+        Self {
+            keys: HashMap::new(),
+        }
+    }
+
+    /// Load every `*.pub` file in `dir` as a trusted key.
+    ///
+    /// The file stem is the key id; the file contents are the base64-encoded
+    /// 32-byte Ed25519 public key. A missing directory yields an empty set.
+    /// Malformed key files are skipped with a warning rather than aborting,
+    /// so one bad file cannot block every other trusted key.
+    pub fn load_from_dir(dir: &Path) -> Self {
+        let mut keys = HashMap::new();
+
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(_) => {
+                tracing::debug!(dir = %dir.display(), "skill key directory not found");
+                return Self { keys };
+            }
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("pub") {
+                continue;
+            }
+            let Some(key_id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            match std::fs::read_to_string(&path)
+                .ok()
+                .and_then(|contents| decode_verifying_key(contents.trim()))
+            {
+                Some(key) => {
+                    keys.insert(key_id.to_string(), key);
+                }
+                None => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        "ignoring malformed skill public key"
+                    );
+                }
+            }
+        }
+
+        Self { keys }
+    }
+
+    /// Number of trusted keys loaded.
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    /// True if no trusted keys are loaded — every verification fails closed.
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
+    /// Verify a base64-encoded detached signature over `message` using the
+    /// trusted key named `key_id`.
+    ///
+    /// Returns `true` only when `key_id` names a trusted key, the signature
+    /// decodes, and it validates over `message`. Any failure — empty inputs,
+    /// unknown key, malformed signature, or invalid signature — returns
+    /// `false`. Uses strict verification to reject malleable / non-canonical
+    /// signatures.
+    pub fn verify_detached(&self, key_id: &str, message: &[u8], signature_b64: &str) -> bool {
+        let key_id = key_id.trim();
+        let signature_b64 = signature_b64.trim();
+        if key_id.is_empty() || signature_b64.is_empty() {
+            return false;
+        }
+
+        let Some(key) = self.keys.get(key_id) else {
+            return false;
+        };
+        let Ok(sig_bytes) = BASE64.decode(signature_b64) else {
+            return false;
+        };
+        let Ok(signature) = Signature::from_slice(&sig_bytes) else {
+            return false;
+        };
+
+        key.verify_strict(message, &signature).is_ok()
+    }
+}
+
+/// Decode a base64-encoded 32-byte Ed25519 public key into a [`VerifyingKey`].
+fn decode_verifying_key(b64: &str) -> Option<VerifyingKey> {
+    let bytes = BASE64.decode(b64).ok()?;
+    let array: [u8; 32] = bytes.try_into().ok()?;
+    VerifyingKey::from_bytes(&array).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    /// Deterministic signing key from a fixed seed — no RNG needed in tests.
+    fn signing_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn write_pub_key(dir: &Path, key_id: &str, key: &VerifyingKey) {
+        std::fs::write(
+            dir.join(format!("{key_id}.pub")),
+            BASE64.encode(key.to_bytes()),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn empty_keys_reject_everything() {
+        let keys = TrustedKeys::empty();
+        assert!(keys.is_empty());
+        assert!(!keys.verify_detached("any", b"payload", "c2ln"));
+    }
+
+    #[test]
+    fn valid_signature_verifies() {
+        let dir = std::env::temp_dir().join(format!("geniepod-keys-valid-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sk = signing_key(7);
+        write_pub_key(&dir, "trusted", &sk.verifying_key());
+
+        let keys = TrustedKeys::load_from_dir(&dir);
+        assert_eq!(keys.len(), 1);
+
+        let message = b"the exact bytes that will run";
+        let sig = BASE64.encode(sk.sign(message).to_bytes());
+        assert!(keys.verify_detached("trusted", message, &sig));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn junk_signature_is_rejected() {
+        let dir = std::env::temp_dir().join(format!("geniepod-keys-junk-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sk = signing_key(7);
+        write_pub_key(&dir, "trusted", &sk.verifying_key());
+
+        let keys = TrustedKeys::load_from_dir(&dir);
+        // The pre-fix bug: any non-empty string counted as "signed". A trusted
+        // key must reject an arbitrary string.
+        assert!(!keys.verify_detached("trusted", b"payload", "x"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn tampered_message_is_rejected() {
+        let dir = std::env::temp_dir().join(format!("geniepod-keys-tamper-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sk = signing_key(7);
+        write_pub_key(&dir, "trusted", &sk.verifying_key());
+        let keys = TrustedKeys::load_from_dir(&dir);
+
+        let sig = BASE64.encode(sk.sign(b"original bytes").to_bytes());
+        assert!(!keys.verify_detached("trusted", b"original bytez", &sig));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unknown_key_id_is_rejected() {
+        let dir =
+            std::env::temp_dir().join(format!("geniepod-keys-unknown-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sk = signing_key(7);
+        write_pub_key(&dir, "trusted", &sk.verifying_key());
+        let keys = TrustedKeys::load_from_dir(&dir);
+
+        let message = b"payload";
+        let sig = BASE64.encode(sk.sign(message).to_bytes());
+        // Correct signature, but the manifest names a key we do not trust.
+        assert!(!keys.verify_detached("attacker", message, &sig));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn wrong_trusted_key_is_rejected() {
+        let dir = std::env::temp_dir().join(format!("geniepod-keys-wrong-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Trust key A, but sign with key B and claim key id "a".
+        write_pub_key(&dir, "a", &signing_key(1).verifying_key());
+        let keys = TrustedKeys::load_from_dir(&dir);
+
+        let message = b"payload";
+        let sig = BASE64.encode(signing_key(2).sign(message).to_bytes());
+        assert!(!keys.verify_detached("a", message, &sig));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn malformed_key_file_is_skipped() {
+        let dir = std::env::temp_dir().join(format!("geniepod-keys-bad-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        std::fs::write(dir.join("broken.pub"), "not base64 !!!").unwrap();
+        let sk = signing_key(3);
+        write_pub_key(&dir, "good", &sk.verifying_key());
+
+        let keys = TrustedKeys::load_from_dir(&dir);
+        // Broken file skipped; the good key still loads and verifies.
+        assert_eq!(keys.len(), 1);
+        let message = b"payload";
+        let sig = BASE64.encode(sk.sign(message).to_bytes());
+        assert!(keys.verify_detached("good", message, &sig));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn malformed_keys_do_not_yield_a_trusted_posture() {
+        let dir = std::env::temp_dir().join(format!("geniepod-keys-allbad-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Every key file in the directory is unparseable: not base64, wrong
+        // length, and empty. None becomes a trust anchor.
+        std::fs::write(dir.join("garbage.pub"), "not base64 !!!").unwrap();
+        std::fs::write(dir.join("shortkey.pub"), BASE64.encode([0u8; 16])).unwrap();
+        std::fs::write(dir.join("empty.pub"), "").unwrap();
+
+        let keys = TrustedKeys::load_from_dir(&dir);
+        // A directory full of malformed keys must read as zero trust anchors —
+        // never as a trusted posture that happens to verify nothing safely.
+        assert!(keys.is_empty());
+        // Even a syntactically valid signature cannot verify: no usable key.
+        let sk = signing_key(4);
+        let message = b"payload";
+        let sig = BASE64.encode(sk.sign(message).to_bytes());
+        assert!(!keys.verify_detached("garbage", message, &sig));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -619,10 +619,14 @@ fn cmd_skill_list() -> Result<()> {
             } else {
                 &skill.manifest.reviewed_by
             };
-            println!(
-                "    reviewed: {}; signed: {}",
-                reviewer, skill.manifest.signed
-            );
+            // `signed` is true only when a trusted key cryptographically
+            // verified the .so bytes; name the key that did.
+            let signed = if skill.manifest.signed {
+                format!("verified (key: {})", skill.manifest.key_id)
+            } else {
+                "no".to_string()
+            };
+            println!("    reviewed: {reviewer}; signed: {signed}");
         }
         if !skill.manifest.error.is_empty() {
             println!("    manifest note: {}", skill.manifest.error);
@@ -2179,7 +2183,9 @@ mod tests {
             installed_skills[0].manifest.permissions,
             vec!["speech.output"]
         );
-        assert!(installed_skills[0].manifest.signed);
+        // A bare "signature" string is not "signed": `signed` is set only by
+        // cryptographic verification against a trusted key, not by presence.
+        assert!(!installed_skills[0].manifest.signed);
 
         let removed = remove_skill("hello_world", &skills_dir).unwrap();
         assert_eq!(removed.file_name().unwrap().to_string_lossy(), "hello.so");

--- a/deploy/config/geniepod.dev.toml
+++ b/deploy/config/geniepod.dev.toml
@@ -48,7 +48,10 @@ expected_runtime_contract_hash = ""  # Optional: pin after a known-good boot.
 
 # [core.skill_policy]
 # require_manifest = false
-# require_signature = false
+# require_signature = false   # true => verify a trusted Ed25519 signature over
+#                             # the .so bytes before dlopen (presence of a
+#                             # signature string is not enough)
+# signature_key_dir = "/etc/geniepod/skill-keys"  # holds <key_id>.pub keys
 # denied_permissions = ["network.raw", "filesystem.write"]
 
 # [core.tool_policy]

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -150,7 +150,11 @@ wakeword_script = ""              # Empty = push-to-talk (alpha.5 default).
 # local skills keep loading; enable these after manifests/signatures are ready.
 # [core.skill_policy]
 # require_manifest = false
-# require_signature = false
+# require_signature = false   # when true, only skills whose .so bytes are
+#                             # verified by a trusted Ed25519 key load (checked
+#                             # before dlopen); a non-empty signature string is
+#                             # not enough. Fails closed with no trusted keys.
+# signature_key_dir = "/etc/geniepod/skill-keys"  # holds <key_id>.pub keys
 # denied_permissions = ["network.raw", "filesystem.write"]
 
 # Optional per-origin tool policy. Defaults are allow unless a rule exists.

--- a/skills/SKILL-DEVELOPER-GUIDE.md
+++ b/skills/SKILL-DEVELOPER-GUIDE.md
@@ -139,7 +139,8 @@ the preferred filename is `myskill.skill.json`.
   "permissions": ["network.http"],
   "capabilities": ["example.lookup"],
   "reviewed_by": "local-operator",
-  "signature": ""
+  "key_id": "geniepod",
+  "signature": "<base64 Ed25519 signature over the .so bytes>"
 }
 ```
 
@@ -150,10 +151,42 @@ Current runtime behavior:
 - Operators can enable `[core.skill_policy].require_manifest` to reject missing or mismatched manifests.
 - Operators can deny requested permission labels through `[core.skill_policy].denied_permissions`.
 - `genie-ctl skill install` copies a detected sidecar manifest.
-- `genie-ctl skill list` shows manifest status, permissions, capabilities, review, and signing presence.
+- `genie-ctl skill list` shows manifest status, permissions, capabilities, review, and whether the skill is cryptographically signed.
 
-`require_signature` currently checks only that signature material exists.
-Cryptographic signature verification is future signed-skill work.
+#### Signing a skill (`require_signature`)
+
+`require_signature` is a **real** authenticity gate, not a presence check. When
+it is enabled the loader verifies, **before `dlopen`**, that the `.so` bytes
+carry a detached **Ed25519** signature produced by a trusted key. A non-empty
+`signature` string alone does **not** count as signed.
+
+- `signature` — base64 of the Ed25519 signature over the exact bytes of the
+  `.so` that will be loaded.
+- `key_id` — the trusted key that produced the signature: the file stem of a
+  `<key_id>.pub` file in `[core.skill_policy].signature_key_dir`
+  (default `/etc/geniepod/skill-keys`). Each `.pub` holds the base64-encoded
+  32-byte Ed25519 public key.
+
+A skill fails to load when `require_signature` is on and the signature is
+missing, malformed, signed by an untrusted key, or no longer matches the `.so`
+bytes (tamper). Verification fails closed: with no trusted keys installed, no
+skill loads.
+
+Generate a key pair and sign a `.so` (raw-byte Ed25519, base64) — e.g. with
+Python's `cryptography`:
+
+```python
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization as s
+import base64, sys
+
+sk = Ed25519PrivateKey.generate()
+pub = sk.public_key().public_bytes(s.Encoding.Raw, s.PublicFormat.Raw)
+print("write to /etc/geniepod/skill-keys/geniepod.pub:", base64.b64encode(pub).decode())
+print('"signature":', base64.b64encode(sk.sign(open(sys.argv[1], "rb").read())).decode())
+```
+
+Set `"key_id": "geniepod"` and the printed `signature` in the sidecar manifest.
 
 ### Step 6: Test
 
@@ -438,8 +471,9 @@ Layer 3: catch_unwind crash containment
 Layer 4: Auto-unload after 3 faults
          → Misbehaving skills are automatically removed
 
-Layer 5: Signature verification (optional)
-         → Unsigned skills trigger taint warning
+Layer 5: Signature verification (optional, enforced before dlopen)
+         → With [core.skill_policy].require_signature = true, only .so bytes
+           verified by a trusted Ed25519 key load; others are rejected
 ```
 
 ### Trust Levels


### PR DESCRIPTION
## Summary

`[core.skill_policy].require_signature` was presence-only: any non-empty
`signature` string in a sidecar manifest counted as "signed", so an attacker
who could drop a `.so` into the skills directory could also drop a manifest
with `"signature": "x"` and have arbitrary native code `dlopen`'d into the
genie-core address space. This PR makes `require_signature` a real authenticity
gate — a detached **Ed25519** signature over the exact `.so` bytes, verified
against a trusted key **before** `dlopen`. Fixes #175.

## Changes

- Add `skills/signature.rs`: `TrustedKeys` loads `<key_id>.pub` (base64 32-byte
  Ed25519) keys from a trusted-key directory and verifies detached signatures
  with `verify_strict`. Fails closed on unknown key id, malformed/invalid
  signature, or empty key set.
- Verify the signature over the `.so` file bytes in `SkillLoader::load_skill`
  **before** `dlopen`; reject the load when `require_signature` is on and the
  bytes are not cryptographically verified. `SkillManifestAudit.signed` is now
  set only by verification, never by string presence.
- Add `key_id` to the sidecar manifest and audit view; signature material is
  documented as cryptographic, not audit-only.
- Add `[core.skill_policy].signature_key_dir` (default `/etc/geniepod/skill-keys`),
  kept outside the attacker-writable skills directory so dropping a `.so`
  cannot also drop a trusting key.
- `household_security_summary()` now reports the signature scheme, key dir, and
  whether trusted keys are present, and raises
  `skill_signature_required_but_no_trusted_keys` when `require_signature` is on
  but no keys are installed (loader fails closed → every skill rejected).
- `genie-ctl skill list` prints `signed: verified (key: <id>)` vs `no` instead
  of a bare boolean.
- Add `ed25519-dalek` (verify-only, no RNG/keygen features) and `base64` deps.
- Update sample-config comments and `SKILL-DEVELOPER-GUIDE.md` with how to
  generate a key pair, sign a `.so`, and populate `key_id` / `signature`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

This is a pure logic/crypto change in `genie-core` — it does not touch voice,
audio, Home Assistant, or the dashboard, so the verification path is the
crate's unit tests, which exercise the real `ed25519-dalek` verification over
real `.so` bytes (no mocks).

### What I ran

```
# host: <fill in — dev workstation, no Jetson required for this crypto path>
cargo test -p genie-core skills::
cargo test -p genie-common config::
cargo test -p genie-ctl
```

### What I observed

<!-- Paste the actual `cargo test` summary lines here. -->

New tests added and expected to pass:

- `skills::signature::tests`
  - `empty_keys_reject_everything`
  - `valid_signature_verifies`
  - `junk_signature_is_rejected` — reproduces the bug: `"signature": "x"` no longer verifies
  - `tampered_message_is_rejected`
  - `unknown_key_id_is_rejected`
  - `wrong_trusted_key_is_rejected`
  - `malformed_key_file_is_skipped`
- `skills::loader::tests`
  - `loader_rejects_required_signature_with_junk_string` — the reported issue: junk string + `require_signature` no longer loads
  - `loader_accepts_valid_signature`
  - `loader_rejects_tampered_so` — one flipped byte after signing → load rejected
  - `loader_rejects_unknown_key_id`
  - `loader_fails_closed_without_trusted_keys`
- `config::` — `skill_policy_signature_key_dir_overridable`,
  `security_posture_flags_require_signature_without_keys`
- `genie-ctl` — install test updated: a bare `"signature"` string asserts
  `!signed`.

## Test plan

1. `cargo test -p genie-core skills::` — all signature + loader cases pass.
2. Negative check by hand: create a `.so` with a sidecar manifest containing
   `"signature": "x"`, enable `[core.skill_policy].require_signature = true`,
   and confirm the loader refuses to load it ("skill signature required but
   not cryptographically verified").
3. Positive check: generate an Ed25519 key pair, drop the public half in
   `signature_key_dir` as `<key_id>.pub`, sign the `.so` bytes, put the base64
   signature + `key_id` in the manifest, and confirm the skill loads and
   `genie-ctl skill list` reports `signed: verified (key: <id>)`.
   (Signing recipe is in `skills/SKILL-DEVELOPER-GUIDE.md`.)
4. Fail-closed check: with `require_signature = true` and an empty key dir,
   confirm no skill loads and `household_security_summary()` raises
   `skill_signature_required_but_no_trusted_keys`.

## Notes for reviewers

- Default behavior is unchanged: `require_signature` defaults to `false`, so
  existing deployments keep loading local skills until an operator opts in.
- Verification runs on the bytes read from disk immediately before `dlopen`;
  there is an unavoidable TOCTOU window between read and load that matches the
  existing model (the skills directory is trusted filesystem). The key
  directory is intentionally separate from the skills directory.
- `ed25519-dalek` is pulled in with `default-features = false` (verify only,
  no RNG/keygen) to keep the runtime footprint minimal.
- Follow-up candidates (not in this PR): a `genie-ctl skill sign` helper, and
  key rotation / revocation handling.
