### PR TITLE
fix(memory): log schema migration and FTS rebuild failures at open (closes #193)

### DIFF
--- a/crates/genie-core/src/memory/mod.rs
+++ b/crates/genie-core/src/memory/mod.rs
@@ -36,6 +36,8 @@ pub struct Memory {
     conn: Connection,
     half_life_days: f64,
     canonical_dir: PathBuf,
+    /// Set when schema migration or FTS rebuild failed during [`Memory::open`].
+    migration_degraded: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,6 +46,7 @@ pub struct MemoryHealth {
     pub memory_rows: usize,
     pub fts_rows: usize,
     pub fts_consistent: bool,
+    pub migration_degraded: bool,
     pub canonical_root_exists: bool,
     pub canonical_namespace_files: usize,
     pub canonical_daily_files: usize,
@@ -168,52 +171,90 @@ impl Memory {
         )?;
 
         // Migrate: add columns if they don't exist (idempotent).
-        let _ = conn.execute(
+        let mut migration_degraded = false;
+        run_open_migration(
+            &conn,
             "ALTER TABLE memories ADD COLUMN recall_count INTEGER NOT NULL DEFAULT 0",
-            [],
+            "add recall_count",
+            &mut migration_degraded,
         );
-        let _ = conn.execute(
+        run_open_migration(
+            &conn,
             "ALTER TABLE memories ADD COLUMN max_score REAL NOT NULL DEFAULT 0.0",
-            [],
+            "add max_score",
+            &mut migration_degraded,
         );
-        let _ = conn.execute(
+        run_open_migration(
+            &conn,
             "ALTER TABLE memories ADD COLUMN promoted INTEGER NOT NULL DEFAULT 0",
-            [],
+            "add promoted",
+            &mut migration_degraded,
         );
-        let _ = conn.execute(
+        run_open_migration(
+            &conn,
             "ALTER TABLE memories ADD COLUMN query_hashes TEXT NOT NULL DEFAULT '[]'",
-            [],
+            "add query_hashes",
+            &mut migration_degraded,
         );
-        let _ = conn.execute(
+        run_open_migration(
+            &conn,
             "ALTER TABLE memories ADD COLUMN evergreen INTEGER NOT NULL DEFAULT 0",
-            [],
+            "add evergreen",
+            &mut migration_degraded,
         );
-        let _ = conn.execute(
+        run_open_migration(
+            &conn,
             "ALTER TABLE memories ADD COLUMN scope TEXT NOT NULL DEFAULT 'household'",
-            [],
+            "add scope",
+            &mut migration_degraded,
         );
-        let _ = conn.execute(
+        run_open_migration(
+            &conn,
             "ALTER TABLE memories ADD COLUMN sensitivity TEXT NOT NULL DEFAULT 'normal'",
-            [],
+            "add sensitivity",
+            &mut migration_degraded,
         );
-        let _ = conn.execute(
+        run_open_migration(
+            &conn,
             "ALTER TABLE memories ADD COLUMN spoken_policy TEXT NOT NULL DEFAULT 'allow'",
-            [],
+            "add spoken_policy",
+            &mut migration_degraded,
         );
-        let _ = conn.execute(
+        run_open_migration(
+            &conn,
             "ALTER TABLE memories ADD COLUMN display_order INTEGER NOT NULL DEFAULT 2147483647",
-            [],
+            "add display_order",
+            &mut migration_degraded,
         );
-        let _ = conn.execute("CREATE INDEX IF NOT EXISTS idx_memories_kind_accessed ON memories(kind, accessed_ms DESC)", []);
-        let _ = conn.execute("CREATE INDEX IF NOT EXISTS idx_memories_promotion ON memories(promoted, recall_count, max_score)", []);
-        let _ = conn.execute("CREATE INDEX IF NOT EXISTS idx_memories_prune ON memories(evergreen, promoted, accessed_ms)", []);
-        let _ = conn.execute(
+        run_open_migration(
+            &conn,
+            "CREATE INDEX IF NOT EXISTS idx_memories_kind_accessed ON memories(kind, accessed_ms DESC)",
+            "create idx_memories_kind_accessed",
+            &mut migration_degraded,
+        );
+        run_open_migration(
+            &conn,
+            "CREATE INDEX IF NOT EXISTS idx_memories_promotion ON memories(promoted, recall_count, max_score)",
+            "create idx_memories_promotion",
+            &mut migration_degraded,
+        );
+        run_open_migration(
+            &conn,
+            "CREATE INDEX IF NOT EXISTS idx_memories_prune ON memories(evergreen, promoted, accessed_ms)",
+            "create idx_memories_prune",
+            &mut migration_degraded,
+        );
+        run_open_migration(
+            &conn,
             "CREATE INDEX IF NOT EXISTS idx_memories_scope_sensitivity ON memories(scope, sensitivity, spoken_policy)",
-            [],
+            "create idx_memories_scope_sensitivity",
+            &mut migration_degraded,
         );
-        let _ = conn.execute(
+        run_open_migration(
+            &conn,
             "CREATE INDEX IF NOT EXISTS idx_memories_display_order ON memories(display_order, accessed_ms DESC, id DESC)",
-            [],
+            "create idx_memories_display_order",
+            &mut migration_degraded,
         );
 
         backfill_policy_columns(&conn)?;
@@ -221,12 +262,13 @@ impl Memory {
         // Older databases may predate the FTS update trigger or may have been
         // edited by a recovery tool. Rebuild once at open so recall and forget
         // do not silently miss rows.
-        let _ = rebuild_fts_index(&conn);
+        run_open_fts_rebuild(&conn, &mut migration_degraded);
 
         Ok(Self {
             conn,
             half_life_days,
             canonical_dir,
+            migration_degraded,
         })
     }
 
@@ -807,6 +849,11 @@ impl Memory {
         rebuild_fts_index(&self.conn)
     }
 
+    /// Whether schema migration or FTS rebuild failed during open.
+    pub fn migration_degraded(&self) -> bool {
+        self.migration_degraded
+    }
+
     /// Lightweight operator health check for the memory store.
     pub fn health(&self) -> Result<MemoryHealth> {
         let quick_check: String = self
@@ -875,6 +922,7 @@ impl Memory {
             memory_rows: memory_rows as usize,
             fts_rows: fts_rows as usize,
             fts_consistent: memory_rows == fts_rows,
+            migration_degraded: self.migration_degraded,
             canonical_root_exists,
             canonical_namespace_files,
             canonical_daily_files,
@@ -1395,6 +1443,32 @@ fn rebuild_fts_index(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn is_duplicate_column_error(err: &rusqlite::Error) -> bool {
+    match err {
+        rusqlite::Error::SqliteFailure(_, Some(msg)) => {
+            msg.to_ascii_lowercase().contains("duplicate column")
+        }
+        _ => false,
+    }
+}
+
+fn run_open_migration(conn: &Connection, sql: &str, step: &str, migration_degraded: &mut bool) {
+    if let Err(error) = conn.execute(sql, []) {
+        if is_duplicate_column_error(&error) {
+            return;
+        }
+        tracing::error!(step, error = %error, "memory schema migration failed");
+        *migration_degraded = true;
+    }
+}
+
+fn run_open_fts_rebuild(conn: &Connection, migration_degraded: &mut bool) {
+    if let Err(error) = rebuild_fts_index(conn) {
+        tracing::error!(error = %error, "memory FTS rebuild failed at open");
+        *migration_degraded = true;
+    }
+}
+
 /// Strip "(source: filename)" tags from memory content for comparison.
 fn strip_source_tag(text: &str) -> String {
     if let Some(pos) = text.rfind(" (source:") {
@@ -1629,7 +1703,59 @@ mod tests {
         let healthy = mem.health().unwrap();
         assert!(healthy.quick_check_ok);
         assert!(healthy.fts_consistent);
+        assert!(!healthy.migration_degraded);
         assert_eq!(healthy.memory_rows, healthy.fts_rows);
+    }
+
+    #[test]
+    fn open_does_not_mark_migration_degraded_on_fresh_db() {
+        let mem = temp_memory();
+        assert!(!mem.migration_degraded());
+        let health = mem.health().unwrap();
+        assert!(!health.migration_degraded);
+    }
+
+    #[test]
+    fn open_marks_migration_degraded_when_fts_rebuild_fails() {
+        let path = temp_memory_path("broken-fts");
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "
+                CREATE TABLE memories (
+                    id            INTEGER PRIMARY KEY,
+                    kind          TEXT NOT NULL,
+                    content       TEXT NOT NULL,
+                    created_ms    INTEGER NOT NULL,
+                    accessed_ms   INTEGER NOT NULL,
+                    recall_count  INTEGER NOT NULL DEFAULT 0,
+                    max_score     REAL NOT NULL DEFAULT 0.0,
+                    promoted      INTEGER NOT NULL DEFAULT 0,
+                    query_hashes  TEXT NOT NULL DEFAULT '[]',
+                    evergreen     INTEGER NOT NULL DEFAULT 0,
+                    scope         TEXT NOT NULL DEFAULT 'household',
+                    sensitivity   TEXT NOT NULL DEFAULT 'normal',
+                    spoken_policy TEXT NOT NULL DEFAULT 'allow',
+                    display_order INTEGER NOT NULL DEFAULT 2147483647
+                );
+                CREATE TABLE memories_fts (content TEXT NOT NULL);
+                ",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO memories (kind, content, created_ms, accessed_ms) VALUES (?1, ?2, 1, 1)",
+                rusqlite::params!["fact", "orphaned row"],
+            )
+            .unwrap();
+        }
+
+        let mem = Memory::open(&path).unwrap();
+        assert!(
+            mem.migration_degraded(),
+            "broken FTS table should mark memory degraded at open"
+        );
+        let health = mem.health().unwrap();
+        assert!(health.migration_degraded);
     }
 
     #[test]

--- a/crates/genie-core/src/server.rs
+++ b/crates/genie-core/src/server.rs
@@ -1106,6 +1106,7 @@ async fn handle_health(
     let llm_ok = llm.health().await;
     let connectivity_health = connectivity.health().await;
     let mem_count = memory.count().unwrap_or(0);
+    let memory_health = memory.health().ok();
     let conv_count = conversations.list().map(|l| l.len()).unwrap_or(0);
     let mem_avail = genie_common::tegrastats::mem_available_mb().unwrap_or(0);
     let runtime_contract = build_runtime_contract_snapshot(
@@ -1127,6 +1128,17 @@ async fn handle_health(
         "llm": if llm_ok { "connected" } else { "offline" },
         "llm_backend": llm.backend_name(),
         "memories": mem_count,
+        "memory": {
+            "count": mem_count,
+            "migration_degraded": memory_health
+                .as_ref()
+                .map(|health| health.migration_degraded)
+                .unwrap_or(true),
+            "fts_consistent": memory_health
+                .as_ref()
+                .map(|health| health.fts_consistent)
+                .unwrap_or(false),
+        },
         "conversations": conv_count,
         "mem_available_mb": mem_avail,
         "connectivity": connectivity_health,

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -915,18 +915,24 @@ impl ToolDispatcher {
             .map_err(|e| anyhow::anyhow!("memory lock: {}", e))?;
         let health = mem.health()?;
         let promoted = mem.promoted_count()?;
-        let state = if health.quick_check_ok && health.fts_consistent {
+        let state = if health.quick_check_ok && health.fts_consistent && !health.migration_degraded
+        {
             "ok"
         } else {
             "degraded"
         };
 
         Ok(format!(
-            "Memory status: {}. Rows: {}. FTS rows: {}. FTS consistent: {}. Promoted memories: {}. Canonical root: {}. Namespace notes: {}. Daily notes: {}. Event logs: {}. Person-scoped memories: {}. Private memories: {}. Restricted memories: {}.",
+            "Memory status: {}. Rows: {}. FTS rows: {}. FTS consistent: {}. Migration degraded: {}. Promoted memories: {}. Canonical root: {}. Namespace notes: {}. Daily notes: {}. Event logs: {}. Person-scoped memories: {}. Private memories: {}. Restricted memories: {}.",
             state,
             health.memory_rows,
             health.fts_rows,
             if health.fts_consistent { "yes" } else { "no" },
+            if health.migration_degraded {
+                "yes"
+            } else {
+                "no"
+            },
             promoted,
             if health.canonical_root_exists {
                 "present"
@@ -2251,6 +2257,7 @@ mod tests {
         assert!(output.contains("Memory status: ok"));
         assert!(output.contains("Rows: 1"));
         assert!(output.contains("FTS consistent: yes"));
+        assert!(output.contains("Migration degraded: no"));
         assert!(output.contains("Canonical root:"));
         assert!(output.contains("Daily notes: 1"));
         assert!(output.contains("Event logs: 1"));


### PR DESCRIPTION
## Summary

- Add `run_open_migration()` / `run_open_fts_rebuild()` helpers that emit `tracing::error!` on unexpected migration or FTS rebuild failures (duplicate-column ALTER errors remain silent/idempotent).
- Track `migration_degraded` on `Memory` and expose it via `MemoryHealth`, `memory_status` tool output, and `/api/health` `memory` section.
- Add tests for fresh DB (not degraded) and broken FTS table fixture (degraded at open).

Closes #193

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
cargo test -p genie-core --lib open_marks open_does_not memory::
cargo test -p genie-core memory_status_reports_health
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo fmt --all -- --check
```

### What I observed

Fresh DB opens with `migration_degraded: false`. Broken FTS fixture sets `migration_degraded: true` while still allowing open. `memory_status` reports `Migration degraded: no/yes` accordingly.

## Test plan

- [x] `cargo test -p genie-core --lib open_marks open_does_not memory::`
- [x] `cargo test -p genie-core memory_status_reports_health`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Optional: corrupt FTS on dev box, restart genie-core, confirm error log + `/api/health` `memory.migration_degraded: true`
