### PR TITLE
fix(governor): abort mode transition on systemctl start/stop failure (closes #214)

### DIFF
--- a/crates/genie-governor/src/governor.rs
+++ b/crates/genie-governor/src/governor.rs
@@ -191,14 +191,14 @@ impl Governor {
             let Some(unit) = self.service_unit_for_alias(alias) else {
                 continue;
             };
-            let _ = ServiceCtl::stop(&unit).await;
+            ServiceCtl::stop(&unit).await?;
         }
 
         // Handle LLM model swap.
         match (from, target) {
             (_, Mode::Media) => {
                 let unit = self.llm_service_unit();
-                let _ = ServiceCtl::stop(&unit).await;
+                ServiceCtl::stop(&unit).await?;
             }
             (Mode::Media, _) => {
                 if let Some(model) = target.llm_model() {
@@ -237,7 +237,7 @@ impl Governor {
                 continue;
             };
             if !ServiceCtl::is_active(&unit).await {
-                let _ = ServiceCtl::start(&unit).await;
+                ServiceCtl::start(&unit).await?;
             }
         }
 

--- a/crates/genie-governor/src/service_ctl.rs
+++ b/crates/genie-governor/src/service_ctl.rs
@@ -35,9 +35,11 @@ impl ServiceCtl {
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             // Don't fail on "not loaded" — service may not be enabled.
-            if !stderr.contains("not loaded") {
-                tracing::warn!(unit, %stderr, "failed to stop service");
+            if stderr.contains("not loaded") {
+                return Ok(());
             }
+            tracing::warn!(unit, %stderr, "failed to stop service");
+            anyhow::bail!("systemctl stop {} failed: {}", unit, stderr);
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Propagate `ServiceCtl::start` errors in `transition()` so `current_mode` and DB history are not updated when a required unit fails to start.
- Make `ServiceCtl::stop` return `Err` on real systemctl failures (still ignores "not loaded").
- Wire stop calls in `transition()` through `?` so failed stops also abort the transition.

Closes #214

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
cargo test -p genie-governor
cargo clippy -p genie-governor --all-targets --locked -- -D warnings
cargo fmt --all -- --check
```

### What I observed

All 11 genie-governor tests passed.

## Test plan

- [x] `cargo test -p genie-governor`
- [x] `cargo clippy -p genie-governor --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Optional: mask a required unit, trigger mode change, confirm `current_mode` stays unchanged