### PR TITLE
feat(llm): cache stable system prompt prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ genie-ai-runtime   Home Assistant today
 - Home Assistant adapter with confirmations, rate limits, and audit logging
 - local HTTP API, dashboard, CLI, health service, and governor service
 - optional `web_search` tool with DuckDuckGo or SearXNG
-- cache-aware `genie-ai-runtime` requests with `conversation_id` and
-  `nvext.agent_hints` for session KV reuse
+- cache-aware `genie-ai-runtime` requests with `conversation_id`,
+  `nvext.agent_hints`, and system-prompt prefix cache metadata for KV reuse
 - system-prompt SHA exposed in boot logs, `/api/health`, and `genie-ctl status`
   to prove deterministic prompt assembly across restarts
 - Jetson aarch64 cross-compile CI
@@ -82,8 +82,8 @@ The repo now has explicit code-level contract surfaces for the new direction:
   response reserve, and optional provider context against the Jetson 4096-token
   baseline.
 - `genie_core::llm::LlmRequestHints` carries session id, expected output
-  length, priority, and short-lived cache TTL to runtimes that understand the
-  `nvext` extension.
+  length, priority, short-lived cache TTL, and stable system-prompt prefix
+  cache metadata to runtimes that understand the `nvext` extension.
 - `[agent]` in `geniepod.toml` selects the runtime profile:
   `jetson`, `raspberry_pi`, `portable_sbc`, `laptop`, or `mac`.
 - `[optional_ai_provider]` is disabled by default. API-key providers must keep

--- a/crates/genie-core/src/llm/openai_compat.rs
+++ b/crates/genie-core/src/llm/openai_compat.rs
@@ -74,6 +74,12 @@ pub(crate) struct CacheControl {
     #[serde(rename = "type")]
     pub(crate) cache_type: &'static str,
     pub(crate) ttl: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) scope: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) cache_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) prefix_bytes: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -189,7 +195,7 @@ impl RequestProfile {
             conversation_id,
             think: self.think_override(),
             response_format,
-            nvext: self.nvext(hints),
+            nvext: self.nvext(messages, hints),
         };
         Ok(serde_json::to_string(&request)?)
     }
@@ -224,10 +230,10 @@ impl RequestProfile {
         }
     }
 
-    fn nvext(&self, hints: Option<&LlmRequestHints>) -> Option<NvExt> {
+    fn nvext(&self, messages: &[Message], hints: Option<&LlmRequestHints>) -> Option<NvExt> {
         match self {
             Self::Generic => None,
-            Self::GenieAiRuntime => hints.and_then(build_nvext),
+            Self::GenieAiRuntime => build_nvext(messages, hints),
         }
     }
 }
@@ -240,6 +246,12 @@ const DEFAULT_MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
 const GENIE_RUNTIME_COMPACT_SYSTEM: &str =
     "You are GeniePod Home. Answer the user's latest request directly and concisely.";
 const GENIE_RUNTIME_COMPACT_SYSTEM_PREFIX: &str = "You are GeniePod Home. Reply briefly for voice. Use a tool only when required. Tool calls must be ONLY JSON: {\"tool\":\"tool_name\",\"arguments\":{}}. No markdown.";
+const SYSTEM_PROMPT_PREFIX_CACHE_SCOPE: &str = "system_prompt_prefix";
+const SYSTEM_PROMPT_PREFIX_CACHE_KEY_PREFIX: &str = "system-prompt-prefix:";
+const SYSTEM_PROMPT_PREFIX_CACHE_MARKERS: [&str; 2] = [
+    "\n\nRelevant household context:\n",
+    "\n\nHousehold context:\n",
+];
 
 impl OpenAiCompatClient {
     pub fn new(backend_name: &'static str, host: &str, port: u16) -> Self {
@@ -696,30 +708,30 @@ async fn read_chunked_body<R: AsyncBufReadExt + Unpin>(
     Ok(String::from_utf8_lossy(&body).to_string())
 }
 
-fn build_nvext(hints: &LlmRequestHints) -> Option<NvExt> {
+fn build_nvext(messages: &[Message], hints: Option<&LlmRequestHints>) -> Option<NvExt> {
     let session_id = hints
-        .session_id
-        .as_deref()
+        .and_then(|h| h.session_id.as_deref())
         .and_then(normalize_runtime_session_id);
-    let agent_hints = if session_id.is_some()
-        || hints.priority.is_some()
-        || hints.output_sequence_length.is_some()
-        || hints.speculative_prefill
-    {
-        Some(AgentHints {
-            session_id,
-            priority: hints.priority,
-            osl: hints.output_sequence_length,
-            speculative_prefill: hints.speculative_prefill.then_some(true),
-        })
-    } else {
-        None
-    };
-
-    let cache_control = hints.cache_ttl_secs.map(|ttl| CacheControl {
-        cache_type: "ephemeral",
-        ttl: format_ttl(ttl),
+    let agent_hints = hints.and_then(|hints| {
+        if session_id.is_some()
+            || hints.priority.is_some()
+            || hints.output_sequence_length.is_some()
+            || hints.speculative_prefill
+        {
+            Some(AgentHints {
+                session_id: session_id.clone(),
+                priority: hints.priority,
+                osl: hints.output_sequence_length,
+                speculative_prefill: hints.speculative_prefill.then_some(true),
+            })
+        } else {
+            None
+        }
     });
+
+    let cache_control = hints
+        .and_then(|h| h.cache_ttl_secs)
+        .map(|ttl| cache_control(ttl, system_prompt_prefix_cache(messages)));
 
     if agent_hints.is_some() || cache_control.is_some() {
         Some(NvExt {
@@ -729,6 +741,50 @@ fn build_nvext(hints: &LlmRequestHints) -> Option<NvExt> {
     } else {
         None
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SystemPromptPrefixCache {
+    cache_key: String,
+    prefix_bytes: usize,
+}
+
+fn cache_control(ttl_secs: u32, prefix_cache: Option<SystemPromptPrefixCache>) -> CacheControl {
+    CacheControl {
+        cache_type: "ephemeral",
+        ttl: format_ttl(ttl_secs),
+        scope: prefix_cache
+            .as_ref()
+            .map(|_| SYSTEM_PROMPT_PREFIX_CACHE_SCOPE),
+        cache_key: prefix_cache.as_ref().map(|cache| cache.cache_key.clone()),
+        prefix_bytes: prefix_cache.map(|cache| cache.prefix_bytes),
+    }
+}
+
+fn system_prompt_prefix_cache(messages: &[Message]) -> Option<SystemPromptPrefixCache> {
+    let system = messages
+        .iter()
+        .find(|message| message.role == "system")?
+        .content
+        .as_str();
+
+    let prefix_end = SYSTEM_PROMPT_PREFIX_CACHE_MARKERS
+        .iter()
+        .filter_map(|marker| system.find(marker).map(|pos| pos + marker.len()))
+        .min()?;
+    let prefix = system.get(..prefix_end)?;
+    if prefix.trim().is_empty() {
+        return None;
+    }
+
+    Some(SystemPromptPrefixCache {
+        cache_key: format!(
+            "{}{}",
+            SYSTEM_PROMPT_PREFIX_CACHE_KEY_PREFIX,
+            crate::prompt_sha::sha256_hex(prefix)
+        ),
+        prefix_bytes: prefix.len(),
+    })
 }
 
 fn normalize_runtime_session_id(raw: &str) -> Option<String> {
@@ -1110,6 +1166,84 @@ mod tests {
         assert_eq!(json["nvext"]["agent_hints"]["osl"], 512);
         assert_eq!(json["nvext"]["cache_control"]["type"], "ephemeral");
         assert_eq!(json["nvext"]["cache_control"]["ttl"], "15m");
+        assert!(json["nvext"]["cache_control"].get("scope").is_none());
+        assert!(json["nvext"]["cache_control"].get("cache_key").is_none());
+        assert!(json["nvext"]["cache_control"].get("prefix_bytes").is_none());
+    }
+
+    #[test]
+    fn genie_runtime_profile_serializes_system_prompt_prefix_cache_hint() {
+        let profile = RequestProfile::genie_ai_runtime();
+        let hints = LlmRequestHints::agent_turn("conv-abc", 512);
+        let static_prompt = "You are GeniePod Home.\nUse tools safely.";
+        let marker = "\n\nRelevant household context:\n";
+        let full_prompt = format!("{static_prompt}{marker}Jared lives here.");
+        let prepared = profile
+            .prepare_body(
+                &[
+                    Message {
+                        role: "system".into(),
+                        content: full_prompt.clone(),
+                    },
+                    Message {
+                        role: "user".into(),
+                        content: "hello".into(),
+                    },
+                ],
+                Some(512),
+                false,
+                None,
+                Some(&hints),
+            )
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&prepared.body).unwrap();
+        let cache = &json["nvext"]["cache_control"];
+        let expected_prefix = format!("{static_prompt}{marker}");
+
+        assert_eq!(cache["type"], "ephemeral");
+        assert_eq!(cache["ttl"], "15m");
+        assert_eq!(cache["scope"], SYSTEM_PROMPT_PREFIX_CACHE_SCOPE);
+        assert_eq!(cache["prefix_bytes"], expected_prefix.len());
+        assert_eq!(
+            cache["cache_key"],
+            format!(
+                "{}{}",
+                SYSTEM_PROMPT_PREFIX_CACHE_KEY_PREFIX,
+                crate::prompt_sha::sha256_hex(&expected_prefix)
+            )
+        );
+    }
+
+    #[test]
+    fn system_prompt_prefix_cache_key_ignores_dynamic_household_context() {
+        let marker = "\n\nRelevant household context:\n";
+        let first = system_prompt_prefix_cache(&[Message {
+            role: "system".into(),
+            content: format!("stable prompt{marker}Jared likes tea."),
+        }])
+        .unwrap();
+        let second = system_prompt_prefix_cache(&[Message {
+            role: "system".into(),
+            content: format!("stable prompt{marker}Maya likes oat milk."),
+        }])
+        .unwrap();
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn compacted_system_prompt_prefix_cache_uses_household_context_boundary() {
+        let marker = "\n\nHousehold context:\n";
+        let cache = system_prompt_prefix_cache(&[Message {
+            role: "system".into(),
+            content: format!("stable compacted prompt{marker}Jared lives here."),
+        }])
+        .unwrap();
+
+        assert_eq!(
+            cache.prefix_bytes,
+            format!("stable compacted prompt{marker}").len()
+        );
     }
 
     #[test]

--- a/crates/genie-core/src/runtime_boundary.rs
+++ b/crates/genie-core/src/runtime_boundary.rs
@@ -42,7 +42,7 @@ pub fn runtime_boundaries(agent: &AgentConfig) -> Vec<RuntimeBoundaryContract> {
             layer: "ai_runtime",
             owner: "genie-ai-runtime",
             mode: format!("{:?}", agent.ai_runtime_boundary),
-            contract: "OpenAI-compatible chat plus limited-context compaction, conversation_id, and nvext.agent_hints",
+            contract: "OpenAI-compatible chat plus limited-context compaction, conversation_id, nvext.agent_hints, and system-prompt prefix cache hints",
             local_default: true,
         },
         RuntimeBoundaryContract {


### PR DESCRIPTION
## Summary

Closes #234. Adds explicit system-prompt prefix cache metadata to genie-ai-runtime `nvext.cache_control` so the runtime can reuse the stable prompt prefix separately from dynamic household context.

## Changes

- Add `scope`, `cache_key`, and `prefix_bytes` to genie-ai-runtime cache-control metadata when a system prompt has a household-context suffix.
- Derive the cache key from the stable prefix bytes before dynamic household context, so the key remains stable across memory changes.
- Keep generic OpenAI-compatible backends unchanged and document the expanded runtime boundary.
- Add unit coverage for serialization, dynamic context stability, and compacted prompt boundaries.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Local Linux dev workspace, serialization/runtime-boundary code path only:

```bash
cargo fmt --all -- --check
cargo test -p genie-core llm::openai_compat
cargo test -p genie-core
cargo clippy -p genie-core --all-targets -- -D warnings
```

### What I observed

- `cargo fmt --all -- --check` passed.
- `cargo test -p genie-core llm::openai_compat` passed: 20 passed, 0 failed.
- `cargo test -p genie-core` passed: all genie-core unit/integration/doc tests passed.
- `cargo clippy -p genie-core --all-targets -- -D warnings` passed.

Jetson was not used for this PR. The changed behavior is request JSON serialization and local unit coverage verifies the emitted `nvext.cache_control` metadata. Runtime-side KV reuse still needs Jetson/genie-ai-runtime observation after merge or in a follow-up runtime PR.

## Test plan

- Run the same cargo commands above.
- On Jetson, send two chat requests with the same boot prompt and different household context, then inspect runtime request logs or cache metrics to confirm the same `system_prompt_prefix` cache key is reused.

## Notes for reviewers

The cache hint is additive under `nvext.cache_control`; generic OpenAI-compatible backends still omit `nvext`. Unknown cache-control fields should be ignored by runtimes that only understand the existing TTL fields.