### PR TITLE
docs: clarify Real Behavior Proof profiles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,17 +25,29 @@ contributor. CI enforces this.
 REQUIRED. CI will fail if this section is missing or empty.
 See CONTRIBUTING.md "Required: Real Behavior Proof" for the rules.
 
-The bar is: tell us what you ran, where you ran it, and what happened.
+The bar is: tell us what you ran, where you ran it, which runtime profile or
+hardware it represents, and what happened.
 A green CI run is NOT sufficient by itself — it doesn't exercise voice,
 audio, Home Assistant, or the dashboard.
 -->
 
 - [ ] I have built and run the affected code locally (or noted why I could not).
-- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.
+- [ ] I have verified the change end-to-end on Jetson hardware.
+- [ ] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.
+
+Tested profile / hardware (check all that apply):
+
+- [ ] `jetson`
+- [ ] `raspberry_pi`
+- [ ] `portable_sbc`
+- [ ] `laptop`
+- [ ] `mac`
+- [ ] CI-only / docs-only
+- [ ] Not run locally
 
 ### What I ran
 
-<!-- Commands you executed, with environment details (Jetson model + L4T version, or "no Jetson available"). -->
+<!-- Commands you executed, with environment/profile details: Jetson model + L4T version, Raspberry Pi / SBC model + OS, laptop/mac OS, CI-only/docs-only, or "not run locally". -->
 
 ### What I observed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ What we are slower to land:
 
 Every PR body must include a **"Real Behavior Proof"** section that demonstrates you have actually run the code you are changing. This is **enforced by CI** — a PR with no proof section will fail the `Contribution checklist` job and cannot be merged.
 
-The bar is **truth, not theatre**: tell us what you ran, where you ran it, and what happened. Real validation > performative completeness.
+The bar is **truth, not theatre**: tell us what you ran, where you ran it, what hardware or runtime profile it represents, and what happened. Real validation > performative completeness.
 
 ### Minimum content
 
@@ -33,11 +33,22 @@ Copy the section from the PR template and fill it in honestly:
 ## Real Behavior Proof
 
 - [ ] I have built and run the affected code locally (or noted why I could not).
-- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.
+- [ ] I have verified the change end-to-end on Jetson hardware.
+- [ ] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.
+
+Tested profile / hardware (check all that apply):
+
+- [ ] `jetson`
+- [ ] `raspberry_pi`
+- [ ] `portable_sbc`
+- [ ] `laptop`
+- [ ] `mac`
+- [ ] CI-only / docs-only
+- [ ] Not run locally
 
 ### What I ran
 
-<commands you executed, with output if useful>
+<commands you executed, with environment/profile details and output if useful>
 
 ### What I observed
 
@@ -49,8 +60,9 @@ Copy the section from the PR template and fill it in honestly:
 In rough order of preference:
 
 1. **You ran it on a real Jetson** (Orin Nano, Orin AGX, or Xavier — any L4T target the repo supports). Include the device, the model loaded, and the output of the affected subsystem (chat reply, voice loop banner, `journalctl -u genie-core`, `genie-ctl status`, dashboard screenshot, etc.).
-2. **The `aarch64-unknown-linux-gnu release build` CI job built your branch cleanly**, AND the code path you changed is exercised by an existing unit / integration test you can show passing under `cargo test`. Document the test names you ran.
-3. **You cannot run on Jetson** (no hardware, no cross-compile toolchain on your dev machine, etc.) — say so explicitly under "What I ran". Explain what verification you did do (`cargo fmt --check`, `cargo clippy -- -D warnings`, targeted unit tests, manual code reading). The reviewer will then decide whether a maintainer needs to run your branch on Jetson before merge.
+2. **You ran the affected path on another declared profile** (`raspberry_pi`, `portable_sbc`, `laptop`, or `mac`). Include the board or machine, OS, config profile, and why that is an equivalent path for the change.
+3. **The `aarch64-unknown-linux-gnu release build` CI job built your branch cleanly**, AND the code path you changed is exercised by an existing unit / integration test you can show passing under `cargo test`. Document the test names you ran.
+4. **You cannot run on Jetson** (no hardware, no cross-compile toolchain on your dev machine, etc.) — tick the "NOT verified on Jetson hardware" checkbox and say so explicitly under "What I ran". Explain what verification you did do (`cargo fmt --check`, `cargo clippy -- -D warnings`, targeted unit tests, manual code reading). The reviewer will then decide whether a maintainer needs to run your branch on Jetson before merge.
 
 ### What does NOT count
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,10 @@ For Jetson setup, deployment, and Home Assistant wiring, use
 ## Contributing
 
 Every PR needs a **Real Behavior Proof** section: what you ran, where you ran it,
-and what happened. CI/local proof is enough for docs, harness, provider, and
-non-hardware work. Hardware-facing changes should include Jetson/device proof or
-state the validation gap clearly.
+which profile or hardware it represents (`jetson`, `raspberry_pi`,
+`portable_sbc`, `laptop`, or `mac`), and what happened. CI/local proof is
+enough for docs, harness, provider, and non-hardware work. Hardware-facing
+changes should include Jetson/device proof or state the validation gap clearly.
 
 ## License
 


### PR DESCRIPTION
## Summary

Clarify the Real Behavior Proof template so reviewers can see both Jetson verification status and which runtime profile or hardware was actually used. Closes #179.

## Changes

- Split the Jetson proof line into explicit Jetson-verified and NOT-verified-on-Jetson checkboxes.
- Add a tested profile / hardware checklist for `jetson`, `raspberry_pi`, `portable_sbc`, `laptop`, `mac`, CI/docs-only, and not-run cases.
- Sync CONTRIBUTING.md and README.md with the updated proof expectations.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [ ] `laptop`
- [x] `mac`
- [x] CI-only / docs-only
- [ ] Not run locally

### What I ran

`git diff --check` on macOS.

### What I observed

The docs/template diff has no whitespace errors. This is a docs-only PR, so no Jetson runtime path is affected.

## Test plan

- Re-read .github/PULL_REQUEST_TEMPLATE.md and confirm the Real Behavior Proof section has explicit Jetson status and tested-profile checkboxes.
- Re-read CONTRIBUTING.md and README.md for matching contributor guidance.

## Notes for reviewers

No runtime behavior change.