### PR TITLE
fix(http): Harden inbound HTTP request framing in shared parser (strict Content-Length and Transfer-Encoding validation)

### DIFF
--- a/crates/genie-common/src/http.rs
+++ b/crates/genie-common/src/http.rs
@@ -115,6 +115,10 @@ pub enum HttpReadError {
     HeadersTooLarge,
     /// The declared `Content-Length` exceeded `max_body_bytes`.
     BodyTooLarge,
+    /// `Content-Length` was malformed, duplicated, or otherwise invalid.
+    InvalidContentLength,
+    /// Inbound request used unsupported `Transfer-Encoding`.
+    UnsupportedTransferEncoding,
     /// A low-level I/O error (including a truncated body).
     Io(std::io::Error),
 }
@@ -129,6 +133,9 @@ impl HttpReadError {
             | HttpReadError::TooManyHeaders
             | HttpReadError::HeadersTooLarge => Some(431),
             HttpReadError::BodyTooLarge => Some(413),
+            HttpReadError::InvalidContentLength | HttpReadError::UnsupportedTransferEncoding => {
+                Some(400)
+            }
             // A read timeout, a vanished peer, garbage, or a socket error: there
             // is no point (or it is unsafe against a stalled peer) writing a
             // status line, so close the connection instead.
@@ -151,6 +158,10 @@ impl std::fmt::Display for HttpReadError {
             HttpReadError::TooManyHeaders => write!(f, "too many headers"),
             HttpReadError::HeadersTooLarge => write!(f, "headers too large"),
             HttpReadError::BodyTooLarge => write!(f, "request body too large"),
+            HttpReadError::InvalidContentLength => write!(f, "invalid content-length"),
+            HttpReadError::UnsupportedTransferEncoding => {
+                write!(f, "unsupported transfer-encoding")
+            }
             HttpReadError::Io(e) => write!(f, "io error: {e}"),
         }
     }
@@ -200,6 +211,7 @@ where
     // Headers.
     let mut headers: Vec<(String, String)> = Vec::new();
     let mut content_length: usize = 0;
+    let mut saw_content_length = false;
     let mut total_header_bytes: usize = 0;
     loop {
         if headers.len() >= limits.max_header_count {
@@ -228,7 +240,17 @@ where
             let name = name.trim().to_ascii_lowercase();
             let value = value.trim().to_string();
             if name == "content-length" {
-                content_length = value.parse().unwrap_or(0);
+                if saw_content_length {
+                    return Err(HttpReadError::InvalidContentLength);
+                }
+                let parsed = value
+                    .parse::<usize>()
+                    .map_err(|_| HttpReadError::InvalidContentLength)?;
+                content_length = parsed;
+                saw_content_length = true;
+            } else if name == "transfer-encoding" && !value.is_empty() {
+                // Inbound chunked/TE requests are not supported by this reader.
+                return Err(HttpReadError::UnsupportedTransferEncoding);
             }
             headers.push((name, value));
         }
@@ -668,6 +690,33 @@ mod tests {
         let err = read_request(&mut reader, &limits).await.unwrap_err();
         assert!(matches!(err, HttpReadError::BodyTooLarge));
         assert_eq!(err.status_code(), Some(413));
+    }
+
+    #[tokio::test]
+    async fn invalid_content_length_is_rejected_with_400() {
+        let raw = "POST /api/chat HTTP/1.1\r\nContent-Length: abc\r\n\r\n";
+        let mut reader = reader_for(raw.as_bytes());
+        let err = read_request(&mut reader, &test_limits()).await.unwrap_err();
+        assert!(matches!(err, HttpReadError::InvalidContentLength));
+        assert_eq!(err.status_code(), Some(400));
+    }
+
+    #[tokio::test]
+    async fn duplicate_content_length_is_rejected_with_400() {
+        let raw = "POST /api/chat HTTP/1.1\r\nContent-Length: 5\r\nContent-Length: 0\r\n\r\nhello";
+        let mut reader = reader_for(raw.as_bytes());
+        let err = read_request(&mut reader, &test_limits()).await.unwrap_err();
+        assert!(matches!(err, HttpReadError::InvalidContentLength));
+        assert_eq!(err.status_code(), Some(400));
+    }
+
+    #[tokio::test]
+    async fn transfer_encoding_request_is_rejected_with_400() {
+        let raw = "POST /api/chat HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n";
+        let mut reader = reader_for(raw.as_bytes());
+        let err = read_request(&mut reader, &test_limits()).await.unwrap_err();
+        assert!(matches!(err, HttpReadError::UnsupportedTransferEncoding));
+        assert_eq!(err.status_code(), Some(400));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related issues
Closes #238 

## Summary

This PR hardens the shared inbound HTTP parser used by both `genie-core` and `genie-api` to fail closed on malformed request framing. It fixes the issue documented in `issue.md` by rejecting invalid/duplicate `Content-Length` and unsupported inbound `Transfer-Encoding`, preventing ambiguous body parsing at gateway boundaries.

## Changes

- Added new parser errors in `crates/genie-common/src/http.rs`:
  - `InvalidContentLength`
  - `UnsupportedTransferEncoding`
- Mapped malformed framing cases to explicit `400 Bad Request` responses via `HttpReadError::status_code()`.
- Enforced strict `Content-Length` rules in `read_request_inner()`:
  - reject non-numeric `Content-Length`
  - reject duplicate `Content-Length` headers
- Enforced strict inbound `Transfer-Encoding` policy in `read_request_inner()`:
  - reject requests that send non-empty `Transfer-Encoding` (unsupported by current inbound parser path)
- Added regression tests:
  - `invalid_content_length_is_rejected_with_400`
  - `duplicate_content_length_is_rejected_with_400`
  - `transfer_encoding_request_is_rejected_with_400`

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

- Environment: Windows 10 workstation (`laptop` profile for development checks).
- Ran local static verification:
  - IDE lint/diagnostic check on edited file:
    - `crates/genie-common/src/http.rs`
- Attempted local test execution:
  - `cargo test -p genie-common http::tests -- --nocapture`
- Validation gap:
  - Rust toolchain (`cargo`) was not available on this machine PATH, so test binary execution could not be completed here.

### What I observed

- Parser behavior was updated in code to reject malformed request framing before routing:
  - invalid `Content-Length` now returns `HttpReadError::InvalidContentLength` -> `400`
  - duplicate `Content-Length` now returns `HttpReadError::InvalidContentLength` -> `400`
  - inbound `Transfer-Encoding` now returns `HttpReadError::UnsupportedTransferEncoding` -> `400`
- New regression tests were added for the above paths in the shared parser test module.
- IDE diagnostics reported no linter errors on the edited file.
- Test-run limitation observed:
  - command failure: `cargo` not recognized (toolchain missing on PATH).

## Test plan

- Build and run parser tests on a machine with Rust toolchain installed:
  - `cargo test -p genie-common http::tests -- --nocapture`
- Manual protocol checks against `genie-core` or `genie-api`:
  - send `Content-Length: abc` -> expect `HTTP/1.1 400 Bad Request`
  - send two `Content-Length` headers -> expect `HTTP/1.1 400 Bad Request`
  - send `Transfer-Encoding: chunked` request -> expect `HTTP/1.1 400 Bad Request`
- Regression sanity:
  - send valid `POST` with one numeric `Content-Length` and body -> expect normal route handling (non-400).

## Notes for reviewers

- This is intentionally strict/fail-closed for inbound request framing in the hand-rolled parser used by both servers.
- Current scope rejects inbound `Transfer-Encoding` rather than implementing chunked request-body decoding; if chunked inbound support is needed later, it should be added with explicit bounded decoding and dedicated tests.