### PR TITLE
fix(weather): enforce read deadline + size cap + percent-encode geocode (closes #203)

### DIFF
--- a/crates/genie-core/src/tools/weather.rs
+++ b/crates/genie-core/src/tools/weather.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
@@ -10,6 +12,21 @@ use tokio::net::TcpStream;
 ///
 /// All requests go through raw TCP+TLS-free HTTP to api.open-meteo.com.
 /// Note: Open-Meteo supports HTTP (no TLS required for the free tier).
+
+/// Connect-timeout cap for Open-Meteo HTTP requests.
+const WEATHER_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Total request-lifecycle timeout (covers write + read). Without this, a
+/// slow or hung Open-Meteo response leaves the calling chat task wedged
+/// forever. Same fix shape as PR #174 / closes #173 for `ha::client`.
+const WEATHER_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Body-size cap on the accumulated response. The Open-Meteo free tier
+/// returns < 4 KiB for geocoding and < 20 KiB for forecasts in practice;
+/// 1 MiB leaves a healthy margin while still preventing RSS growth from a
+/// misbehaving or man-in-the-middle response (the connection is plain
+/// HTTP). Without this the body-read loop would accumulate unboundedly.
+const WEATHER_MAX_RESPONSE_BYTES: usize = 1024 * 1024;
 
 // ── Public API ──────────────────────────────────────────────
 
@@ -65,7 +82,13 @@ struct ForecastDay {
 
 /// Geocode a location name using Open-Meteo's geocoding API.
 async fn geocode(location: &str) -> Result<(f64, f64, String)> {
-    let encoded = location.replace(' ', "+");
+    // Previously `location.replace(' ', "+")` — that only handled spaces,
+    // so reserved URL characters in the location (e.g. `&`, `?`, `#`, `=`,
+    // `%`, `+`) leaked into the query string and silently broke geocoding.
+    // A user asking the weather in "Q&A Cafe Tokyo" used to produce
+    // `name=Q&A+Cafe+Tokyo&count=1…` — Open-Meteo parsed the `&` as a
+    // separator and saw `name=Q`. Percent-encode every reserved char now.
+    let encoded = url_encode_query_param(location);
     let path = format!(
         "/v1/search?name={}&count=1&language=en&format=json",
         encoded
@@ -179,14 +202,36 @@ async fn fetch_forecast(lat: f64, lon: f64) -> Result<Vec<ForecastDay>> {
 }
 
 /// Raw HTTP GET (no TLS — Open-Meteo supports plain HTTP).
+///
+/// Production callers reach this via the host-only convenience signature;
+/// it defaults to port 80 and the workspace-wide timeout/size constants.
 async fn http_get(host: &str, path: &str) -> Result<String> {
-    let addr = format!("{}:80", host);
-    let stream = tokio::time::timeout(
-        std::time::Duration::from_secs(10),
-        TcpStream::connect(&addr),
+    http_get_with_limits(
+        host,
+        80,
+        path,
+        WEATHER_CONNECT_TIMEOUT,
+        WEATHER_REQUEST_TIMEOUT,
+        WEATHER_MAX_RESPONSE_BYTES,
     )
     .await
-    .map_err(|_| anyhow::anyhow!("connection timeout"))??;
+}
+
+/// Inner implementation that takes explicit limits — exposed `pub(crate)`
+/// only so the test module can point at an ephemeral mock listener with
+/// millisecond-scale timeouts. NOT part of any stable API.
+pub(crate) async fn http_get_with_limits(
+    host: &str,
+    port: u16,
+    path: &str,
+    connect_timeout: Duration,
+    request_timeout: Duration,
+    max_bytes: usize,
+) -> Result<String> {
+    let addr = format!("{}:{}", host, port);
+    let stream = tokio::time::timeout(connect_timeout, TcpStream::connect(&addr))
+        .await
+        .map_err(|_| anyhow::anyhow!("Open-Meteo connect to {} timed out", addr))??;
 
     let (reader, mut writer) = stream.into_split();
 
@@ -194,11 +239,36 @@ async fn http_get(host: &str, path: &str) -> Result<String> {
         "GET {} HTTP/1.1\r\nHost: {}\r\nUser-Agent: GeniePod/0.2\r\nAccept: application/json\r\nConnection: close\r\n\r\n",
         path, host
     );
-    writer.write_all(request.as_bytes()).await?;
 
+    // Run the entire write + read cycle under a single deadline. Without
+    // this a hung Open-Meteo wedges the chat task forever even after the
+    // TCP connect succeeds. Same shape as PR #174 / closes #173.
+    let body = tokio::time::timeout(request_timeout, async move {
+        writer.write_all(request.as_bytes()).await?;
+        read_http_get_body(reader, max_bytes).await
+    })
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "Open-Meteo GET {} timed out after {}s",
+            path,
+            request_timeout.as_secs()
+        )
+    })??;
+
+    Ok(body.trim().to_string())
+}
+
+/// Drain headers and body from a one-shot `Connection: close` GET response,
+/// rejecting chunked encoding (Open-Meteo's free tier doesn't use it) and
+/// bounding accumulated body bytes at `max_bytes`.
+async fn read_http_get_body(
+    reader: tokio::net::tcp::OwnedReadHalf,
+    max_bytes: usize,
+) -> Result<String> {
     let mut buf_reader = BufReader::new(reader);
-    let mut body = String::new();
     let mut in_body = false;
+    let mut body = String::new();
 
     loop {
         let mut line = String::new();
@@ -206,25 +276,72 @@ async fn http_get(host: &str, path: &str) -> Result<String> {
         if n == 0 {
             break;
         }
-        if in_body {
-            body.push_str(&line);
-        } else if line.trim().is_empty() {
-            in_body = true;
-        }
-    }
 
-    // Handle chunked transfer encoding (simple: just strip chunk headers).
-    if body.contains("\r\n") && body.starts_with(|c: char| c.is_ascii_hexdigit()) {
-        let mut decoded = String::new();
-        for line in body.split("\r\n") {
-            if !line.is_empty() && !line.chars().all(|c| c.is_ascii_hexdigit()) {
-                decoded.push_str(line);
+        if !in_body {
+            // The previous implementation tried to be clever about
+            // `Transfer-Encoding: chunked` after the fact (lines 216-225
+            // of the pre-fix code) and joined non-hex-only lines with
+            // `push_str` — no separator between adjacent chunks, so JSON
+            // spanning multiple chunks was silently corrupted, and the
+            // heuristic fired on legitimate responses whose first body
+            // character was a hex digit. Refuse chunked explicitly
+            // instead: Open-Meteo's free tier returns Content-Length, so
+            // this path should be unreachable in practice; if a proxy or
+            // future Open-Meteo upgrade turns it on, the user gets a
+            // clear error and the call site can retry/fallback.
+            let lower = line.to_ascii_lowercase();
+            if let Some(value) = lower.strip_prefix("transfer-encoding:")
+                && value.split(',').any(|tok| tok.trim() == "chunked")
+            {
+                anyhow::bail!("Open-Meteo response uses unsupported chunked encoding");
             }
+
+            if line.trim().is_empty() {
+                in_body = true;
+            }
+            continue;
         }
-        body = decoded;
+
+        // Body branch.
+        let projected = body.len().saturating_add(line.len());
+        if projected > max_bytes {
+            anyhow::bail!(
+                "Open-Meteo response exceeded {} bytes (got at least {})",
+                max_bytes,
+                projected
+            );
+        }
+        body.push_str(&line);
     }
 
-    Ok(body.trim().to_string())
+    Ok(body)
+}
+
+/// Percent-encode `s` for safe use as a single query-string parameter
+/// value. Encodes every byte that is NOT an unreserved RFC 3986 character
+/// (`A-Z`, `a-z`, `0-9`, `-`, `_`, `.`, `~`). Multi-byte UTF-8 codepoints
+/// are encoded byte-by-byte, which is what every HTTP server (including
+/// Open-Meteo's geocoder) expects. The result is always pure ASCII.
+fn url_encode_query_param(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for byte in s.as_bytes() {
+        if matches!(byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~') {
+            out.push(*byte as char);
+        } else {
+            out.push('%');
+            out.push(hex_nibble(byte >> 4));
+            out.push(hex_nibble(byte & 0x0F));
+        }
+    }
+    out
+}
+
+fn hex_nibble(n: u8) -> char {
+    match n {
+        0..=9 => (b'0' + n) as char,
+        10..=15 => (b'A' + (n - 10)) as char,
+        _ => '0', // unreachable for caller using `b & 0x0F`
+    }
 }
 
 /// WMO weather interpretation codes → human-readable description.
@@ -253,6 +370,8 @@ fn wmo_code_to_description(code: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
 
     #[test]
     fn wmo_codes() {
@@ -260,5 +379,226 @@ mod tests {
         assert_eq!(wmo_code_to_description(61), "rain");
         assert_eq!(wmo_code_to_description(95), "thunderstorm");
         assert_eq!(wmo_code_to_description(999), "unknown conditions");
+    }
+
+    /// Direct unit coverage on the URL-encoding helper. The bug being fixed
+    /// is that `location.replace(' ', "+")` only handled spaces; reserved
+    /// RFC 3986 characters used to leak into the query string and silently
+    /// break geocoding.
+    #[test]
+    fn url_encode_query_param_percent_encodes_reserved_chars() {
+        // Unreserved RFC 3986 characters pass through verbatim.
+        assert_eq!(url_encode_query_param("Denver"), "Denver");
+        assert_eq!(url_encode_query_param("New-York_2.0~"), "New-York_2.0~");
+        // Reserved characters — each must be percent-encoded.
+        assert_eq!(url_encode_query_param("Q&A"), "Q%26A");
+        assert_eq!(url_encode_query_param("Mom & Pop"), "Mom%20%26%20Pop");
+        assert_eq!(url_encode_query_param("a=b"), "a%3Db");
+        assert_eq!(url_encode_query_param("a?b"), "a%3Fb");
+        assert_eq!(url_encode_query_param("a#b"), "a%23b");
+        assert_eq!(url_encode_query_param("a+b"), "a%2Bb");
+        assert_eq!(url_encode_query_param("100%"), "100%25");
+        assert_eq!(url_encode_query_param("a b"), "a%20b");
+        // Multi-byte UTF-8 — each byte of the codepoint encoded.
+        // 'ü' is U+00FC, UTF-8 bytes 0xC3 0xBC.
+        assert_eq!(url_encode_query_param("München"), "M%C3%BCnchen");
+        // Empty string round-trips empty.
+        assert_eq!(url_encode_query_param(""), "");
+    }
+
+    /// Spawn a `TcpListener` that accepts one connection, drains the
+    /// request, and then hangs forever without writing a response. Returns
+    /// the local address the client should connect to and a join handle.
+    fn spawn_hung_listener() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        listener.set_nonblocking(true).expect("nonblocking");
+        let listener = tokio::net::TcpListener::from_std(listener).expect("from_std");
+        let handle = tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                // Drain headers so the client thinks the request landed.
+                let mut buf = [0u8; 4096];
+                let _ = tokio::io::AsyncReadExt::read(&mut sock, &mut buf).await;
+                // Hang forever (mimics a paused / stuck Open-Meteo).
+                tokio::time::sleep(Duration::from_secs(600)).await;
+            }
+        });
+        (addr, handle)
+    }
+
+    /// Regression for the timeout fix: a hung Open-Meteo no longer wedges
+    /// the chat task. Pre-fix `http_get` blocked indefinitely; with the
+    /// fix it returns `Err("…timed out…")` inside the test budget.
+    #[tokio::test(flavor = "current_thread")]
+    async fn hung_server_after_connect_times_out_cleanly() {
+        let (addr, server) = spawn_hung_listener();
+        let result = http_get_with_limits(
+            &addr.ip().to_string(),
+            addr.port(),
+            "/v1/search?name=Denver",
+            Duration::from_millis(500),
+            Duration::from_millis(500),
+            WEATHER_MAX_RESPONSE_BYTES,
+        )
+        .await;
+        server.abort();
+        let err = result.expect_err("hung server must produce a timeout error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("timed out"),
+            "expected a timeout error, got: {}",
+            msg
+        );
+    }
+
+    /// Regression for the size-cap fix: an oversized response body fails
+    /// cleanly with a "exceeded N bytes" error instead of growing RSS.
+    #[tokio::test(flavor = "current_thread")]
+    async fn oversized_response_is_size_capped() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.expect("accept");
+            let mut buf = [0u8; 4096];
+            let _ = tokio::io::AsyncReadExt::read(&mut sock, &mut buf).await;
+            // Write headers without `Content-Length`, then stream lots of
+            // bytes. The body loop should bail before reading all of it.
+            let _ = sock
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n")
+                .await;
+            let chunk = vec![b'x'; 16 * 1024]; // 16 KiB at a time
+            for _ in 0..1024 {
+                if sock.write_all(&chunk).await.is_err() {
+                    break;
+                }
+            }
+        });
+        let result = http_get_with_limits(
+            &addr.ip().to_string(),
+            addr.port(),
+            "/v1/search?name=Denver",
+            Duration::from_millis(500),
+            Duration::from_secs(5),
+            64 * 1024, // cap at 64 KiB so the test bails fast
+        )
+        .await;
+        server.abort();
+        let err = result.expect_err("oversized response must produce a size error");
+        assert!(
+            err.to_string().contains("exceeded"),
+            "expected a size-exceeded error, got: {}",
+            err
+        );
+    }
+
+    /// Regression for the chunked-encoding fix: a `Transfer-Encoding:
+    /// chunked` response is rejected explicitly instead of going through
+    /// the old broken decoder that silently corrupted multi-chunk JSON.
+    #[tokio::test(flavor = "current_thread")]
+    async fn chunked_encoding_is_explicitly_rejected() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.expect("accept");
+            let mut buf = [0u8; 4096];
+            let _ = tokio::io::AsyncReadExt::read(&mut sock, &mut buf).await;
+            let response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n7\r\n{\"a\":1}\r\n0\r\n\r\n";
+            let _ = sock.write_all(response.as_bytes()).await;
+        });
+        let result = http_get_with_limits(
+            &addr.ip().to_string(),
+            addr.port(),
+            "/v1/search?name=Denver",
+            Duration::from_millis(500),
+            Duration::from_secs(5),
+            WEATHER_MAX_RESPONSE_BYTES,
+        )
+        .await;
+        server.abort();
+        let err = result.expect_err("chunked encoding must produce an explicit error");
+        assert!(
+            err.to_string().contains("chunked"),
+            "expected a chunked-encoding error, got: {}",
+            err
+        );
+    }
+
+    /// Regression for the URL-encoding fix: the geocode request line on
+    /// the wire percent-encodes `&` in the location. Pre-fix the unencoded
+    /// `&` terminated the `name` query parameter at the HTTP level.
+    #[tokio::test(flavor = "current_thread")]
+    async fn geocode_request_line_contains_percent_encoded_location() {
+        // We rebuild the geocode query string the same way `geocode` does,
+        // then verify the wire-level encoding by sending it through a mock
+        // server that echoes the first request line back into the body.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.expect("accept");
+            let mut bytes = Vec::new();
+            // Read until we see the end-of-headers marker.
+            let mut tmp = [0u8; 4096];
+            loop {
+                match tokio::io::AsyncReadExt::read(&mut sock, &mut tmp).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        bytes.extend_from_slice(&tmp[..n]);
+                        if bytes.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            // Reflect the captured first line back as a JSON body.
+            let first_line = String::from_utf8_lossy(&bytes)
+                .lines()
+                .next()
+                .unwrap_or("")
+                .to_string();
+            let body = format!(
+                "{{\"first_line\":{}}}",
+                serde_json::to_string(&first_line).unwrap_or_default()
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = sock.write_all(response.as_bytes()).await;
+        });
+
+        // Construct the same path geocode() builds, using the helper.
+        let encoded = url_encode_query_param("Q&A Cafe Tokyo");
+        let path = format!(
+            "/v1/search?name={}&count=1&language=en&format=json",
+            encoded
+        );
+        let body = http_get_with_limits(
+            &addr.ip().to_string(),
+            addr.port(),
+            &path,
+            Duration::from_millis(500),
+            Duration::from_secs(5),
+            WEATHER_MAX_RESPONSE_BYTES,
+        )
+        .await
+        .expect("mock server must respond");
+        server.abort();
+        let echo: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        let line = echo
+            .get("first_line")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(
+            line.contains("name=Q%26A"),
+            "wire-level request line must percent-encode '&'; got: {}",
+            line
+        );
+        assert!(
+            !line.contains("name=Q&A"),
+            "must NOT contain unencoded '&' inside the name parameter; got: {}",
+            line
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three sibling concerns in `crates/genie-core/src/tools/weather.rs`'s
raw-TCP HTTP client, closed by one PR over one file:

1. **No read timeout.** `http_get` (pre-fix lines 182-228) had a 10 s
   `TcpStream::connect` timeout but nothing on `write_all` / `read_line`
   afterwards. A slow / hung Open-Meteo wedged the chat task forever.
   Same crash mode as bug #173 / PR #174 for `ha/client`.
2. **No body-size cap.** The body-accumulation loop had no bound. A
   misbehaving (or man-in-the-middle, since the connection is plain
   HTTP per the file comment) response could grow RSS without limit.
3. **Broken chunked-encoding decoder** at pre-fix lines 216-225 joined
   non-hex lines with `push_str` (no separator → silent JSON corruption
   across chunks) and misfired its heuristic on legitimate responses
   whose first body char was a hex digit.
4. **URL encoding only handled spaces** at pre-fix line 68. Any reserved
   RFC 3986 char in the location (`&`, `?`, `#`, `=`, `%`, `+`) leaked
   into the geocode query string. "Q&A Cafe Tokyo" produced
   `name=Q&A+Cafe+Tokyo&count=1…` — Open-Meteo parsed it as `name=Q`
   and silently returned no match.

Closes #203.

## Changes

- `crates/genie-core/src/tools/weather.rs`:
  - New constants `WEATHER_CONNECT_TIMEOUT = 10s`,
    `WEATHER_REQUEST_TIMEOUT = 15s`, `WEATHER_MAX_RESPONSE_BYTES = 1 MiB`.
    Doc-commented with the failure mode each one prevents.
  - `http_get(host, path)` becomes a thin wrapper around new
    `pub(crate) async fn http_get_with_limits(host, port, path,
    connect_timeout, request_timeout, max_bytes)` so the test module can
    drive an ephemeral mock listener at millisecond-scale.
  - Connect uses `tokio::time::timeout(connect_timeout, …)` — clear
    `"Open-Meteo connect to {addr} timed out"` on `Elapsed`.
  - Post-connect (write + read) is wrapped in
    `tokio::time::timeout(request_timeout, …)` — clear
    `"Open-Meteo GET {path} timed out after {N}s"` on `Elapsed`.
  - New helper `read_http_get_body(reader, max_bytes)`: bails on
    `Transfer-Encoding: chunked` with an explicit
    `"Open-Meteo response uses unsupported chunked encoding"`
    (replacing the old silently-corrupting decoder); bounds the body
    `String` with a check-and-bail on every appended line.
  - New helper `url_encode_query_param(s: &str) -> String` percent-
    encodes every non-RFC-3986-unreserved byte; multi-byte UTF-8 is
    encoded byte-by-byte (e.g. `"München"` → `M%C3%BCnchen`). Hand-
    rolled, no new dependency.
  - `geocode()` swaps `location.replace(' ', "+")` for
    `url_encode_query_param(location)`.

- `crates/genie-core/src/tools/weather.rs::tests` — 5 new regressions:
  - `url_encode_query_param_percent_encodes_reserved_chars` — unit
    coverage on the helper: ASCII pass-through, every reserved char,
    multi-byte UTF-8, empty input.
  - `hung_server_after_connect_times_out_cleanly` — mock `TcpListener`
    accepts and `sleep_forever`s; asserts `Err("…timed out…")` inside
    the test budget. Pre-fix this hangs the whole test process.
  - `oversized_response_is_size_capped` — listener streams 16 KiB
    chunks past a 64 KiB cap; asserts `Err("…exceeded…")` before OOM.
  - `chunked_encoding_is_explicitly_rejected` — listener returns
    `Transfer-Encoding: chunked`; asserts the explicit
    `Err("…chunked encoding…")` instead of silent body corruption.
  - `geocode_request_line_contains_percent_encoded_location` — listener
    captures the raw HTTP request line and echoes it back as JSON;
    asserts the line contains `name=Q%26A` and does NOT contain
    `name=Q&A`. Locks the URL-encoding fix at the wire level.

No config schema change, no public API change. ASCII / space-only
locations against a healthy Open-Meteo see byte-identical behaviour.

## Real Behavior Proof

- [x] Built and ran the affected code locally.
- [x] NOT verified on Jetson hardware. The change is in pure tokio I/O
  scheduling and string formatting — no audio, voice, ALSA, CUDA, HA,
  LLM-backend, or systemd surface — exercised end-to-end by 5 new
  `#[tokio::test]` regressions that spin up real local `TcpListener`s
  and drive each failure mode.

### What I ran

Environment: x86_64 Linux dev host (Ubuntu 22.04, Rust 1.95.0). No
Jetson available.

```bash
cargo fmt --all -- --check                                                # clean
cargo clippy --workspace --all-targets -- -D warnings                    # clean
cargo clippy --workspace --all-targets --no-default-features -- -D warnings  # clean
cargo test -p genie-core --lib tools::weather                             # 6 / 0
cargo test                                                                # 675 / 0 / 3
cargo test --workspace --no-default-features                             # 570 / 0
```

### What I observed

1. **Hung Open-Meteo is bounded.** With a `TcpListener` that accepts
   then `sleep_forever`s, `http_get_with_limits(…, 500ms, 500ms, …)`
   returns `Err("Open-Meteo GET … timed out after 0s")` in well under
   a second. Pre-fix the same call hangs for 600 s.
2. **Oversized response is rejected before OOM.** Listener streams
   16 KiB chunks against a 64 KiB cap; the helper bails with
   `"Open-Meteo response exceeded 65536 bytes (got at least …)"`.
3. **Chunked encoding gets an explicit error.** Listener returns
   `Transfer-Encoding: chunked` with a real chunk; helper bails with
   `"Open-Meteo response uses unsupported chunked encoding"`. Pre-fix
   this silently corrupted multi-chunk JSON.
4. **URL encoding is wire-correct.** Listener captures the raw HTTP
   request line via `read` and echoes it back as JSON. For
   `geocode("Q&A Cafe Tokyo")` the captured line is
   `GET /v1/search?name=Q%26A%20Cafe%20Tokyo&count=1&language=en&format=json HTTP/1.1`.
   Pre-fix this would have been `name=Q&A+Cafe+Tokyo&…`, which
   Open-Meteo parses as `name=Q`.
5. **No regression on the happy path.** `wmo_codes` (existing test)
   still passes. Full `cargo test`: 675 / 0 / 3 (up from main baseline
   ~670 by exactly the 5 new tests). `--no-default-features`: 570 / 0.

## Test plan

A reviewer can re-verify on any Rust 1.85+ host (no Jetson, no Open-
Meteo, no audio needed):

- `cargo test -p genie-core --lib tools::weather` — 6 tests (1 existing
  + 5 new), all green in <1 s.
- Optional manual proof against a real Open-Meteo:
  1. Start `genie-core` with default configuration.
  2. `curl -X POST http://127.0.0.1:3000/api/chat \
        -H 'Content-Type: application/json' \
        -d '{"message":"weather in Q&A Cafe Tokyo"}'`.
     Pre-fix: returns "location not found". Post-fix: returns a
     geocoded weather report for the closest matching location.
  3. Optionally `tcpdump -i any 'port 80'` to see
     `GET /v1/search?name=Q%26A%20Cafe%20Tokyo&…` on the wire.

## Notes for reviewers

- **No merge-conflict surface with any open PR.** The file
  `crates/genie-core/src/tools/weather.rs` has not been touched since
  the workspace scaffold commit `0a7363b`. No open PR touches it.
- **Why three concerns in one PR.** They live in the same function
  family (`http_get` + the three callers) and the test scaffolding
  (mock `TcpListener` + raw HTTP framing) is shared. Splitting them
  would multiply review surface for the same total diff.
- **Why reject chunked instead of fix the decoder.** Open-Meteo's free
  tier returns `Content-Length`, never chunked. The pre-fix decoder
  silently corrupted multi-chunk JSON — refusing chunked explicitly is
  safer than fixing a decoder for a path that should be unreachable.
  A proper chunked decoder can land later if Open-Meteo ever changes.
- **Defaults.** 15 s request timeout is comfortably above Open-Meteo's
  typical 200 ms response. 1 MiB is ~50x the largest realistic forecast
  response. Both are workspace-private constants; making them operator-
  configurable can be a follow-up if needed.
- **Related work.** PR #174 (mine, merged) fixed the same unbounded-
  read pattern in `ha/client`. PR #182 (open) fixes the LLM client.
  This PR is the third leg — once it lands the "raw-TCP HTTP client
  with insufficient read timeouts" class is closed across the
  workspace.
