### PR TITLE
fix(governor): restrict control socket to owner/group (closes #217)

### DIFF
--- a/crates/genie-governor/src/control.rs
+++ b/crates/genie-governor/src/control.rs
@@ -8,6 +8,9 @@ use tokio::sync::mpsc;
 use genie_common::mode::Mode;
 
 const SOCKET_PATH: &str = "/run/geniepod/governor.sock";
+/// Owner/group read-write only — genie-core and genie-ctl run as root on device.
+const SOCKET_MODE: u32 = 0o660;
+const RUN_DIR_MODE: u32 = 0o750;
 
 /// Commands that external processes (genie-core, CLI) can send to the governor.
 #[derive(Debug, Serialize, Deserialize)]
@@ -37,13 +40,23 @@ pub async fn spawn_listener() -> Result<mpsc::Receiver<(Command, ResponseSender)
     let _ = tokio::fs::remove_file(SOCKET_PATH).await;
     tokio::fs::create_dir_all("/run/geniepod").await?;
 
-    let listener = UnixListener::bind(SOCKET_PATH)?;
-
-    // Make socket world-writable so genie-core (non-root) can connect.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(SOCKET_PATH, std::fs::Permissions::from_mode(0o666))?;
+        std::fs::set_permissions(
+            "/run/geniepod",
+            std::fs::Permissions::from_mode(RUN_DIR_MODE),
+        )?;
+    }
+
+    let listener = UnixListener::bind(SOCKET_PATH)?;
+
+    // Restrict socket to owner/group — blocks unprivileged local users from
+    // sending mode commands while root-owned services (genie-core, genie-ctl) retain access.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(SOCKET_PATH, std::fs::Permissions::from_mode(SOCKET_MODE))?;
     }
 
     let (tx, rx) = mpsc::channel::<(Command, ResponseSender)>(16);


### PR DESCRIPTION
## Summary

- Change `/run/geniepod/governor.sock` permissions from `0666` to `0660`.
- Set `/run/geniepod` to `0750` so unprivileged local users cannot connect and send mode commands.
- Root-owned services (`genie-core`, `genie-governor`, `genie-ctl` via sudo) retain access.

Closes #217

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
cargo test -p genie-governor
cargo clippy -p genie-governor --all-targets --locked -- -D warnings
cargo fmt --all -- --check
```

### What I observed

All 11 genie-governor tests passed.

## Test plan

- [x] `cargo test -p genie-governor`
- [x] `cargo clippy -p genie-governor --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Optional: as unprivileged user, confirm `socat` connect to governor.sock is denied