### PR TITLE
fix(audit): tail-read actuation JSONL instead of loading whole file (closes #223)

### DIFF
--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -1,4 +1,5 @@
 use genie_common::config::Config;
+use genie_common::jsonl::{self, DEFAULT_MAX_JSONL_LINE_BYTES};
 use genie_common::tegrastats;
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -678,15 +679,11 @@ pub async fn get_actuation_actions(config: &Config) -> Response {
 pub async fn get_actuation_audit(config: &Config) -> Response {
     let path = config.data_dir.join("safety/actuation-audit.jsonl");
     let result = tokio::task::spawn_blocking(move || -> Result<String, String> {
-        if !path.exists() {
-            return Ok("[]".into());
-        }
-        let text = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
-        let items = text
-            .lines()
-            .rev()
-            .take(50)
-            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        let lines = jsonl::tail_lines(&path, 50, DEFAULT_MAX_JSONL_LINE_BYTES)
+            .map_err(|e| e.to_string())?;
+        let items = lines
+            .into_iter()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(&line).ok())
             .collect::<Vec<_>>();
         serde_json::to_string(&items).map_err(|e| e.to_string())
     })

--- a/crates/genie-common/src/jsonl.rs
+++ b/crates/genie-common/src/jsonl.rs
@@ -1,0 +1,167 @@
+//! Bounded tail reads for append-only JSONL logs.
+//!
+//! Dashboard and tool paths only need the last *N* lines; loading the entire
+//! file on every poll grows memory with log age (issue #223).
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+const TAIL_CHUNK_BYTES: usize = 4096;
+/// Skip individual lines larger than this instead of allocating them whole.
+pub const DEFAULT_MAX_JSONL_LINE_BYTES: usize = 256 * 1024;
+
+/// Return up to `limit` trailing non-empty lines from `path`, in file order.
+pub fn tail_lines(
+    path: &Path,
+    limit: usize,
+    max_line_bytes: usize,
+) -> std::io::Result<Vec<String>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut file = File::open(path)?;
+    let mut pos = file.metadata()?.len();
+    if pos == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut collected: Vec<Vec<u8>> = Vec::new();
+    let mut current_line: Vec<u8> = Vec::new();
+    let mut chunk = [0u8; TAIL_CHUNK_BYTES];
+
+    while pos > 0 && collected.len() < limit {
+        let read_size = std::cmp::min(TAIL_CHUNK_BYTES as u64, pos) as usize;
+        pos -= read_size as u64;
+        file.seek(SeekFrom::Start(pos))?;
+        file.read_exact(&mut chunk[..read_size])?;
+
+        for &byte in chunk[..read_size].iter().rev() {
+            if byte == b'\n' {
+                if !current_line.is_empty() {
+                    current_line.reverse();
+                    if current_line.len() <= max_line_bytes {
+                        collected.push(std::mem::take(&mut current_line));
+                    } else {
+                        current_line.clear();
+                    }
+                    if collected.len() >= limit {
+                        break;
+                    }
+                }
+            } else {
+                current_line.push(byte);
+            }
+        }
+
+        if collected.len() >= limit {
+            break;
+        }
+    }
+
+    if collected.len() < limit && !current_line.is_empty() {
+        current_line.reverse();
+        if current_line.len() <= max_line_bytes {
+            collected.push(current_line);
+        }
+    }
+
+    collected.reverse();
+    Ok(collected
+        .into_iter()
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_log(path: &Path, lines: &[&str]) {
+        let mut file = std::fs::File::create(path).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+    }
+
+    #[test]
+    fn tail_lines_returns_last_entries_in_order() {
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-jsonl-tail-{}-{}.jsonl",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&path);
+        write_log(
+            &path,
+            &[r#"{"n":1}"#, r#"{"n":2}"#, r#"{"n":3}"#, r#"{"n":4}"#],
+        );
+
+        let lines = tail_lines(&path, 2, DEFAULT_MAX_JSONL_LINE_BYTES).unwrap();
+        assert_eq!(
+            lines,
+            vec![r#"{"n":3}"#.to_string(), r#"{"n":4}"#.to_string()]
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn tail_lines_skips_oversize_lines() {
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-jsonl-tail-big-{}-{}.jsonl",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&path);
+        write_log(
+            &path,
+            &[
+                r#"{"n":1}"#,
+                &format!(r#"{{"blob":"{}"}}"#, "x".repeat(512)),
+                r#"{"n":3}"#,
+            ],
+        );
+
+        let lines = tail_lines(&path, 3, 64).unwrap();
+        assert_eq!(
+            lines,
+            vec![r#"{"n":1}"#.to_string(), r#"{"n":3}"#.to_string()]
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn tail_lines_handles_large_files_without_reading_whole_file() {
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-jsonl-tail-large-{}-{}.jsonl",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let mut file = std::fs::File::create(&path).unwrap();
+        for idx in 0..5_000 {
+            writeln!(file, r#"{{"idx":{idx}}}"#).unwrap();
+        }
+        drop(file);
+
+        let lines = tail_lines(&path, 3, DEFAULT_MAX_JSONL_LINE_BYTES).unwrap();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], r#"{"idx":4997}"#);
+        assert_eq!(lines[2], r#"{"idx":4999}"#);
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/genie-common/src/lib.rs
+++ b/crates/genie-common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod http;
+pub mod jsonl;
 pub mod mode;
 pub mod tegrastats;

--- a/crates/genie-core/src/tools/actuation.rs
+++ b/crates/genie-core/src/tools/actuation.rs
@@ -1,7 +1,8 @@
+use genie_common::jsonl::{self, DEFAULT_MAX_JSONL_LINE_BYTES};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -327,20 +328,20 @@ impl AuditLogger {
         let Some(path) = &self.path else {
             return Vec::new();
         };
-        let file = match File::open(path) {
-            Ok(file) => file,
+        let scan_limit = limit.saturating_mul(16).max(limit);
+        let lines = match jsonl::tail_lines(path, scan_limit, DEFAULT_MAX_JSONL_LINE_BYTES) {
+            Ok(lines) => lines,
             Err(e) => {
                 tracing::warn!(
                     path = %path.display(),
                     error = %e,
-                    "audit read failed; returning no recent executed actions"
+                    "audit tail read failed; returning no recent executed actions"
                 );
                 return Vec::new();
             }
         };
-        let mut actions = BufReader::new(file)
-            .lines()
-            .map_while(Result::ok)
+        let mut actions = lines
+            .into_iter()
             .filter_map(|line| match serde_json::from_str::<AuditEvent>(&line) {
                 Ok(event) => audit_event_to_recorded_action(event),
                 Err(e) => {
@@ -524,6 +525,43 @@ mod tests {
             None,
         );
         assert_eq!(next.id, 12);
+    }
+
+    #[test]
+    fn audit_logger_reads_recent_executed_actions_from_log_tail() {
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-actuation-audit-tail-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let logger = AuditLogger::new(&path);
+
+        for idx in 0..500 {
+            logger.append(AuditEvent {
+                ts_ms: idx,
+                status: if idx % 2 == 0 {
+                    AuditStatus::Executed
+                } else {
+                    AuditStatus::ConfirmationIssued
+                },
+                origin: RequestOrigin::Voice,
+                entity: format!("entity-{idx}"),
+                action: "turn_on".into(),
+                value: None,
+                reason: "home action executed".into(),
+                token: None,
+                confidence: None,
+                action_id: if idx % 2 == 0 { Some(idx) } else { None },
+                undo_of: None,
+            });
+        }
+
+        let actions = logger.read_recent_executed_actions(3);
+        assert_eq!(actions.len(), 3);
+        assert_eq!(actions[0].entity, "entity-494");
+        assert_eq!(actions[1].entity, "entity-496");
+        assert_eq!(actions[2].entity, "entity-498");
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `genie_common::jsonl::tail_lines` for bounded reverse-chunk reads of append-only JSONL logs.
- Use tail reads in `AuditLogger::read_recent_executed_actions` and `get_actuation_audit` instead of loading the entire file.
- Add unit tests for large logs and executed-action tail selection.

Closes #223

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware **OR** explained the equivalent verification path I used.

### What I ran

```bash
cargo test -p genie-common jsonl
cargo test -p genie-core audit_logger
cargo test -p genie-api
cargo clippy -p genie-common -p genie-core -p genie-api --all-targets --locked -- -D warnings
cargo fmt --all -- --check
```

### What I observed

All targeted tests passed.

## Test plan

- [x] `cargo test -p genie-common jsonl`
- [x] `cargo test -p genie-core audit_logger`
- [x] `cargo test -p genie-api`
- [x] `cargo clippy -p genie-common -p genie-core -p genie-api --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all -- --check`