### PR TITLE
fix(security): mint actuation confirmation tokens from a CSPRNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "async-trait",
  "genie-common",
  "genie-skill-sdk",
+ "getrandom 0.3.4",
  "libc",
  "libloading",
  "reqwest",

--- a/crates/genie-core/Cargo.toml
+++ b/crates/genie-core/Cargo.toml
@@ -47,6 +47,9 @@ toml = { workspace = true }
 genie-skill-sdk = { path = "../genie-skill-sdk" }
 async-trait = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
+# CSPRNG for actuation confirmation tokens (see crates/genie-core/src/tools/actuation.rs).
+# Already in the resolved graph via rustls/quinn, so this adds no new third-party crate.
+getrandom = "0.3"
 
 [dev-dependencies]
 toml = { workspace = true }

--- a/crates/genie-core/src/tools/actuation.rs
+++ b/crates/genie-core/src/tools/actuation.rs
@@ -110,7 +110,11 @@ impl ConfirmationManager {
         prune_expired(&mut state.pending);
         state.next_id += 1;
         let created_ms = now_ms();
-        let token = format!("act-{:x}-{:x}", created_ms, state.next_id);
+        // The token is a bearer secret: its only entropy is 128 CSPRNG bits.
+        // `created_ms`/`next_id` are display/bookkeeping fields and MUST NOT
+        // feed the token, or it collapses back to the guessable clock+counter
+        // scheme this manager replaced.
+        let token = random_token();
         let pending = PendingConfirmation {
             token: token.clone(),
             entity: entity.to_string(),
@@ -128,7 +132,18 @@ impl ConfirmationManager {
     pub fn confirm(&self, token: &str) -> Option<PendingConfirmation> {
         let mut state = self.inner.lock().expect("confirmation manager lock");
         prune_expired(&mut state.pending);
-        state.pending.remove(token)
+        // Constant-time match: a plain `HashMap::remove(token)` would compare
+        // the supplied token against stored keys with early-exit equality,
+        // leaking how many leading bytes matched as a timing signal. Scan
+        // every pending token, fold the comparisons with `ct_eq`, and never
+        // short-circuit on the first mismatch.
+        let mut matched: Option<String> = None;
+        for key in state.pending.keys() {
+            if ct_eq(key.as_bytes(), token.as_bytes()) {
+                matched = Some(key.clone());
+            }
+        }
+        matched.and_then(|key| state.pending.remove(&key))
     }
 
     pub fn list(&self) -> Vec<PendingConfirmation> {
@@ -387,6 +402,42 @@ pub fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Mint an unguessable confirmation token from 128 bits of CSPRNG entropy,
+/// hex-encoded behind the `act-` prefix the rest of the system expects.
+///
+/// `getrandom` reads the OS CSPRNG (`/dev/urandom`, `getrandom(2)`,
+/// `BCryptGenRandom`, …). It cannot return short reads; the only error is the
+/// source being unavailable, which on a running host means the entropy pool is
+/// broken. Rather than fall back to a weaker, guessable source, we panic — a
+/// confirmation token we cannot generate securely must not be issued at all.
+fn random_token() -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut bytes = [0u8; 16];
+    getrandom::fill(&mut bytes).expect("OS CSPRNG unavailable while minting confirmation token");
+    let mut token = String::with_capacity(4 + bytes.len() * 2);
+    token.push_str("act-");
+    for byte in bytes {
+        token.push(HEX[(byte >> 4) as usize] as char);
+        token.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    token
+}
+
+/// Constant-time byte-slice equality. Returns `true` only when both slices have
+/// the same length and identical contents, without leaking the position of the
+/// first differing byte through timing. Used to compare confirmation tokens so
+/// the confirm endpoint is not a partial-match timing oracle.
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -407,6 +458,90 @@ mod tests {
         let confirmed = manager.confirm(&pending.token).unwrap();
         assert_eq!(confirmed.entity, "front door");
         assert!(manager.list().is_empty());
+    }
+
+    /// The token is the entire authorization to execute a sensitive physical
+    /// action, so it must carry real entropy — not be derivable from the clock
+    /// plus a per-process counter. Two tokens issued back-to-back differ in
+    /// their random body, and neither equals what the old `act-{ms:x}-{id:x}`
+    /// scheme would have produced for the same clock/counter inputs.
+    #[test]
+    fn confirmation_tokens_are_unpredictable() {
+        let manager = ConfirmationManager::default();
+        let first = manager.issue("front door", "unlock", None, "r", RequestOrigin::Api);
+        let second = manager.issue("front door", "unlock", None, "r", RequestOrigin::Api);
+
+        assert_ne!(
+            first.token, second.token,
+            "two issued tokens must not collide"
+        );
+
+        // 128 bits of entropy => "act-" + 32 lowercase hex chars.
+        for token in [&first.token, &second.token] {
+            let body = token
+                .strip_prefix("act-")
+                .expect("token keeps the act- prefix");
+            assert_eq!(body.len(), 32, "expected 16 random bytes hex-encoded");
+            assert!(
+                body.bytes().all(|b| b.is_ascii_hexdigit()),
+                "token body must be hex: {token}"
+            );
+        }
+
+        // The old guessable scheme would have produced these from clock +
+        // counter. Knowing both must not let an attacker reconstruct the token.
+        let counter_guess_1 = format!("act-{:x}-{:x}", first.created_ms, 1);
+        let counter_guess_2 = format!("act-{:x}-{:x}", second.created_ms, 2);
+        assert_ne!(first.token, counter_guess_1);
+        assert_ne!(second.token, counter_guess_2);
+    }
+
+    /// A forged or guessed token — including one built from the now-public
+    /// `created_ms` and the low integer counter — must be refused, and must not
+    /// consume or match the genuine pending confirmation.
+    #[test]
+    fn forged_token_is_rejected() {
+        let manager = ConfirmationManager::default();
+        let pending = manager.issue("front door", "unlock", None, "r", RequestOrigin::Api);
+
+        // Reconstruct what the old clock+counter token would have been.
+        let forged_clock_counter = format!("act-{:x}-{:x}", pending.created_ms, 1);
+        assert!(
+            manager.confirm(&forged_clock_counter).is_none(),
+            "clock+counter forgery must not confirm"
+        );
+
+        // Same length/shape as a real token but wrong bytes.
+        let forged_same_shape = format!("act-{}", "0".repeat(32));
+        assert!(
+            manager.confirm(&forged_same_shape).is_none(),
+            "same-shape forgery must not confirm"
+        );
+
+        // A prefix of the real token (timing-oracle probe) must not confirm.
+        let prefix = &pending.token[..pending.token.len() - 1];
+        assert!(
+            manager.confirm(prefix).is_none(),
+            "token prefix must not confirm"
+        );
+
+        // After all the failed attempts, the genuine token still works exactly
+        // once — failed forgeries neither consumed nor unlocked it.
+        assert_eq!(manager.list().len(), 1, "forgeries must not evict pending");
+        assert!(
+            manager.confirm(&pending.token).is_some(),
+            "the genuine token must still confirm"
+        );
+        assert!(manager.confirm(&pending.token).is_none(), "single use only");
+    }
+
+    #[test]
+    fn ct_eq_matches_only_identical_slices() {
+        assert!(ct_eq(b"act-abc", b"act-abc"));
+        assert!(!ct_eq(b"act-abc", b"act-abd"));
+        assert!(!ct_eq(b"act-abc", b"act-ab")); // differing length
+        assert!(!ct_eq(b"", b"x"));
+        assert!(ct_eq(b"", b""));
     }
 
     #[test]

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -699,9 +699,15 @@ impl ToolDispatcher {
                     action_id: None,
                     undo_of: None,
                 });
+                // The token is a bearer secret: a leaked one is a reusable
+                // door-unlock credential for its full validity window. Keep it
+                // out of LLM tool output (transcripts, voice, logs). The
+                // dashboard fetches it over /api/actuation/pending to drive the
+                // Confirm button; humans confirm there rather than reading the
+                // token back from this string.
                 Ok(format!(
-                    "Confirmation required before I can do that: {}. Pending token: {}. Confirm from the local dashboard or POST /api/actuation/confirm.",
-                    reason, pending.token
+                    "Confirmation required before I can do that: {}. Confirm this pending action from the local dashboard (or POST /api/actuation/confirm with its token from /api/actuation/pending).",
+                    reason
                 ))
             }
             Err(err) => {
@@ -2337,18 +2343,19 @@ mod tests {
         }
     }
 
-    /// Pull the `act-…` confirmation token out of the "Confirmation required"
-    /// message that `home_control` emits when the policy gate returns
-    /// `ConfirmationRequired`.
-    fn extract_confirmation_token(output: &str) -> String {
-        let marker = "Pending token: ";
-        let start = output
-            .find(marker)
-            .unwrap_or_else(|| panic!("no confirmation token in output: {output:?}"))
-            + marker.len();
-        let tail = &output[start..];
-        let end = tail.find('.').unwrap_or(tail.len());
-        tail[..end].trim().to_string()
+    /// Fetch the freshest pending confirmation token from the dispatcher.
+    ///
+    /// The token is deliberately NOT echoed into `home_control`'s tool output
+    /// (it is a bearer secret), so tests read it from the same channel the
+    /// dashboard uses — the pending-confirmations list — rather than scraping
+    /// the LLM-visible string.
+    fn latest_confirmation_token(dispatcher: &ToolDispatcher) -> String {
+        dispatcher
+            .pending_confirmations()
+            .into_iter()
+            .max_by_key(|item| item.created_ms)
+            .map(|item| item.token)
+            .expect("a pending confirmation must exist")
     }
 
     /// Read the actuation audit JSONL written via `with_actuation_audit_path`
@@ -2400,7 +2407,12 @@ mod tests {
             )
             .await;
         assert!(issued.success, "issuing confirmation must succeed");
-        let token = extract_confirmation_token(&issued.output);
+        assert!(
+            !issued.output.contains("act-"),
+            "raw bearer token must not be echoed into tool output: {:?}",
+            issued.output
+        );
+        let token = latest_confirmation_token(&dispatcher);
         let executed_output = dispatcher
             .confirm_pending_home_action(&token)
             .await
@@ -2456,7 +2468,7 @@ mod tests {
             )
             .await;
         assert!(first_issue.success);
-        let first_token = extract_confirmation_token(&first_issue.output);
+        let first_token = latest_confirmation_token(&dispatcher);
 
         // Confirming that first request must succeed: the bucket already paid
         // its single slot on the request, the confirmation must not double-
@@ -2533,7 +2545,7 @@ mod tests {
             )
             .await;
         assert!(first_issue.success);
-        let first_token = extract_confirmation_token(&first_issue.output);
+        let first_token = latest_confirmation_token(&dispatcher);
         dispatcher
             .confirm_pending_home_action(&first_token)
             .await

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -330,7 +330,20 @@ async fn tool_gate_confirmable_home_action_requires_token_and_audits() {
         result.output
     );
     assert!(result.output.contains("Confirmation required"));
-    assert!(result.output.contains("Pending token:"));
+    // The confirmation token is a bearer secret and must NOT be echoed into
+    // tool output (transcripts/logs/voice). The user confirms from the local
+    // dashboard, which reads the token from /api/actuation/pending.
+    assert!(
+        !result.output.contains("Pending token:"),
+        "tool output must not echo the raw token: {}",
+        result.output
+    );
+    assert!(
+        !result.output.contains("act-"),
+        "tool output must not contain a raw act- token: {}",
+        result.output
+    );
+    assert!(result.output.contains("local dashboard"));
     assert!(
         executed.lock().unwrap().is_empty(),
         "sensitive action must not execute before confirmation"


### PR DESCRIPTION
## Summary

Actuation confirmation tokens were minted as `act-{created_ms:x}-{next_id:x}` — wall-clock ms plus a low-entropy per-process counter, with no CSPRNG and no secret — so a token could be guessed/brute-forced within its 10-minute window and replay the unauthenticated `POST /api/actuation/confirm` to unlock a door, open a garage, or disarm an alarm. This mints tokens from 128 bits of OS CSPRNG entropy, compares them in constant time, and stops echoing the raw token into LLM tool output. Closes #226.

## Changes

- Mint confirmation tokens from 128 bits of OS CSPRNG entropy (`getrandom::fill`), hex-encoded behind the existing `act-` prefix. `created_ms`/`next_id` remain display/bookkeeping fields and no longer feed the token.
- Compare tokens in constant time in `ConfirmationManager::confirm` (scan all pending keys, fold with `ct_eq`, no early exit) so the confirm path is not a partial-match timing oracle.
- Stop echoing the raw token into LLM tool output (`dispatch.rs`) — it is a bearer secret and a leaked one is a reusable credential. The local dashboard still drives the Confirm button from `/api/actuation/pending`; the tool message now points there instead.
- Add `getrandom` as a direct dependency of `genie-core`. It is already in the resolved graph via rustls/quinn, so no new third-party crate enters the build.
- Tests: token unpredictability + shape (`act-` + 32 hex), forged- and prefix-token rejection (genuine token still confirms exactly once), `ct_eq` behavior, and an assertion that the raw token is not echoed into tool output.

Scoped to the token-entropy / timing / leak vectors. The unauthenticated confirm endpoint is a larger architectural change (no auth primitives exist in `server.rs`/`genie-api` yet) and is left for a follow-up; the issue notes the CSPRNG token is the single highest-leverage change and closes the guess/brute-force vector independent of the auth gap.

## Real Behavior Proof

- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] Not run locally

### What I ran

Nothing compiled or executed locally: this contribution host has no Rust toolchain (`cargo` unavailable), so `cargo build`/`cargo test` could not be run here. The change is hardware-independent logic in `genie-core` (token minting + comparison + tool-output string), so there is no Jetson/voice/HA-specific behavior to exercise — CI's build + test matrix is the first real compile and is the intended verification gate.

### What I observed

No local runtime observation (see above). Verification is delegated to CI. The added unit tests assert the security-relevant behavior directly:

- `confirmation_tokens_are_unpredictable` — two back-to-back tokens differ, are `act-` + 32 hex chars, and do not equal the clock+counter token the old scheme would have produced.
- `forged_token_is_rejected` — a reconstructed clock+counter token, a same-shape all-zeros token, and a prefix of the real token are all refused; the genuine token still confirms exactly once afterward.
- `ct_eq_matches_only_identical_slices` — constant-time equality returns true only for identical equal-length slices.
- `tool_gate_confirmable_home_action_requires_token_and_audits` (integration) — tool output no longer contains the raw `act-` token or "Pending token:", and points to the local dashboard.

## Test plan

On a host with the Rust toolchain:

```
cargo test -p genie-core
cargo test -p genie-core --test tool_gate_integration_test
cargo clippy -p genie-core --all-targets
```

To re-verify end-to-end: stage a sensitive action (e.g. `home_control` unlock) so a confirmation is pending; confirm the tool reply no longer prints the token; open the local dashboard, confirm via the Confirm button (token fetched from `/api/actuation/pending`); confirm a guessed/forged token to `POST /api/actuation/confirm` is rejected.

## Notes for reviewers

- Could not build/test locally (no Rust toolchain on this host) — relying on CI for the compile/test gate; flagged honestly above per CONTRIBUTING.
- Intentionally out of scope (suggest separate issues/PRs): (1) authenticating `POST /api/actuation/confirm` / binding to a local principal; (2) the dashboard still renders `Token: …` in plaintext at `dashboard.js:280` — defensible since it's local-operator UI, but worth a follow-up if tokens should be treated as secret end-to-end.
- `getrandom::fill` failure (broken OS entropy source) panics rather than falling back to a weaker token — a confirmation token that can't be generated securely must not be issued.
