### PR TITLE
fix(api/http): bound and deadline-guard inbound request reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -200,6 +201,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
+ "tokio",
  "toml",
  "tracing",
 ]

--- a/crates/genie-api/Cargo.toml
+++ b/crates/genie-api/Cargo.toml
@@ -18,3 +18,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 rusqlite = { workspace = true }
+
+[dev-dependencies]
+toml = { workspace = true }

--- a/crates/genie-api/src/http.rs
+++ b/crates/genie-api/src/http.rs
@@ -1,74 +1,108 @@
+use std::sync::Arc;
+use std::time::Duration;
+
 use anyhow::Result;
 use genie_common::config::Config;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use genie_common::http::{HttpLimits, read_request};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
+use tokio::net::tcp::OwnedWriteHalf;
+use tokio::sync::Semaphore;
 
 use crate::routes;
+
+/// Largest request body genie-api will read into memory. The dashboard only
+/// sends tiny JSON control payloads, so this stays well below genie-core's
+/// 64 KiB cap. Mirrored into the header phase via `[http].max_header_bytes`.
+const API_MAX_BODY_BYTES: usize = 4 * 1024;
 
 /// Minimal HTTP/1.1 server — no framework, no allocator overhead.
 ///
 /// Handles one request per connection (Connection: close).
 /// This is intentional: the dashboard polls every 5 seconds,
 /// and the API serves <10 concurrent clients on a home appliance.
+///
+/// The inbound reader is bounded and deadline-guarded (issue #195): oversized
+/// request lines/headers are rejected, idle connections are dropped after a
+/// read timeout, transient `accept()` errors never terminate the daemon, and
+/// concurrent connections are capped by a semaphore.
 pub async fn serve(addr: &str, config: Config) -> Result<()> {
     let listener = TcpListener::bind(addr).await?;
-    let config = std::sync::Arc::new(config);
-
     tracing::info!(addr, "listening");
+    serve_listener(listener, config).await
+}
+
+/// Accept connections from an already-bound `TcpListener`.
+///
+/// Split out from [`serve`] so tests can pre-bind to port 0 and drive the
+/// hardened reader/accept loop directly.
+pub(crate) async fn serve_listener(listener: TcpListener, config: Config) -> Result<()> {
+    let config = Arc::new(config);
+    let limits = HttpLimits::from_config(&config.http, API_MAX_BODY_BYTES);
+    let max_connections = config.http.max_connections.max(1);
+    // Bound concurrently handled connections so a flood cannot exhaust fds.
+    let semaphore = Arc::new(Semaphore::new(max_connections));
 
     loop {
-        let (stream, peer) = listener.accept().await?;
+        // Reserve a slot before accepting; connections beyond the ceiling stay
+        // parked in the OS backlog rather than being spawned unbounded.
+        let permit = match Arc::clone(&semaphore).acquire_owned().await {
+            Ok(permit) => permit,
+            Err(_) => break, // semaphore closed — shutting down
+        };
+        let (stream, peer) = match listener.accept().await {
+            Ok(accepted) => accepted,
+            Err(e) => {
+                // A transient accept() error (e.g. EMFILE under a connection
+                // flood) must never propagate out and terminate the daemon.
+                tracing::warn!(error = %e, "accept failed; continuing");
+                drop(permit);
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                continue;
+            }
+        };
         let config = config.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, &config).await {
+            // Hold the permit for the lifetime of the request.
+            let _permit = permit;
+            if let Err(e) = handle_connection(stream, &config, &limits).await {
                 tracing::debug!(peer = %peer, error = %e, "connection error");
             }
         });
     }
+
+    Ok(())
 }
 
-async fn handle_connection(stream: tokio::net::TcpStream, config: &Config) -> Result<()> {
+async fn handle_connection(
+    stream: tokio::net::TcpStream,
+    config: &Config,
+    limits: &HttpLimits,
+) -> Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut buf_reader = BufReader::new(reader);
 
-    // Read the request line.
-    let mut request_line = String::new();
-    buf_reader.read_line(&mut request_line).await?;
-
-    // Parse method and path.
-    let parts: Vec<&str> = request_line.split_whitespace().collect();
-    if parts.len() < 2 {
-        return Ok(());
-    }
-    let method = parts[0];
-    let path = parts[1];
-
-    // Drain headers (we don't need them for our simple API).
-    let mut header_line = String::new();
-    let mut content_length: usize = 0;
-    loop {
-        header_line.clear();
-        buf_reader.read_line(&mut header_line).await?;
-        if header_line.trim().is_empty() {
-            break;
+    // Bounded, deadline-guarded request read (issue #195). Oversized headers
+    // get a 431, an oversized body a 413; a stalled or vanished peer is just
+    // dropped.
+    let request = match read_request(&mut buf_reader, limits).await {
+        Ok(request) => request,
+        Err(e) => {
+            if let Some(status) = e.status_code() {
+                let _ = write_response(&mut writer, &error_response(status)).await;
+            }
+            tracing::debug!(error = %e, "rejected request");
+            return Ok(());
         }
-        if let Some(val) = header_line.strip_prefix("Content-Length: ") {
-            content_length = val.trim().parse().unwrap_or(0);
-        }
-    }
-
-    // Read body if present.
-    let body = if content_length > 0 && content_length < 4096 {
-        let mut buf = vec![0u8; content_length];
-        tokio::io::AsyncReadExt::read_exact(&mut buf_reader, &mut buf).await?;
-        Some(String::from_utf8_lossy(&buf).to_string())
-    } else {
-        None
     };
 
+    let body = request.body;
+    let method = request.method;
+    let path = request.path;
+
     // Route the request.
-    let response = match (method, path) {
+    let response = match (method.as_str(), path.as_str()) {
         ("GET", "/api/status") => routes::get_status(config).await,
         ("GET", "/api/tegrastats") => routes::get_tegrastats(config).await,
         ("GET", "/api/services") => routes::get_services(config).await,
@@ -100,7 +134,26 @@ async fn handle_connection(stream: tokio::net::TcpStream, config: &Config) -> Re
         },
     };
 
-    // Write HTTP response.
+    write_response(&mut writer, &response).await
+}
+
+pub struct Response {
+    pub status: u16,
+    pub content_type: &'static str,
+    pub body: String,
+}
+
+/// JSON error response used to reject oversized requests (431 / 413) before
+/// routing.
+fn error_response(status: u16) -> Response {
+    Response {
+        status,
+        content_type: "application/json",
+        body: format!(r#"{{"error":"{}"}}"#, status_text(status)),
+    }
+}
+
+async fn write_response(writer: &mut OwnedWriteHalf, response: &Response) -> Result<()> {
     let http_response = format!(
         "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n",
         response.status,
@@ -116,19 +169,137 @@ async fn handle_connection(stream: tokio::net::TcpStream, config: &Config) -> Re
     Ok(())
 }
 
-pub struct Response {
-    pub status: u16,
-    pub content_type: &'static str,
-    pub body: String,
-}
-
 fn status_text(code: u16) -> &'static str {
     match code {
         200 => "OK",
         400 => "Bad Request",
         404 => "Not Found",
+        408 => "Request Timeout",
+        413 => "Payload Too Large",
+        431 => "Request Header Fields Too Large",
         502 => "Bad Gateway",
         500 => "Internal Server Error",
         _ => "Unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use genie_common::config::Config;
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    /// Parse a `Config` from a TOML fragment; every field has a serde default,
+    /// so the fragment only needs the `[http]` overrides under test.
+    fn config_with_http(fragment: &str) -> Config {
+        toml::from_str(fragment).expect("config parses")
+    }
+
+    /// Bind to an ephemeral port, start the hardened listener, return the port.
+    async fn start_server(config: Config) -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let _ = super::serve_listener(listener, config).await;
+        });
+        port
+    }
+
+    async fn read_all(mut stream: TcpStream, timeout: Duration) -> String {
+        let mut buf = Vec::new();
+        let _ = tokio::time::timeout(timeout, stream.read_to_end(&mut buf)).await;
+        String::from_utf8_lossy(&buf).to_string()
+    }
+
+    #[tokio::test]
+    async fn oversized_request_header_is_rejected_and_server_survives() {
+        let config = config_with_http(
+            "[http]\nmax_header_line_bytes = 256\nread_timeout_secs = 2\nmax_connections = 8\n",
+        );
+        let port = start_server(config).await;
+
+        // Oversized header line → 431, in bounded memory.
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let pad = "A".repeat(2048);
+        let req = format!("GET /api/status HTTP/1.1\r\nX-Pad: {pad}\r\n\r\n");
+        stream.write_all(req.as_bytes()).await.unwrap();
+        let resp = read_all(stream, Duration::from_secs(5)).await;
+        assert!(
+            resp.starts_with("HTTP/1.1 431"),
+            "expected 431, got: {resp:?}"
+        );
+
+        // The daemon survives: a well-formed request is still routed.
+        let mut stream2 = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        stream2
+            .write_all(b"GET /does-not-exist HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let resp2 = read_all(stream2, Duration::from_secs(5)).await;
+        assert!(
+            resp2.starts_with("HTTP/1.1 404"),
+            "expected 404 after rejection, got: {resp2:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn idle_connection_is_dropped_after_read_timeout() {
+        let config = config_with_http("[http]\nread_timeout_secs = 1\nmax_connections = 8\n");
+        let port = start_server(config).await;
+
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        // Partial request, never terminated.
+        stream
+            .write_all(b"GET /api/status HTTP/1.1\r\nX-Partial: ")
+            .await
+            .unwrap();
+
+        let start = std::time::Instant::now();
+        let mut buf = Vec::new();
+        let n = tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut buf))
+            .await
+            .expect("server did not drop the idle connection within 5s")
+            .unwrap();
+        assert_eq!(
+            n,
+            0,
+            "idle connection should close with no response, got: {:?}",
+            String::from_utf8_lossy(&buf)
+        );
+        assert!(start.elapsed() >= Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn connection_flood_does_not_wedge_server() {
+        let config = config_with_http("[http]\nread_timeout_secs = 1\nmax_connections = 4\n");
+        let port = start_server(config).await;
+
+        // More stalled peers than the ceiling, kept open so they don't EOF.
+        let mut stalled = Vec::new();
+        for _ in 0..8 {
+            let mut s = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+            let _ = s.write_all(b"G").await;
+            stalled.push(s);
+        }
+
+        // A well-formed request still gets served once stalled peers time out.
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        stream
+            .write_all(b"GET /does-not-exist HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let mut buf = Vec::new();
+        tokio::time::timeout(Duration::from_secs(8), stream.read_to_end(&mut buf))
+            .await
+            .expect("server wedged: no response within 8s under connection flood")
+            .unwrap();
+        let resp = String::from_utf8_lossy(&buf);
+        assert!(
+            resp.starts_with("HTTP/1.1 404"),
+            "expected 404 after flood, got: {resp:?}"
+        );
+
+        drop(stalled);
     }
 }

--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -917,6 +917,7 @@ mod tests {
             telegram: TelegramConfig::default(),
             web_search: WebSearchConfig::default(),
             connectivity: ConnectivityConfig::default(),
+            http: Default::default(),
         }
     }
 

--- a/crates/genie-common/Cargo.toml
+++ b/crates/genie-common/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
+tokio = { workspace = true }

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -37,6 +37,9 @@ pub struct Config {
 
     #[serde(default)]
     pub connectivity: ConnectivityConfig,
+
+    #[serde(default)]
+    pub http: HttpServerConfig,
 }
 
 #[derive(Debug, Deserialize)]
@@ -725,6 +728,56 @@ pub enum WebSearchProvider {
     Searxng,
 }
 
+/// Inbound HTTP-server hardening shared by `genie-core` (`:3000`) and
+/// `genie-api` (`:3080`).
+///
+/// These bounds protect the always-on daemon from an unauthenticated peer on
+/// the LAN: oversized request lines/headers are rejected, a stalled connection
+/// is dropped after `read_timeout_secs`, and the number of concurrent
+/// connections is capped (issue #195). The per-request body cap is fixed per
+/// server (64 KiB for genie-core, 4 KiB for genie-api) and is not part of this
+/// section.
+#[derive(Debug, Deserialize, Clone, Copy)]
+pub struct HttpServerConfig {
+    /// Max bytes in the request line, newline included.
+    #[serde(default = "defaults::http_max_request_line_bytes")]
+    pub max_request_line_bytes: usize,
+
+    /// Max bytes in any single header line, newline included.
+    #[serde(default = "defaults::http_max_header_line_bytes")]
+    pub max_header_line_bytes: usize,
+
+    /// Max number of header lines per request.
+    #[serde(default = "defaults::http_max_header_count")]
+    pub max_header_count: usize,
+
+    /// Max total bytes across all header lines (the header-phase ceiling).
+    /// Mirrors the existing body cap upward into the header phase.
+    #[serde(default = "defaults::http_max_header_bytes")]
+    pub max_header_bytes: usize,
+
+    /// Deadline for reading one whole request (line + headers + body).
+    #[serde(default = "defaults::http_read_timeout_secs")]
+    pub read_timeout_secs: u64,
+
+    /// Ceiling on concurrently handled connections.
+    #[serde(default = "defaults::http_max_connections")]
+    pub max_connections: usize,
+}
+
+impl Default for HttpServerConfig {
+    fn default() -> Self {
+        Self {
+            max_request_line_bytes: defaults::http_max_request_line_bytes(),
+            max_header_line_bytes: defaults::http_max_header_line_bytes(),
+            max_header_count: defaults::http_max_header_count(),
+            max_header_bytes: defaults::http_max_header_bytes(),
+            read_timeout_secs: defaults::http_read_timeout_secs(),
+            max_connections: defaults::http_max_connections(),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ConnectivityConfig {
     /// Enable the external connectivity coprocessor path.
@@ -1313,6 +1366,7 @@ mod tests {
             telegram: TelegramConfig::default(),
             web_search: WebSearchConfig::default(),
             connectivity: ConnectivityConfig::default(),
+            http: HttpServerConfig::default(),
         }
     }
 
@@ -2024,6 +2078,60 @@ expected_runtime_contract_hash = "abc123"
     }
 
     #[test]
+    fn http_server_config_defaults_are_bounded() {
+        let config = test_config();
+        assert_eq!(config.http.max_request_line_bytes, 8 * 1024);
+        assert_eq!(config.http.max_header_line_bytes, 8 * 1024);
+        assert_eq!(config.http.max_header_count, 100);
+        assert_eq!(config.http.max_header_bytes, 64 * 1024);
+        assert_eq!(config.http.read_timeout_secs, 15);
+        assert_eq!(config.http.max_connections, 256);
+    }
+
+    #[test]
+    fn http_server_config_falls_back_when_section_absent() {
+        // Existing deployments have no [http] section yet — the whole config
+        // must still parse and use the hardened defaults.
+        let config: Config = toml::from_str(
+            r#"
+[services.core]
+url = "http://127.0.0.1:3000/api/health"
+systemd_unit = "genie-core.service"
+
+[services.llm]
+url = "http://127.0.0.1:8080/health"
+systemd_unit = "genie-ai-runtime.service"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.http.max_header_bytes, 64 * 1024);
+        assert_eq!(config.http.max_connections, 256);
+    }
+
+    #[test]
+    fn http_server_config_parses_overrides() {
+        let config: HttpServerConfig = toml::from_str(
+            r#"
+max_request_line_bytes = 2048
+max_header_line_bytes = 2048
+max_header_count = 32
+max_header_bytes = 16384
+read_timeout_secs = 5
+max_connections = 16
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.max_request_line_bytes, 2048);
+        assert_eq!(config.max_header_line_bytes, 2048);
+        assert_eq!(config.max_header_count, 32);
+        assert_eq!(config.max_header_bytes, 16384);
+        assert_eq!(config.read_timeout_secs, 5);
+        assert_eq!(config.max_connections, 16);
+    }
+
+    #[test]
     fn legacy_spi_connectivity_config_still_parses() {
         let config: ConnectivityConfig = toml::from_str(
             r#"
@@ -2264,6 +2372,29 @@ mod defaults {
     }
     pub fn connectivity_device() -> String {
         "esp32c6".into()
+    }
+    pub fn http_max_request_line_bytes() -> usize {
+        8 * 1024
+    }
+    pub fn http_max_header_line_bytes() -> usize {
+        8 * 1024
+    }
+    pub fn http_max_header_count() -> usize {
+        100
+    }
+    pub fn http_max_header_bytes() -> usize {
+        // Mirror the genie-core 64 KiB body cap upward into the header phase.
+        64 * 1024
+    }
+    pub fn http_read_timeout_secs() -> u64 {
+        15
+    }
+    pub fn http_max_connections() -> usize {
+        // Generous headroom over the handful of real clients (dashboard polls
+        // every 5 s, plus voice/Telegram/local apps) while still bounding fan-out
+        // so a connection flood cannot exhaust fds or wedge the single-threaded
+        // genie-core runtime.
+        256
     }
     pub fn esp32c6_uart_device() -> String {
         "/dev/ttyTHS1".into()

--- a/crates/genie-common/src/http.rs
+++ b/crates/genie-common/src/http.rs
@@ -1,0 +1,464 @@
+//! Hardened HTTP/1.1 request reader shared by the GeniePod backend servers.
+//!
+//! Both `genie-core` (chat/agent API, `:3000`) and `genie-api` (dashboard API,
+//! `:3080`) speak a tiny hand-rolled HTTP/1.1 dialect over raw `tokio` sockets
+//! — no framework. The original readers grew the request line and headers with
+//! an unbounded `read_line` loop and never imposed a read deadline, so a single
+//! unauthenticated peer on the LAN could exhaust memory (a header that never
+//! terminates with `\n`) or stall the listener with half-open connections and
+//! take the always-on home daemon down (issue #195).
+//!
+//! This module centralizes a bounded, deadline-guarded reader so the fix lives
+//! in exactly one place. Callers supply [`HttpLimits`] — typically built from
+//! the `[http]` config section plus a per-server body cap — and get back a
+//! parsed [`HttpRequest`], or a typed [`HttpReadError`] they can map onto a
+//! `431` / `413` response (or simply close the connection).
+//!
+//! The reader is bounded in three independent ways:
+//!   * **Size** — request line, each header line, the total header bytes, and
+//!     the header count are all capped; the body is capped too. Memory never
+//!     grows past the configured ceilings regardless of what the peer sends.
+//!   * **Time** — the entire read (line + headers + body) runs under a single
+//!     [`tokio::time::timeout`], so a connection that opens and then stalls is
+//!     dropped instead of awaiting forever.
+//!   * **Liveness** — a half-sent request that never reaches the blank-line
+//!     terminator is reported (`Closed` / `Timeout`) instead of being parsed.
+//!
+//! Connection-count ceilings and accept-loop resilience are the server's job
+//! (a `tokio::sync::Semaphore` plus a log-and-continue accept loop); they are
+//! not part of the per-request read and so live in each server's listener.
+
+use std::time::Duration;
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt};
+
+/// Bounds enforced while reading one inbound HTTP request.
+///
+/// Construct with [`HttpLimits::from_config`] to pull the shared knobs from the
+/// `[http]` config section, passing the per-server body cap (genie-core keeps
+/// its 64 KiB cap, genie-api its 4 KiB cap).
+#[derive(Debug, Clone, Copy)]
+pub struct HttpLimits {
+    /// Max bytes in the request line (`METHOD PATH VERSION\r\n`), newline included.
+    pub max_request_line_bytes: usize,
+    /// Max bytes in any single header line, newline included.
+    pub max_header_line_bytes: usize,
+    /// Max number of header lines.
+    pub max_header_count: usize,
+    /// Max total bytes across all header lines (the header phase ceiling).
+    pub max_header_bytes: usize,
+    /// Max declared `Content-Length` the server will read into memory.
+    pub max_body_bytes: usize,
+    /// Deadline for the whole request read (line + headers + body).
+    pub read_timeout: Duration,
+}
+
+impl HttpLimits {
+    /// Build limits from the shared `[http]` config plus a per-server body cap.
+    pub fn from_config(cfg: &crate::config::HttpServerConfig, max_body_bytes: usize) -> Self {
+        Self {
+            max_request_line_bytes: cfg.max_request_line_bytes.max(1),
+            max_header_line_bytes: cfg.max_header_line_bytes.max(1),
+            max_header_count: cfg.max_header_count,
+            max_header_bytes: cfg.max_header_bytes.max(1),
+            max_body_bytes,
+            read_timeout: Duration::from_secs(cfg.read_timeout_secs.max(1)),
+        }
+    }
+}
+
+/// A parsed inbound HTTP request.
+///
+/// Header names are stored lowercased; [`HttpRequest::header`] looks them up
+/// case-insensitively. The body, if any, has already been read in full (and is
+/// therefore bounded by [`HttpLimits::max_body_bytes`]).
+#[derive(Debug, Clone)]
+pub struct HttpRequest {
+    pub method: String,
+    pub path: String,
+    pub headers: Vec<(String, String)>,
+    pub content_length: usize,
+    pub body: Option<String>,
+}
+
+impl HttpRequest {
+    /// First value for `name`, matched case-insensitively. Returns the raw
+    /// (un-lowercased) value so callers see exactly what the peer sent.
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(key, _)| key.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.as_str())
+    }
+}
+
+/// Why an inbound request could not be read.
+///
+/// [`HttpReadError::status_code`] gives the HTTP status to reply with for the
+/// cases where a reply is appropriate; the rest mean "just drop the
+/// connection" (the peer is gone, stalled, or sending garbage).
+#[derive(Debug)]
+pub enum HttpReadError {
+    /// The whole-request read deadline elapsed (idle / slowloris connection).
+    Timeout,
+    /// The peer closed before sending a complete request.
+    Closed,
+    /// The request line had no method/path.
+    Malformed,
+    /// The request line exceeded `max_request_line_bytes`.
+    RequestLineTooLong,
+    /// A header line exceeded `max_header_line_bytes`.
+    HeaderLineTooLong,
+    /// More than `max_header_count` header lines were sent.
+    TooManyHeaders,
+    /// The header phase exceeded `max_header_bytes` in total.
+    HeadersTooLarge,
+    /// The declared `Content-Length` exceeded `max_body_bytes`.
+    BodyTooLarge,
+    /// A low-level I/O error (including a truncated body).
+    Io(std::io::Error),
+}
+
+impl HttpReadError {
+    /// HTTP status to respond with, or `None` when the connection should just
+    /// be dropped without a reply.
+    pub fn status_code(&self) -> Option<u16> {
+        match self {
+            HttpReadError::RequestLineTooLong
+            | HttpReadError::HeaderLineTooLong
+            | HttpReadError::TooManyHeaders
+            | HttpReadError::HeadersTooLarge => Some(431),
+            HttpReadError::BodyTooLarge => Some(413),
+            // A read timeout, a vanished peer, garbage, or a socket error: there
+            // is no point (or it is unsafe against a stalled peer) writing a
+            // status line, so close the connection instead.
+            HttpReadError::Timeout
+            | HttpReadError::Closed
+            | HttpReadError::Malformed
+            | HttpReadError::Io(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for HttpReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HttpReadError::Timeout => write!(f, "request read timed out"),
+            HttpReadError::Closed => write!(f, "peer closed before a complete request"),
+            HttpReadError::Malformed => write!(f, "malformed request line"),
+            HttpReadError::RequestLineTooLong => write!(f, "request line too long"),
+            HttpReadError::HeaderLineTooLong => write!(f, "header line too long"),
+            HttpReadError::TooManyHeaders => write!(f, "too many headers"),
+            HttpReadError::HeadersTooLarge => write!(f, "headers too large"),
+            HttpReadError::BodyTooLarge => write!(f, "request body too large"),
+            HttpReadError::Io(e) => write!(f, "io error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for HttpReadError {}
+
+/// Read and parse one HTTP request from `reader`, enforcing every bound in
+/// `limits`. The entire read runs under a single deadline, so a stalled peer
+/// cannot hold the task open.
+pub async fn read_request<R>(
+    reader: &mut R,
+    limits: &HttpLimits,
+) -> Result<HttpRequest, HttpReadError>
+where
+    R: AsyncBufRead + Unpin,
+{
+    match tokio::time::timeout(limits.read_timeout, read_request_inner(reader, limits)).await {
+        Ok(result) => result,
+        Err(_elapsed) => Err(HttpReadError::Timeout),
+    }
+}
+
+async fn read_request_inner<R>(
+    reader: &mut R,
+    limits: &HttpLimits,
+) -> Result<HttpRequest, HttpReadError>
+where
+    R: AsyncBufRead + Unpin,
+{
+    // Request line.
+    let mut line = Vec::new();
+    let n = read_line_bounded(reader, &mut line, limits.max_request_line_bytes, || {
+        HttpReadError::RequestLineTooLong
+    })
+    .await?;
+    if n == 0 {
+        return Err(HttpReadError::Closed);
+    }
+    let request_line = String::from_utf8_lossy(&line);
+    let mut parts = request_line.split_whitespace();
+    let (method, path) = match (parts.next(), parts.next()) {
+        (Some(method), Some(path)) => (method.to_string(), path.to_string()),
+        _ => return Err(HttpReadError::Malformed),
+    };
+
+    // Headers.
+    let mut headers: Vec<(String, String)> = Vec::new();
+    let mut content_length: usize = 0;
+    let mut total_header_bytes: usize = 0;
+    loop {
+        if headers.len() >= limits.max_header_count {
+            return Err(HttpReadError::TooManyHeaders);
+        }
+        line.clear();
+        let n = read_line_bounded(reader, &mut line, limits.max_header_line_bytes, || {
+            HttpReadError::HeaderLineTooLong
+        })
+        .await?;
+        if n == 0 {
+            // EOF before the blank-line terminator — a truncated request.
+            return Err(HttpReadError::Closed);
+        }
+        total_header_bytes = total_header_bytes.saturating_add(n);
+        if total_header_bytes > limits.max_header_bytes {
+            return Err(HttpReadError::HeadersTooLarge);
+        }
+
+        let text = String::from_utf8_lossy(&line);
+        let trimmed = text.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = trimmed.split_once(':') {
+            let name = name.trim().to_ascii_lowercase();
+            let value = value.trim().to_string();
+            if name == "content-length" {
+                content_length = value.parse().unwrap_or(0);
+            }
+            headers.push((name, value));
+        }
+        // Lines without a colon are ignored, matching the previous lenient
+        // parser (it only ever looked for specific `name: value` prefixes).
+    }
+
+    // Body.
+    let body = if content_length > 0 {
+        if content_length > limits.max_body_bytes {
+            return Err(HttpReadError::BodyTooLarge);
+        }
+        let mut buf = vec![0u8; content_length];
+        reader
+            .read_exact(&mut buf)
+            .await
+            .map_err(HttpReadError::Io)?;
+        Some(String::from_utf8_lossy(&buf).to_string())
+    } else {
+        None
+    };
+
+    Ok(HttpRequest {
+        method,
+        path,
+        headers,
+        content_length,
+        body,
+    })
+}
+
+/// Read one `\n`-terminated line into `out`, appending at most `max_bytes`.
+///
+/// Returns the number of bytes appended for this line (0 on immediate EOF).
+/// If `max_bytes` is reached before a newline, returns the error built by
+/// `too_long` — crucially *without* having accumulated more than `max_bytes`,
+/// so a peer streaming an endless line cannot drive memory growth.
+///
+/// Bytes are pulled out of the buffered reader a chunk at a time via
+/// `fill_buf` / `consume` rather than `read_line`, which would append the whole
+/// (attacker-controlled) line to a `String` with no ceiling.
+async fn read_line_bounded<R, F>(
+    reader: &mut R,
+    out: &mut Vec<u8>,
+    max_bytes: usize,
+    too_long: F,
+) -> Result<usize, HttpReadError>
+where
+    R: AsyncBufRead + Unpin,
+    F: Fn() -> HttpReadError,
+{
+    let start = out.len();
+    loop {
+        let available = reader.fill_buf().await.map_err(HttpReadError::Io)?;
+        if available.is_empty() {
+            // EOF.
+            return Ok(out.len() - start);
+        }
+        match available.iter().position(|&b| b == b'\n') {
+            Some(idx) => {
+                let take = idx + 1;
+                if (out.len() - start) + take > max_bytes {
+                    return Err(too_long());
+                }
+                out.extend_from_slice(&available[..take]);
+                reader.consume(take);
+                return Ok(out.len() - start);
+            }
+            None => {
+                let take = available.len();
+                if (out.len() - start) + take > max_bytes {
+                    // The cap is reached and still no newline in sight: refuse
+                    // now instead of buffering an unbounded line.
+                    return Err(too_long());
+                }
+                out.extend_from_slice(available);
+                reader.consume(take);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+
+    fn test_limits() -> HttpLimits {
+        HttpLimits {
+            max_request_line_bytes: 8 * 1024,
+            max_header_line_bytes: 8 * 1024,
+            max_header_count: 64,
+            max_header_bytes: 64 * 1024,
+            max_body_bytes: 64 * 1024,
+            read_timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn reader_for(bytes: &[u8]) -> BufReader<Cursor<Vec<u8>>> {
+        BufReader::new(Cursor::new(bytes.to_vec()))
+    }
+
+    #[tokio::test]
+    async fn parses_simple_get() {
+        let mut reader = reader_for(b"GET /api/health HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        let req = read_request(&mut reader, &test_limits()).await.unwrap();
+        assert_eq!(req.method, "GET");
+        assert_eq!(req.path, "/api/health");
+        assert_eq!(req.header("host"), Some("localhost"));
+        assert!(req.body.is_none());
+    }
+
+    #[tokio::test]
+    async fn parses_post_with_body_and_origin_header() {
+        let body = r#"{"message":"hi"}"#;
+        let raw = format!(
+            "POST /api/chat HTTP/1.1\r\nContent-Length: {}\r\nX-Genie-Origin: Voice\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let mut reader = reader_for(raw.as_bytes());
+        let req = read_request(&mut reader, &test_limits()).await.unwrap();
+        assert_eq!(req.method, "POST");
+        assert_eq!(req.content_length, body.len());
+        assert_eq!(req.body.as_deref(), Some(body));
+        // Header name matched case-insensitively; raw value preserved.
+        assert_eq!(req.header("x-genie-origin"), Some("Voice"));
+    }
+
+    #[tokio::test]
+    async fn oversized_request_line_is_rejected() {
+        let mut limits = test_limits();
+        limits.max_request_line_bytes = 64;
+        let raw = format!("GET /{} HTTP/1.1\r\n\r\n", "a".repeat(4096));
+        let mut reader = reader_for(raw.as_bytes());
+        let err = read_request(&mut reader, &limits).await.unwrap_err();
+        assert!(matches!(err, HttpReadError::RequestLineTooLong));
+        assert_eq!(err.status_code(), Some(431));
+    }
+
+    #[tokio::test]
+    async fn unterminated_header_is_rejected_in_bounded_memory() {
+        // A header that never ends with `\n` is the OOM vector from issue #195:
+        // chain a valid request line with an infinite stream of 'A'. The reader
+        // must reject it, not grow without limit.
+        let mut limits = test_limits();
+        limits.max_header_line_bytes = 4096;
+        let prefix = Cursor::new(b"GET / HTTP/1.1\r\nX-Pad: ".to_vec());
+        let endless = prefix.chain(tokio::io::repeat(b'A'));
+        let mut reader = BufReader::new(endless);
+        let err = read_request(&mut reader, &limits).await.unwrap_err();
+        assert!(matches!(err, HttpReadError::HeaderLineTooLong));
+        assert_eq!(err.status_code(), Some(431));
+    }
+
+    #[tokio::test]
+    async fn too_many_headers_is_rejected() {
+        let mut limits = test_limits();
+        limits.max_header_count = 4;
+        let mut raw = String::from("GET / HTTP/1.1\r\n");
+        for i in 0..50 {
+            raw.push_str(&format!("X-H-{i}: v\r\n"));
+        }
+        raw.push_str("\r\n");
+        let mut reader = reader_for(raw.as_bytes());
+        let err = read_request(&mut reader, &limits).await.unwrap_err();
+        assert!(matches!(err, HttpReadError::TooManyHeaders));
+        assert_eq!(err.status_code(), Some(431));
+    }
+
+    #[tokio::test]
+    async fn total_header_bytes_cap_is_enforced() {
+        let mut limits = test_limits();
+        limits.max_header_bytes = 256;
+        limits.max_header_line_bytes = 8 * 1024;
+        let mut raw = String::from("GET / HTTP/1.1\r\n");
+        for i in 0..40 {
+            raw.push_str(&format!("X-Filler-{i}: {}\r\n", "x".repeat(40)));
+        }
+        raw.push_str("\r\n");
+        let mut reader = reader_for(raw.as_bytes());
+        let err = read_request(&mut reader, &limits).await.unwrap_err();
+        assert!(matches!(err, HttpReadError::HeadersTooLarge));
+        assert_eq!(err.status_code(), Some(431));
+    }
+
+    #[tokio::test]
+    async fn oversized_declared_body_is_rejected() {
+        let mut limits = test_limits();
+        limits.max_body_bytes = 4096;
+        let raw = "POST /api/chat HTTP/1.1\r\nContent-Length: 999999\r\n\r\n";
+        let mut reader = reader_for(raw.as_bytes());
+        let err = read_request(&mut reader, &limits).await.unwrap_err();
+        assert!(matches!(err, HttpReadError::BodyTooLarge));
+        assert_eq!(err.status_code(), Some(413));
+    }
+
+    #[tokio::test]
+    async fn idle_connection_times_out() {
+        // A peer that sends a partial request and then stalls (never sending
+        // the header terminator) must be dropped after the read deadline, not
+        // awaited forever.
+        let mut limits = test_limits();
+        limits.read_timeout = Duration::from_millis(150);
+
+        let (mut client, server) = tokio::io::duplex(1024);
+        client
+            .write_all(b"GET / HTTP/1.1\r\nX-Partial: ")
+            .await
+            .unwrap();
+        // Keep `client` alive (no EOF) but send nothing more.
+
+        let mut reader = BufReader::new(server);
+        let start = std::time::Instant::now();
+        let err = read_request(&mut reader, &limits).await.unwrap_err();
+        assert!(matches!(err, HttpReadError::Timeout));
+        assert_eq!(err.status_code(), None, "timeout should just drop the conn");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "read must abandon the stalled peer promptly"
+        );
+        drop(client);
+    }
+
+    #[tokio::test]
+    async fn peer_close_before_request_is_reported() {
+        let mut reader = reader_for(b"");
+        let err = read_request(&mut reader, &test_limits()).await.unwrap_err();
+        assert!(matches!(err, HttpReadError::Closed));
+        assert_eq!(err.status_code(), None);
+    }
+}

--- a/crates/genie-common/src/lib.rs
+++ b/crates/genie-common/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
+pub mod http;
 pub mod mode;
 pub mod tegrastats;

--- a/crates/genie-core/src/main.rs
+++ b/crates/genie-core/src/main.rs
@@ -286,7 +286,8 @@ async fn main() -> Result<()> {
             config.core.max_history_turns,
             model_family,
             config.core.expected_runtime_contract_hash.clone(),
-        )?;
+        )?
+        .with_http_config(config.http);
 
         tracing::info!(port, "starting HTTP chat API");
         if config.telegram.enabled {

--- a/crates/genie-core/src/server.rs
+++ b/crates/genie-core/src/server.rs
@@ -1,10 +1,13 @@
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use genie_common::config::HttpServerConfig;
+use genie_common::http::{HttpLimits, read_request};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use tokio::net::tcp::OwnedWriteHalf;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 
 use crate::connectivity::{ConnectivityController, ConnectivityHealth, ConnectivityState};
 use crate::conversation::ConversationStore;
@@ -16,6 +19,10 @@ use crate::tools::ToolDispatcher;
 use crate::tools::{RequestOrigin, ToolExecutionContext};
 
 const HTML_CONTENT_TYPE: &str = "text/html; charset=utf-8";
+
+/// Largest request body genie-core will read into memory (mirrored into the
+/// header phase as the `[http]` `max_header_bytes` default). Issue #195.
+const CORE_MAX_BODY_BYTES: usize = 64 * 1024;
 
 struct StaticHtml {
     body: &'static str,
@@ -73,6 +80,8 @@ pub struct ChatServer {
     max_history: usize,
     model_family: ModelFamily,
     expected_runtime_contract_hash: String,
+    /// Inbound HTTP-server hardening (read caps, timeout, connection ceiling).
+    http_config: HttpServerConfig,
 }
 
 pub struct ChatTurnResult {
@@ -111,7 +120,15 @@ impl ChatServer {
             max_history,
             model_family,
             expected_runtime_contract_hash,
+            http_config: HttpServerConfig::default(),
         })
+    }
+
+    /// Override the inbound HTTP-server hardening config (read caps, timeout,
+    /// and connection ceiling). Defaults to [`HttpServerConfig::default`].
+    pub fn with_http_config(mut self, http_config: HttpServerConfig) -> Self {
+        self.http_config = http_config;
+        self
     }
 
     /// Serve HTTP requests on the current-thread runtime.
@@ -145,15 +162,43 @@ impl ChatServer {
     /// and hand the listener directly to the server — avoiding the
     /// bind-drop-rebind race that a port-0 `serve()` call would require.
     pub(crate) async fn serve_listener(self, listener: TcpListener) -> Result<()> {
+        let limits = HttpLimits::from_config(&self.http_config, CORE_MAX_BODY_BYTES);
+        let max_connections = self.http_config.max_connections.max(1);
+        // Bound concurrently handled connections so a flood cannot exhaust fds
+        // or wedge the single-threaded runtime (issue #195).
+        let semaphore = Arc::new(Semaphore::new(max_connections));
         let ctx = Rc::new(self);
         let local = tokio::task::LocalSet::new();
         local
             .run_until(async move {
                 loop {
-                    let (stream, _) = listener.accept().await?;
+                    // Reserve a slot *before* accepting; connections beyond the
+                    // ceiling stay parked in the OS backlog rather than being
+                    // spawned unbounded.
+                    let permit = match Arc::clone(&semaphore).acquire_owned().await {
+                        Ok(permit) => permit,
+                        Err(_) => break, // semaphore closed — shutting down
+                    };
+                    let stream = match listener.accept().await {
+                        Ok((stream, _)) => stream,
+                        Err(e) => {
+                            // A transient accept() error (e.g. EMFILE under a
+                            // connection flood) must never propagate out and
+                            // terminate the daemon. Log, free the slot, back
+                            // off briefly, and keep serving.
+                            tracing::warn!(error = %e, "accept failed; continuing");
+                            drop(permit);
+                            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                            continue;
+                        }
+                    };
                     let request_ctx = Rc::clone(&ctx);
                     tokio::task::spawn_local(async move {
-                        if let Err(e) = handle_request(stream, request_ctx.as_ref()).await {
+                        // Hold the permit for the lifetime of the request; it
+                        // is released when this task ends.
+                        let _permit = permit;
+                        if let Err(e) = handle_request(stream, request_ctx.as_ref(), &limits).await
+                        {
                             tracing::debug!(error = %e, "request error");
                         }
                     });
@@ -238,7 +283,11 @@ fn normalized_origin(request_origin: RequestOrigin) -> RequestOrigin {
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn handle_request(stream: tokio::net::TcpStream, ctx: &ChatServer) -> Result<()> {
+async fn handle_request(
+    stream: tokio::net::TcpStream,
+    ctx: &ChatServer,
+    limits: &HttpLimits,
+) -> Result<()> {
     let llm = &ctx.llm;
     let tools = &ctx.tools;
     let memory = &ctx.memory;
@@ -254,44 +303,30 @@ async fn handle_request(stream: tokio::net::TcpStream, ctx: &ChatServer) -> Resu
     let (reader, mut writer) = stream.into_split();
     let mut buf_reader = BufReader::new(reader);
 
-    // Parse request line.
-    let mut request_line = String::new();
-    buf_reader.read_line(&mut request_line).await?;
-    let parts: Vec<&str> = request_line.split_whitespace().collect();
-    if parts.len() < 2 {
-        return Ok(());
-    }
-    let method = parts[0];
-    let path = parts[1];
-
-    // Read headers.
-    let mut content_length: usize = 0;
-    let mut request_origin = RequestOrigin::Unknown;
-    loop {
-        let mut line = String::new();
-        buf_reader.read_line(&mut line).await?;
-        if line.trim().is_empty() {
-            break;
+    // Bounded, deadline-guarded request read (issue #195). Oversized headers
+    // get a 431, an oversized body a 413; a stalled or vanished peer is just
+    // dropped.
+    let request = match read_request(&mut buf_reader, limits).await {
+        Ok(request) => request,
+        Err(e) => {
+            if let Some(status) = e.status_code() {
+                let _ = write_status_response(&mut writer, status).await;
+            }
+            tracing::debug!(error = %e, "rejected inbound request");
+            return Ok(());
         }
-        if let Some(val) = line.to_lowercase().strip_prefix("content-length: ") {
-            content_length = val.trim().parse().unwrap_or(0);
-        }
-        if let Some(val) = line.to_lowercase().strip_prefix("x-genie-origin: ") {
-            request_origin = RequestOrigin::from_header(val.trim());
-        }
-    }
-
-    // Read body.
-    let body = if content_length > 0 && content_length < 65536 {
-        let mut buf = vec![0u8; content_length];
-        tokio::io::AsyncReadExt::read_exact(&mut buf_reader, &mut buf).await?;
-        Some(String::from_utf8_lossy(&buf).to_string())
-    } else {
-        None
     };
 
+    let request_origin = request
+        .header("x-genie-origin")
+        .map(RequestOrigin::from_header)
+        .unwrap_or(RequestOrigin::Unknown);
+    let body = request.body;
+    let method = request.method;
+    let path = request.path;
+
     // Route.
-    let route = classify_route(method, path);
+    let route = classify_route(&method, &path);
     if matches!(route, RequestRoute::ChatStream) {
         let _guard = chat_turn_lock.lock().await;
         if let Err(e) = handle_chat_stream(
@@ -1957,11 +1992,31 @@ fn status_text(code: u16) -> &'static str {
         200 => "OK",
         400 => "Bad Request",
         404 => "Not Found",
+        408 => "Request Timeout",
+        413 => "Payload Too Large",
+        431 => "Request Header Fields Too Large",
         502 => "Bad Gateway",
         503 => "Service Unavailable",
         500 => "Internal Server Error",
         _ => "Unknown",
     }
+}
+
+/// Write a minimal JSON error response (used to reject oversized requests with
+/// 431 / 413 before any routing). Best-effort: failures to write back to a
+/// misbehaving peer are ignored by the caller.
+async fn write_status_response(writer: &mut OwnedWriteHalf, status: u16) -> Result<()> {
+    let body = format!(r#"{{"error":"{}"}}"#, status_text(status));
+    let http = format!(
+        "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        status,
+        status_text(status),
+        body.len(),
+    );
+    writer.write_all(http.as_bytes()).await?;
+    writer.write_all(body.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -2389,6 +2444,239 @@ mod tests {
                     "LLM producer must be cancelled on client disconnect, not run to completion"
                 );
 
+                let _ = std::fs::remove_file(&memory_path);
+                let _ = std::fs::remove_file(&conv_path);
+            })
+            .await;
+    }
+
+    // --- Inbound HTTP reader hardening (issue #195) -----------------------
+
+    fn unique_db_paths(tag: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+        let uid = format!(
+            "{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let tmp = std::env::temp_dir();
+        (
+            tmp.join(format!("{uid}-memory.db")),
+            tmp.join(format!("{uid}-conv.db")),
+        )
+    }
+
+    /// A `ChatServer` whose LLM points at a dead port (so `/api/health` returns
+    /// quickly without needing a model), wired with the given HTTP hardening.
+    fn offline_server(
+        memory_path: &std::path::Path,
+        conv_path: &std::path::Path,
+        http: genie_common::config::HttpServerConfig,
+    ) -> super::ChatServer {
+        use crate::connectivity::NullConnectivityController;
+        use crate::conversation::ConversationStore;
+        use crate::llm::LlmClient;
+        use crate::memory::Memory;
+        use crate::tools::ToolDispatcher;
+
+        let system_prompt = "You are a helpful assistant.";
+        super::ChatServer::new(
+            LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:1/health"),
+            ToolDispatcher::new(None),
+            std::sync::Arc::new(NullConnectivityController::from_config(
+                &ConnectivityConfig::default(),
+            )),
+            Memory::open(memory_path).unwrap(),
+            ConversationStore::open(conv_path).unwrap(),
+            system_prompt.into(),
+            crate::prompt_sha::sha256_hex(system_prompt),
+            10,
+            ModelFamily::Phi,
+            "".into(),
+        )
+        .unwrap()
+        .with_http_config(http)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn oversized_request_header_is_rejected_and_server_survives() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        let (memory_path, conv_path) = unique_db_paths("genie-431");
+        let http = genie_common::config::HttpServerConfig {
+            max_header_line_bytes: 256,
+            read_timeout_secs: 2,
+            max_connections: 8,
+            ..genie_common::config::HttpServerConfig::default()
+        };
+        let server = offline_server(&memory_path, &conv_path, http);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async move {
+                tokio::task::spawn_local(async move {
+                    let _ = server.serve_listener(listener).await;
+                });
+
+                // An oversized header line is rejected with 431 in bounded memory.
+                let mut stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+                let pad = "A".repeat(2048);
+                let req = format!("GET /api/health HTTP/1.1\r\nX-Pad: {pad}\r\n\r\n");
+                stream.write_all(req.as_bytes()).await.unwrap();
+                let mut buf = Vec::new();
+                let _ = tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    stream.read_to_end(&mut buf),
+                )
+                .await;
+                let resp = String::from_utf8_lossy(&buf);
+                assert!(
+                    resp.starts_with("HTTP/1.1 431"),
+                    "expected 431, got: {resp:?}"
+                );
+
+                // The daemon survives: a well-formed request is still served.
+                let mut stream2 = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+                stream2
+                    .write_all(b"GET /api/health HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                    .await
+                    .unwrap();
+                let mut buf2 = Vec::new();
+                let _ = tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    stream2.read_to_end(&mut buf2),
+                )
+                .await;
+                let resp2 = String::from_utf8_lossy(&buf2);
+                assert!(
+                    resp2.starts_with("HTTP/1.1 200"),
+                    "expected 200 after rejection, got: {resp2:?}"
+                );
+
+                let _ = std::fs::remove_file(&memory_path);
+                let _ = std::fs::remove_file(&conv_path);
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn idle_connection_is_dropped_after_read_timeout() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        let (memory_path, conv_path) = unique_db_paths("genie-idle");
+        let http = genie_common::config::HttpServerConfig {
+            read_timeout_secs: 1,
+            max_connections: 8,
+            ..genie_common::config::HttpServerConfig::default()
+        };
+        let server = offline_server(&memory_path, &conv_path, http);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async move {
+                tokio::task::spawn_local(async move {
+                    let _ = server.serve_listener(listener).await;
+                });
+
+                // A partial request that never reaches the blank-line terminator.
+                let mut stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+                stream
+                    .write_all(b"GET /api/health HTTP/1.1\r\nX-Partial: ")
+                    .await
+                    .unwrap();
+
+                // The server must close the connection after the read timeout;
+                // read_to_end then sees a clean EOF (no response) in bounded time.
+                let start = std::time::Instant::now();
+                let mut buf = Vec::new();
+                let n = tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    stream.read_to_end(&mut buf),
+                )
+                .await
+                .expect("server did not drop the idle connection within 5s")
+                .unwrap();
+                assert_eq!(
+                    n,
+                    0,
+                    "idle connection should be closed with no response, got: {:?}",
+                    String::from_utf8_lossy(&buf)
+                );
+                assert!(
+                    start.elapsed() >= std::time::Duration::from_millis(500),
+                    "connection should have been held until the read timeout"
+                );
+
+                let _ = std::fs::remove_file(&memory_path);
+                let _ = std::fs::remove_file(&conv_path);
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn connection_flood_does_not_wedge_server() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        let (memory_path, conv_path) = unique_db_paths("genie-flood");
+        let http = genie_common::config::HttpServerConfig {
+            read_timeout_secs: 1,
+            max_connections: 4,
+            ..genie_common::config::HttpServerConfig::default()
+        };
+        let server = offline_server(&memory_path, &conv_path, http);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async move {
+                tokio::task::spawn_local(async move {
+                    let _ = server.serve_listener(listener).await;
+                });
+
+                // More stalled peers than the connection ceiling, kept open so
+                // they don't EOF early.
+                let mut stalled = Vec::new();
+                for _ in 0..8 {
+                    let mut s = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+                    let _ = s.write_all(b"G").await;
+                    stalled.push(s);
+                }
+
+                // A well-formed request is still served once the stalled peers
+                // time out and free their slots — the daemon is not wedged.
+                let mut stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+                stream
+                    .write_all(b"GET /api/health HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                    .await
+                    .unwrap();
+                let mut buf = Vec::new();
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(8),
+                    stream.read_to_end(&mut buf),
+                )
+                .await
+                .expect("server wedged: no response within 8s under connection flood")
+                .unwrap();
+                let resp = String::from_utf8_lossy(&buf);
+                assert!(
+                    resp.starts_with("HTTP/1.1 200"),
+                    "expected 200 after flood, got: {resp:?}"
+                );
+
+                drop(stalled);
                 let _ = std::fs::remove_file(&memory_path);
                 let _ = std::fs::remove_file(&conv_path);
             })

--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -1965,6 +1965,7 @@ mod tests {
             telegram: Default::default(),
             web_search: Default::default(),
             connectivity: Default::default(),
+            http: Default::default(),
         };
 
         assert_eq!(config.core_http_addr(), "127.0.0.1:3001");
@@ -1992,6 +1993,7 @@ mod tests {
             telegram: Default::default(),
             web_search: Default::default(),
             connectivity: Default::default(),
+            http: Default::default(),
         };
 
         assert_eq!(config.core_http_addr(), "127.0.0.1:3000");

--- a/crates/genie-governor/src/governor.rs
+++ b/crates/genie-governor/src/governor.rs
@@ -351,6 +351,7 @@ mod tests {
             telegram: TelegramConfig::default(),
             web_search: WebSearchConfig::default(),
             connectivity: ConnectivityConfig::default(),
+            http: Default::default(),
         }
     }
 

--- a/crates/genie-health/src/checker.rs
+++ b/crates/genie-health/src/checker.rs
@@ -341,6 +341,7 @@ mod tests {
             telegram: TelegramConfig::default(),
             web_search: WebSearchConfig::default(),
             connectivity: ConnectivityConfig::default(),
+            http: Default::default(),
         }
     }
 

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -188,6 +188,20 @@ interval_secs = 30
 alert_enabled = false
 alert_webhook_url = ""            # Optional local notifier endpoint.
 
+# Inbound HTTP-server hardening, shared by genie-core (:3000) and genie-api
+# (:3080). Bounds the hand-rolled request reader so a single unauthenticated
+# peer on the LAN cannot exhaust memory (an endless header), stall the listener
+# with half-open connections, or fd-exhaust the daemon (issue #195). Defaults
+# are safe; tune only if a first-party client legitimately needs larger headers
+# or more concurrency.
+[http]
+max_request_line_bytes = 8192    # Reject request lines longer than this (431).
+max_header_line_bytes = 8192     # Reject any single header line longer than this (431).
+max_header_count = 100           # Reject more than this many header lines (431).
+max_header_bytes = 65536         # Reject when total header bytes exceed this (431).
+read_timeout_secs = 15           # Drop a connection that stalls mid-request.
+max_connections = 256            # Ceiling on concurrently handled connections.
+
 # Uncomment to enable Telegram long-poll chat integration:
 # [telegram]
 # enabled = true

--- a/doc/http-and-cli.md
+++ b/doc/http-and-cli.md
@@ -12,6 +12,23 @@ Set `[core].bind_host = "0.0.0.0"` only when `genie-core` is behind a trusted
 LAN, firewall, or first-party gateway. The API includes chat, memory, tool, and
 physical-actuation surfaces, so localhost is the safe default.
 
+### Request Limits And Hardening
+
+Both `genie-core` (`:3000`) and `genie-api` (`:3080`) read inbound requests
+through the shared, bounded reader in `genie-common::http`, configured by the
+`[http]` section (see `deploy/config/geniepod.toml`). This protects the
+always-on daemon from an unauthenticated peer on the LAN:
+
+- An oversized request line or header is rejected with `431` (the request body
+  is capped per server — 64 KiB for `genie-core`, 4 KiB for `genie-api` — and an
+  over-cap `Content-Length` is rejected with `413`).
+- A connection that opens and then stalls mid-request is dropped after
+  `[http].read_timeout_secs`, so half-open connections cannot wedge the
+  listener.
+- Concurrent connections are capped at `[http].max_connections`; transient
+  `accept()` errors (e.g. `EMFILE`) are logged and the accept loop continues
+  rather than terminating the process.
+
 ### UI And Chat Endpoints
 
 First-party clients should set `X-Genie-Origin` so tool and actuation policy can


### PR DESCRIPTION
## Summary
Closes #195 
Bound and deadline-guard the hand-rolled inbound HTTP/1.1 request reader shared
by `genie-core` (`:3000`) and `genie-api` (`:3080`). Previously the request line
and headers grew with an unbounded `read_line` loop and there was no read
deadline, so a single unauthenticated peer on the LAN could exhaust memory (a
header that never terminates), stall the listener with half-open connections, or
fd-exhaust the always-on daemon. 

## Changes

- Add a shared, hardened reader in `genie-common::http` (`read_request`) that
  enforces size bounds (request line, per-header line, header count, total
  header bytes, body) and runs the whole read under a single
  `tokio::time::timeout`. Returns a typed `HttpReadError` that maps onto `431`
  (oversized line/headers) or `413` (oversized declared body), or signals
  "just close the connection" for stalled/vanished/garbage peers.
- Add a `[http]` config section (`HttpServerConfig`) with safe, bounded defaults
  — 8 KiB request line, 8 KiB header line, 100 headers, 64 KiB total headers,
  15 s read timeout, 256 max connections. Missing section falls back to defaults
  so existing deployments keep parsing.
- Wire both servers onto the shared reader and cap concurrency with a
  `tokio::sync::Semaphore` (permit reserved before `accept`, held for the
  request lifetime). Transient `accept()` errors (e.g. `EMFILE`) are logged and
  the accept loop continues instead of terminating the process. Per-server body
  caps unchanged (64 KiB genie-core, 4 KiB genie-api).
- Document the hardening in `doc/http-and-cli.md` and the `[http]` knobs in
  `deploy/config/geniepod.toml`.
- Add unit/integration tests covering oversized request line, oversized/
  unterminated header (bounded memory), too-many-headers, total-header-byte cap,
  oversized declared body, idle/slowloris timeout, peer close, connection flood,
  and config default/override/fallback parsing.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

<!-- Replace with your actual environment. Example shown below. -->
This is a server-side networking change with no dependency on Jetson-specific
hardware, voice, audio, or Home Assistant — it is fully exercised by the
crate-level tests. On `<your OS / machine>`:

```
cargo test -p genie-common http
cargo test -p genie-core  server
cargo test -p genie-api   http
```

### What I observed

<!-- Paste the actual test output (counts + pass/fail). Example placeholder: -->
All tests pass, including:

- `oversized_request_line_is_rejected`, `oversized_request_header_is_rejected_and_server_survives`,
  `too_many_headers_is_rejected`, `total_header_bytes_cap_is_enforced`,
  `unterminated_header_is_rejected_in_bounded_memory` → reader returns `431`
  and the server stays up.
- `oversized_declared_body_is_rejected` → `413`.
- `idle_connection_times_out` / `idle_connection_is_dropped_after_read_timeout`
  → stalled connection dropped after the read deadline.
- `peer_close_before_request_is_reported`, `connection_flood_does_not_wedge_server`
  → half-open / flood traffic does not wedge the listener.
- `http_server_config_defaults_are_bounded`, `http_server_config_falls_back_when_section_absent`,
  `http_server_config_parses_overrides` → defaults applied, missing section
  tolerated, overrides honored.

`<paste raw `test result: ok. N passed; 0 failed` lines here>`

## Test plan

- `cargo test -p genie-common http` — reader bounds + config parsing.
- `cargo test -p genie-core server` and `cargo test -p genie-api http` — server
  integration (431/413 responses, read timeout, connection-flood survival).
- Manual smoke (optional): with the daemon running, send an oversized header and
  confirm a `431`; open a connection and send nothing, confirm it is dropped
  after `read_timeout_secs`.

## Notes for reviewers

- Bounds and the connection cap are configurable via the new `[http]` section;
  defaults are intentionally generous for first-party clients while still
  bounding fan-out. The per-request body cap stays per-server and is not part of
  `[http]`.
- Connection-count ceiling and accept-loop resilience live in each server's
  listener (semaphore + log-and-continue), not in the shared per-request reader,
  by design.
