### PR TITLE
feat(llm): support OpenAI OAuth bearer provider auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ The repo now has explicit code-level contract surfaces for the new direction:
   cache metadata to runtimes that understand the `nvext` extension.
 - `[agent]` in `geniepod.toml` selects the runtime profile:
   `jetson`, `raspberry_pi`, `portable_sbc`, `laptop`, or `mac`.
-- `[optional_ai_provider]` is disabled by default. API-key providers must keep
-  their configured context at or below `[agent].context_window_tokens` before
-  they are production candidates.
+- `[optional_ai_provider]` is disabled by default. API-key and OAuth-bearer
+  providers must keep their configured context at or below
+  `[agent].context_window_tokens` before they are production candidates.
 
 ## Quick Start
 

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -329,6 +329,12 @@ pub struct OptionalAiProviderConfig {
     #[serde(default)]
     pub provider: OptionalAiProviderKind,
 
+    /// Credential type used by the provider. `api_key` preserves the existing
+    /// default; `oauth_bearer` lets operators provide an OAuth access token
+    /// through `oauth_token_env` without storing the token in config.
+    #[serde(default)]
+    pub auth_mode: OptionalAiProviderAuthMode,
+
     /// Base URL or endpoint identifier for provider clients. Empty while
     /// disabled. Remote endpoints require allow_remote_base_url = true.
     #[serde(default)]
@@ -338,6 +344,12 @@ pub struct OptionalAiProviderConfig {
     /// never stored in config and is not included in support summaries.
     #[serde(default = "defaults::optional_ai_provider_api_key_env")]
     pub api_key_env: String,
+
+    /// Environment variable that contains an OAuth bearer access token when
+    /// `auth_mode = "oauth_bearer"`. The token value itself is never stored in
+    /// config and is not included in support summaries.
+    #[serde(default = "defaults::optional_ai_provider_oauth_token_env")]
+    pub oauth_token_env: String,
 
     /// Provider path must pass the same limited-context harness before it is
     /// promoted. Keep this at or below [agent].context_window_tokens.
@@ -357,8 +369,15 @@ impl OptionalAiProviderConfig {
     pub fn production_candidate(&self, agent: &AgentConfig) -> bool {
         self.enabled
             && self.limited_context_compatible(agent)
-            && !self.api_key_env.trim().is_empty()
+            && !self.credential_env().trim().is_empty()
             && (!is_remote_url(&self.base_url) || self.allow_remote_base_url)
+    }
+
+    pub fn credential_env(&self) -> &str {
+        match self.auth_mode {
+            OptionalAiProviderAuthMode::ApiKey => &self.api_key_env,
+            OptionalAiProviderAuthMode::OAuthBearer => &self.oauth_token_env,
+        }
     }
 }
 
@@ -367,12 +386,28 @@ impl Default for OptionalAiProviderConfig {
         Self {
             enabled: false,
             provider: OptionalAiProviderKind::OpenAiCompatible,
+            auth_mode: OptionalAiProviderAuthMode::ApiKey,
             base_url: String::new(),
             api_key_env: defaults::optional_ai_provider_api_key_env(),
+            oauth_token_env: defaults::optional_ai_provider_oauth_token_env(),
             context_window_tokens: defaults::agent_context_window_tokens(),
             allow_remote_base_url: false,
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OptionalAiProviderAuthMode {
+    /// Standard provider key loaded from `api_key_env`.
+    #[default]
+    ApiKey,
+    /// OAuth access token loaded from `oauth_token_env` and sent as
+    /// `Authorization: Bearer <token>`.
+    #[serde(rename = "oauth_bearer")]
+    #[serde(alias = "oauth")]
+    #[serde(alias = "oauth2")]
+    OAuthBearer,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
@@ -1464,12 +1499,15 @@ impl Config {
             "optional_ai_provider": {
                 "enabled": self.optional_ai_provider.enabled,
                 "provider": format!("{:?}", self.optional_ai_provider.provider),
+                "auth_mode": format!("{:?}", self.optional_ai_provider.auth_mode),
                 "context_window_tokens": self.optional_ai_provider.context_window_tokens,
                 "limited_context_compatible": self.optional_ai_provider.limited_context_compatible(&self.agent),
                 "allow_remote_base_url": self.optional_ai_provider.allow_remote_base_url,
                 "api_key_env_configured": !self.optional_ai_provider.api_key_env.trim().is_empty(),
+                "oauth_token_env_configured": !self.optional_ai_provider.oauth_token_env.trim().is_empty(),
                 "base_url_configured": !self.optional_ai_provider.base_url.trim().is_empty(),
-                "api_key_value_exposed": false
+                "api_key_value_exposed": false,
+                "credential_value_exposed": false
             },
             "policy": {
                 "tool_policy_enabled": self.core.tool_policy.enabled,
@@ -1673,6 +1711,14 @@ home_runtime_boundary = "external_runtime"
             config.optional_ai_provider.provider,
             OptionalAiProviderKind::OpenAiCompatible
         );
+        assert_eq!(
+            config.optional_ai_provider.auth_mode,
+            OptionalAiProviderAuthMode::ApiKey
+        );
+        assert_eq!(
+            config.optional_ai_provider.credential_env(),
+            "GENIEPOD_AI_PROVIDER_API_KEY"
+        );
         assert!(
             config
                 .optional_ai_provider
@@ -1702,6 +1748,27 @@ allow_remote_base_url = true
 
         assert!(!provider.limited_context_compatible(&agent));
         assert!(!provider.production_candidate(&agent));
+    }
+
+    #[test]
+    fn optional_ai_provider_can_use_oauth_bearer_env() {
+        let agent = AgentConfig::default();
+        let provider: OptionalAiProviderConfig = toml::from_str(
+            r#"
+enabled = true
+provider = "open_ai"
+auth_mode = "oauth_bearer"
+base_url = "https://api.openai.com/v1"
+oauth_token_env = "OPENAI_OAUTH_ACCESS_TOKEN"
+context_window_tokens = 4096
+allow_remote_base_url = true
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(provider.auth_mode, OptionalAiProviderAuthMode::OAuthBearer);
+        assert_eq!(provider.credential_env(), "OPENAI_OAUTH_ACCESS_TOKEN");
+        assert!(provider.production_candidate(&agent));
     }
 
     #[test]
@@ -2550,6 +2617,9 @@ mod defaults {
     }
     pub fn optional_ai_provider_api_key_env() -> String {
         "GENIEPOD_AI_PROVIDER_API_KEY".into()
+    }
+    pub fn optional_ai_provider_oauth_token_env() -> String {
+        "GENIEPOD_AI_PROVIDER_OAUTH_TOKEN".into()
     }
     pub fn llm_model_name() -> String {
         "phi".into()

--- a/crates/genie-core/src/agent_harness.rs
+++ b/crates/genie-core/src/agent_harness.rs
@@ -110,7 +110,7 @@ pub fn estimate_tokens(text: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use genie_common::config::OptionalAiProviderKind;
+    use genie_common::config::{OptionalAiProviderAuthMode, OptionalAiProviderKind};
 
     fn sample_tool(name: &str) -> ToolDef {
         ToolDef {
@@ -176,8 +176,10 @@ mod tests {
         let provider = OptionalAiProviderConfig {
             enabled: true,
             provider: OptionalAiProviderKind::OpenAiCompatible,
+            auth_mode: OptionalAiProviderAuthMode::ApiKey,
             base_url: "https://provider.example/v1".into(),
             api_key_env: "GENIE_PROVIDER_KEY".into(),
+            oauth_token_env: "GENIE_PROVIDER_OAUTH_TOKEN".into(),
             context_window_tokens: 8192,
             allow_remote_base_url: true,
         };

--- a/crates/genie-core/src/llm/mod.rs
+++ b/crates/genie-core/src/llm/mod.rs
@@ -2,6 +2,7 @@ mod genie_ai_runtime;
 mod llama_cpp;
 mod mock;
 mod openai_compat;
+mod openai_compatible;
 mod provider;
 
 use anyhow::Result;
@@ -12,6 +13,7 @@ pub use genie_ai_runtime::GenieAiRuntimeBackend;
 pub use llama_cpp::LlamaCppBackend;
 pub use mock::MockLlmBackend;
 pub use openai_compat::{LlmTimeouts, Message, ResponseFormat};
+pub use openai_compatible::OpenAiCompatibleBackend;
 pub use provider::{OptionalProviderPlan, ProviderReadiness};
 
 #[async_trait]
@@ -172,6 +174,53 @@ impl LlmClient {
         }
     }
 
+    pub fn from_openai_compatible_url_with_bearer_token(url: &str, token: impl AsRef<str>) -> Self {
+        Self::from_openai_compatible_url_with_bearer_token_and_timeouts(
+            url,
+            token,
+            LlmTimeouts::default(),
+        )
+    }
+
+    pub fn from_openai_compatible_url_with_bearer_token_and_timeouts(
+        url: &str,
+        token: impl AsRef<str>,
+        timeouts: LlmTimeouts,
+    ) -> Self {
+        Self {
+            backend: Box::new(
+                OpenAiCompatibleBackend::from_url_with_bearer_token_and_timeouts(
+                    url, token, timeouts,
+                ),
+            ),
+        }
+    }
+
+    pub fn from_openai_compatible_url_with_bearer_token_env(
+        url: &str,
+        env_var: impl AsRef<str>,
+    ) -> Self {
+        Self::from_openai_compatible_url_with_bearer_token_env_and_timeouts(
+            url,
+            env_var,
+            LlmTimeouts::default(),
+        )
+    }
+
+    pub fn from_openai_compatible_url_with_bearer_token_env_and_timeouts(
+        url: &str,
+        env_var: impl AsRef<str>,
+        timeouts: LlmTimeouts,
+    ) -> Self {
+        Self {
+            backend: Box::new(
+                OpenAiCompatibleBackend::from_url_with_bearer_token_env_and_timeouts(
+                    url, env_var, timeouts,
+                ),
+            ),
+        }
+    }
+
     /// Construct an in-memory LLM client that replays the given scripted
     /// replies in order. Used by `tests/voice_loop_integration.rs` (issue #21).
     pub fn mock<I, S>(replies: I) -> Self
@@ -287,6 +336,15 @@ mod tests {
     fn can_construct_genie_ai_runtime_client() {
         let client = LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:8080/health");
         assert_eq!(client.backend_name(), "genie-ai-runtime");
+    }
+
+    #[test]
+    fn can_construct_openai_compatible_bearer_client() {
+        let client = LlmClient::from_openai_compatible_url_with_bearer_token(
+            "http://127.0.0.1:8080/v1",
+            "oauth-token",
+        );
+        assert_eq!(client.backend_name(), "openai-compatible");
     }
 
     #[test]

--- a/crates/genie-core/src/llm/openai_compat.rs
+++ b/crates/genie-core/src/llm/openai_compat.rs
@@ -60,6 +60,34 @@ pub struct OpenAiCompatClient {
     port: u16,
     request_profile: RequestProfile,
     timeouts: LlmTimeouts,
+    auth: Option<AuthorizationHeader>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct AuthorizationHeader {
+    value: String,
+}
+
+impl std::fmt::Debug for AuthorizationHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("AuthorizationHeader([redacted])")
+    }
+}
+
+impl AuthorizationHeader {
+    pub(crate) fn bearer(token: impl AsRef<str>) -> Option<Self> {
+        let token = token.as_ref().trim();
+        if token.is_empty() || token.contains(['\r', '\n']) {
+            return None;
+        }
+        Some(Self {
+            value: format!("Bearer {token}"),
+        })
+    }
+
+    fn header_line(&self) -> String {
+        format!("Authorization: {}\r\n", self.value)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -332,6 +360,7 @@ impl OpenAiCompatClient {
             port,
             request_profile,
             timeouts,
+            auth: None,
         }
     }
 
@@ -368,11 +397,32 @@ impl OpenAiCompatClient {
             port,
             request_profile,
             timeouts,
+            auth: None,
         }
     }
 
     pub fn backend_name(&self) -> &str {
         self.backend_name
+    }
+
+    pub(crate) fn with_bearer_token(mut self, token: impl AsRef<str>) -> Self {
+        self.auth = AuthorizationHeader::bearer(token);
+        self
+    }
+
+    pub(crate) fn with_bearer_token_env(mut self, env_var: impl AsRef<str>) -> Self {
+        let env_var = env_var.as_ref().trim();
+        if let Ok(token) = std::env::var(env_var) {
+            self.auth = AuthorizationHeader::bearer(token);
+        }
+        self
+    }
+
+    fn authorization_header(&self) -> String {
+        self.auth
+            .as_ref()
+            .map(AuthorizationHeader::header_line)
+            .unwrap_or_default()
     }
 
     /// Connect to the backend, bounded by the configured connect timeout.
@@ -610,9 +660,10 @@ impl OpenAiCompatClient {
         let (reader, mut writer) = stream.into_split();
 
         let http_req = format!(
-            "POST /v1/chat/completions HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nAccept: text/event-stream\r\n\r\n{}",
+            "POST /v1/chat/completions HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nAccept: text/event-stream\r\n{}\r\n{}",
             addr,
             prepared.body.len(),
+            self.authorization_header(),
             prepared.body,
         );
 
@@ -724,10 +775,11 @@ impl OpenAiCompatClient {
         let (reader, mut writer) = stream.into_split();
 
         let request = format!(
-            "POST {} HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            "POST {} HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{}Connection: close\r\n\r\n{}",
             path,
             addr,
             body.len(),
+            self.authorization_header(),
             body
         );
 
@@ -753,8 +805,10 @@ impl OpenAiCompatClient {
         let (reader, mut writer) = stream.into_split();
 
         let request = format!(
-            "GET {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
-            path, addr
+            "GET {} HTTP/1.1\r\nHost: {}\r\n{}Connection: close\r\n\r\n",
+            path,
+            addr,
+            self.authorization_header()
         );
         self.timed(
             self.timeouts.read,
@@ -1636,7 +1690,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_oversize_content_length() {
-        let addr = spawn_test_listener(|mut conn| async move {
+        let addr = spawn_test_listener(move |mut conn| async move {
             let mut buf = [0u8; 1024];
             let _ = conn.read(&mut buf).await;
             let response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1048576\r\nConnection: close\r\n\r\n";
@@ -1708,6 +1762,53 @@ mod tests {
         let response = read_bounded_http_response(reader, 16 * 1024).await.unwrap();
         assert_eq!(response.status, 200);
         assert_eq!(response.body, r#"{"ok":true}"#);
+    }
+
+    #[tokio::test]
+    async fn bearer_auth_header_is_sent_on_chat_requests() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let addr = spawn_test_listener(|mut conn| async move {
+            let mut buf = [0u8; 4096];
+            let n = conn.read(&mut buf).await.unwrap_or(0);
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            let _ = tx.send(request);
+            let body = r#"{"choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = conn.write_all(response.as_bytes()).await;
+            let _ = conn.shutdown().await;
+        })
+        .await;
+
+        let client = OpenAiCompatClient::from_url_with_profile_and_timeouts(
+            "test-backend",
+            &format!("http://{addr}"),
+            RequestProfile::generic(),
+            LlmTimeouts {
+                connect: Duration::from_secs(2),
+                read: Duration::from_secs(2),
+                request: Duration::from_secs(2),
+            },
+        )
+        .with_bearer_token("oauth-access-token");
+
+        let response = client
+            .chat(
+                &[Message {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                Some(8),
+            )
+            .await
+            .unwrap();
+        let request = rx.await.unwrap();
+
+        assert_eq!(response, "ok");
+        assert!(request.contains("Authorization: Bearer oauth-access-token\r\n"));
     }
 
     #[test]

--- a/crates/genie-core/src/llm/openai_compatible.rs
+++ b/crates/genie-core/src/llm/openai_compatible.rs
@@ -1,0 +1,108 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::openai_compat::{LlmTimeouts, OpenAiCompatClient, RequestProfile};
+use super::{LlmBackendClient, LlmRequestHints, Message, ResponseFormat};
+
+/// Generic OpenAI-compatible adapter for API providers that authenticate with
+/// bearer tokens, including OAuth access tokens.
+pub struct OpenAiCompatibleBackend {
+    inner: OpenAiCompatClient,
+}
+
+impl OpenAiCompatibleBackend {
+    pub fn from_url_with_bearer_token(url: &str, token: impl AsRef<str>) -> Self {
+        Self::from_url_with_bearer_token_and_timeouts(url, token, LlmTimeouts::default())
+    }
+
+    pub fn from_url_with_bearer_token_and_timeouts(
+        url: &str,
+        token: impl AsRef<str>,
+        timeouts: LlmTimeouts,
+    ) -> Self {
+        Self {
+            inner: OpenAiCompatClient::from_url_with_profile_and_timeouts(
+                "openai-compatible",
+                url,
+                RequestProfile::generic(),
+                timeouts,
+            )
+            .with_bearer_token(token),
+        }
+    }
+
+    pub fn from_url_with_bearer_token_env(url: &str, env_var: impl AsRef<str>) -> Self {
+        Self::from_url_with_bearer_token_env_and_timeouts(url, env_var, LlmTimeouts::default())
+    }
+
+    pub fn from_url_with_bearer_token_env_and_timeouts(
+        url: &str,
+        env_var: impl AsRef<str>,
+        timeouts: LlmTimeouts,
+    ) -> Self {
+        Self {
+            inner: OpenAiCompatClient::from_url_with_profile_and_timeouts(
+                "openai-compatible",
+                url,
+                RequestProfile::generic(),
+                timeouts,
+            )
+            .with_bearer_token_env(env_var),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmBackendClient for OpenAiCompatibleBackend {
+    fn backend_name(&self) -> &str {
+        self.inner.backend_name()
+    }
+
+    async fn health(&self) -> bool {
+        self.inner.health().await
+    }
+
+    async fn chat_with_format(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+    ) -> Result<String> {
+        self.inner
+            .chat_with_format(messages, max_tokens, response_format)
+            .await
+    }
+
+    async fn chat_with_format_and_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        response_format: Option<ResponseFormat>,
+        hints: Option<&LlmRequestHints>,
+    ) -> Result<String> {
+        self.inner
+            .chat_with_format_and_hints(messages, max_tokens, response_format, hints)
+            .await
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String> {
+        self.inner.chat_stream(messages, max_tokens, on_token).await
+    }
+
+    async fn chat_stream_with_hints(
+        &self,
+        messages: &[Message],
+        max_tokens: Option<u32>,
+        hints: Option<&LlmRequestHints>,
+        on_token: &mut (dyn for<'a> FnMut(&'a str) + Send),
+    ) -> Result<String> {
+        self.inner
+            .chat_stream_with_hints(messages, max_tokens, hints, on_token)
+            .await
+    }
+}

--- a/crates/genie-core/src/llm/provider.rs
+++ b/crates/genie-core/src/llm/provider.rs
@@ -5,7 +5,9 @@
 //! wired behind the existing LLM facade without violating the limited-context
 //! agent contract.
 
-use genie_common::config::{AgentConfig, OptionalAiProviderConfig, OptionalAiProviderKind};
+use genie_common::config::{
+    AgentConfig, OptionalAiProviderAuthMode, OptionalAiProviderConfig, OptionalAiProviderKind,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProviderReadiness {
@@ -17,8 +19,10 @@ pub enum ProviderReadiness {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OptionalProviderPlan {
     pub provider: OptionalAiProviderKind,
+    pub auth_mode: OptionalAiProviderAuthMode,
     pub base_url: String,
     pub api_key_env: String,
+    pub oauth_token_env: String,
     pub context_window_tokens: u32,
     pub remote_allowed: bool,
 }
@@ -31,8 +35,10 @@ impl OptionalProviderPlan {
 
         Some(Self {
             provider: config.provider,
+            auth_mode: config.auth_mode,
             base_url: config.base_url.clone(),
             api_key_env: config.api_key_env.clone(),
+            oauth_token_env: config.oauth_token_env.clone(),
             context_window_tokens: config.context_window_tokens,
             remote_allowed: config.allow_remote_base_url,
         })
@@ -43,8 +49,11 @@ impl OptionalProviderPlan {
         if self.context_window_tokens > agent.context_window_tokens {
             reasons.push("context_window_exceeds_agent_budget");
         }
-        if self.api_key_env.trim().is_empty() {
-            reasons.push("missing_api_key_env");
+        if self.credential_env().trim().is_empty() {
+            reasons.push(match self.auth_mode {
+                OptionalAiProviderAuthMode::ApiKey => "missing_api_key_env",
+                OptionalAiProviderAuthMode::OAuthBearer => "missing_oauth_token_env",
+            });
         }
         if self.base_url.trim().is_empty() {
             reasons.push("missing_base_url");
@@ -57,6 +66,13 @@ impl OptionalProviderPlan {
             ProviderReadiness::Ready
         } else {
             ProviderReadiness::Blocked(reasons)
+        }
+    }
+
+    pub fn credential_env(&self) -> &str {
+        match self.auth_mode {
+            OptionalAiProviderAuthMode::ApiKey => &self.api_key_env,
+            OptionalAiProviderAuthMode::OAuthBearer => &self.oauth_token_env,
         }
     }
 }
@@ -95,8 +111,10 @@ mod tests {
         let provider = OptionalAiProviderConfig {
             enabled: true,
             provider: OptionalAiProviderKind::OpenAiCompatible,
+            auth_mode: OptionalAiProviderAuthMode::ApiKey,
             base_url: "https://provider.example/v1".into(),
             api_key_env: "GENIE_PROVIDER_KEY".into(),
+            oauth_token_env: "GENIE_PROVIDER_OAUTH_TOKEN".into(),
             context_window_tokens: 8192,
             allow_remote_base_url: false,
         };
@@ -116,13 +134,36 @@ mod tests {
         let provider = OptionalAiProviderConfig {
             enabled: true,
             provider: OptionalAiProviderKind::OpenAiCompatible,
+            auth_mode: OptionalAiProviderAuthMode::ApiKey,
             base_url: "http://127.0.0.1:11434/v1".into(),
             api_key_env: "LOCAL_PROVIDER_KEY".into(),
+            oauth_token_env: "LOCAL_PROVIDER_OAUTH_TOKEN".into(),
             context_window_tokens: 4096,
             allow_remote_base_url: false,
         };
         let plan = OptionalProviderPlan::from_config(&provider).unwrap();
 
+        assert_eq!(
+            plan.readiness(&AgentConfig::default()),
+            ProviderReadiness::Ready
+        );
+    }
+
+    #[test]
+    fn oauth_provider_uses_oauth_token_env_for_readiness() {
+        let provider = OptionalAiProviderConfig {
+            enabled: true,
+            provider: OptionalAiProviderKind::OpenAi,
+            auth_mode: OptionalAiProviderAuthMode::OAuthBearer,
+            base_url: "https://api.openai.com/v1".into(),
+            api_key_env: String::new(),
+            oauth_token_env: "OPENAI_OAUTH_ACCESS_TOKEN".into(),
+            context_window_tokens: 4096,
+            allow_remote_base_url: true,
+        };
+        let plan = OptionalProviderPlan::from_config(&provider).unwrap();
+
+        assert_eq!(plan.credential_env(), "OPENAI_OAUTH_ACCESS_TOKEN");
         assert_eq!(
             plan.readiness(&AgentConfig::default()),
             ProviderReadiness::Ready

--- a/crates/genie-core/src/runtime_boundary.rs
+++ b/crates/genie-core/src/runtime_boundary.rs
@@ -93,7 +93,7 @@ pub fn is_jetson_baseline(agent: &AgentConfig) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use genie_common::config::OptionalAiProviderKind;
+    use genie_common::config::{OptionalAiProviderAuthMode, OptionalAiProviderKind};
 
     #[test]
     fn default_agent_contract_is_jetson_limited_context() {
@@ -122,8 +122,10 @@ mod tests {
         let provider = OptionalAiProviderConfig {
             enabled: true,
             provider: OptionalAiProviderKind::OpenAi,
+            auth_mode: OptionalAiProviderAuthMode::ApiKey,
             base_url: "https://api.openai.com/v1".into(),
             api_key_env: "OPENAI_API_KEY".into(),
+            oauth_token_env: "OPENAI_OAUTH_ACCESS_TOKEN".into(),
             context_window_tokens: 8192,
             allow_remote_base_url: true,
         };

--- a/deploy/config/geniepod.dev.toml
+++ b/deploy/config/geniepod.dev.toml
@@ -14,8 +14,10 @@ home_runtime_boundary = "transitional_adapter"
 [optional_ai_provider]
 enabled = false
 provider = "open_ai_compatible"
+auth_mode = "api_key"
 base_url = ""
 api_key_env = "GENIEPOD_AI_PROVIDER_API_KEY"
+oauth_token_env = "GENIEPOD_AI_PROVIDER_OAUTH_TOKEN"
 context_window_tokens = 4096
 allow_remote_base_url = false
 

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -16,8 +16,10 @@ home_runtime_boundary = "transitional_adapter"  # HA provider today; target is g
 [optional_ai_provider]
 enabled = false
 provider = "open_ai_compatible"   # "open_ai_compatible", "open_ai", "anthropic", "gemini", or "custom".
+auth_mode = "api_key"             # "api_key" or "oauth_bearer" (OAuth access token in oauth_token_env).
 base_url = ""
 api_key_env = "GENIEPOD_AI_PROVIDER_API_KEY"
+oauth_token_env = "GENIEPOD_AI_PROVIDER_OAUTH_TOKEN"
 context_window_tokens = 4096
 allow_remote_base_url = false
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -18,6 +18,7 @@ Runtime load path:
 | Section | Purpose |
 | --- | --- |
 | `data_dir` | Root directory for runtime databases and profile data |
+| `[optional_ai_provider]` | Disabled-by-default API provider planning, including API-key or OAuth bearer auth mode |
 | `[core]` | `genie-core` runtime behavior |
 | `[governor]` | governor polling and day/night behavior |
 | `[governor.pressure]` | memory-pressure thresholds |
@@ -27,6 +28,37 @@ Runtime load path:
 | `[web_search]` | public web search tool behavior |
 | `[connectivity]` | coprocessor boundary enablement |
 | `[connectivity.esp32c6_uart]` | UART transport settings for ESP32-C6 |
+
+## `[optional_ai_provider]`
+
+This path is disabled by default. It records whether a remote or alternate
+OpenAI-compatible provider is eligible for future wiring without changing the
+local Jetson `genie-ai-runtime` default.
+
+| Key | Purpose |
+| --- | --- |
+| `enabled` | Turn optional provider planning on |
+| `provider` | `open_ai_compatible`, `open_ai`, `anthropic`, `gemini`, or `custom` |
+| `auth_mode` | `api_key` for provider keys or `oauth_bearer` for OAuth access tokens |
+| `base_url` | Provider endpoint, for example `https://api.openai.com/v1` |
+| `api_key_env` | Env var that stores an API key when `auth_mode = "api_key"` |
+| `oauth_token_env` | Env var that stores an OAuth access token when `auth_mode = "oauth_bearer"` |
+| `context_window_tokens` | Provider context budget, which must fit the agent budget |
+| `allow_remote_base_url` | Required opt-in for non-loopback provider URLs |
+
+OAuth bearer mode never stores the token in TOML. For an OpenAI OAuth-token
+deployment, use a secret env var and point config at it:
+
+```toml
+[optional_ai_provider]
+enabled = true
+provider = "open_ai"
+auth_mode = "oauth_bearer"
+base_url = "https://api.openai.com/v1"
+oauth_token_env = "OPENAI_OAUTH_ACCESS_TOKEN"
+context_window_tokens = 4096
+allow_remote_base_url = true
+```
 
 ## `[core]`
 


### PR DESCRIPTION
## Summary

Adds OAuth bearer-token support for optional OpenAI/OpenAI-compatible provider planning and the OpenAI-compatible LLM client path. The default local Genie AI Runtime path remains unchanged.

## Changes

- Add `auth_mode = "api_key" | "oauth_bearer"` and `oauth_token_env` to optional AI provider config.
- Route provider readiness and security summaries through the selected credential env without exposing secret values.
- Add bearer Authorization header support to the OpenAI-compatible client and a generic bearer-token backend facade.
- Document the OAuth bearer config path and update sample TOML defaults.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

```bash
cargo fmt --all
cargo test -p genie-common optional_ai_provider
cargo test -p genie-core llm::provider
cargo test -p genie-core bearer_auth_header_is_sent_on_chat_requests
cargo test -p genie-core can_construct_openai_compatible_bearer_client
cargo clippy -p genie-common -p genie-core --all-targets -- -D warnings
```

### What I observed

Config parsing accepts `auth_mode = "oauth_bearer"` with `oauth_token_env`, provider readiness checks the OAuth token env, the OpenAI-compatible client emits `Authorization: Bearer ...` in a captured HTTP request, and clippy passes without warnings. I did not run this on Jetson because the patch is config/client plumbing and leaves the default local `genie-ai-runtime` path unchanged; a live remote provider token was not used in local validation.

## Test plan

- Configure `[optional_ai_provider]` with `auth_mode = "oauth_bearer"` and `oauth_token_env` pointing at a secret env var.
- Verify readiness reports `Ready` only when the provider context fits the agent budget and remote URLs are explicitly allowed.
- Re-run the captured HTTP request test to confirm the bearer header is sent and never logged in support summaries.

## Notes for reviewers

This PR adds the auth/config/client support for bearer-token providers. It does not switch the default runtime away from `genie-ai-runtime`.
