### PR TITLE
test(health): reject non-HTTP TCP banner in check_http probe

### DIFF
--- a/crates/genie-health/src/checker.rs
+++ b/crates/genie-health/src/checker.rs
@@ -491,6 +491,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn check_http_rejects_non_http_tcp_banner() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}/health");
+
+        let server = tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let mut buf = [0u8; 512];
+                let _ = stream.read(&mut buf).await;
+                let _ = stream.write_all(b"SSH-2.0-OpenSSH_9.0\r\n").await;
+            }
+        });
+
+        let status = check_http("llm", &url).await;
+        server.abort();
+
+        assert!(
+            !status.healthy,
+            "non-HTTP TCP banner should be reported unhealthy"
+        );
+        assert!(
+            status
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("invalid HTTP response")),
+            "expected invalid HTTP error, got: {:?}",
+            status.error
+        );
+    }
+
+    #[tokio::test]
     async fn send_http_post_rejects_non_http_tcp_banner() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
## Summary

Fixes #185 — adds regression test ensuring `check_http()` reports unhealthy when a service endpoint returns a non-HTTP TCP payload (e.g. SSH banner). On `main`, `check_http()` already delegates to `genie_common::probe_configured_url`, which rejects invalid HTTP; this test guards against regressions.

## Changes

- Add `check_http_rejects_non_http_tcp_banner` — mock TCP listener returning `SSH-2.0-OpenSSH_9.0` → `healthy: false`, error contains `invalid HTTP response`

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On x86_64 Linux dev host (`laptop` profile), branch `fix/issue-185-check-http-invalid-response`:

```bash
cargo fmt -p genie-health
cargo test -p genie-health check_http_rejects_non_http_tcp_banner
cargo test -p genie-health
cargo clippy -p genie-health -- -D warnings
```

### What I observed

- `check_http_rejects_non_http_tcp_banner` passed — mock SSH banner probe returns `healthy: false` with `invalid HTTP response` in the error field
- Full `cargo test -p genie-health`: 11 passed, 0 failed
- `cargo clippy -p genie-health -- -D warnings`: clean (no warnings)

This change is test-only; runtime behavior is already correct on `main` via `probe_configured_url`. No Jetson-specific path (voice/audio/HA) is affected.

## Test plan

- [x] `cargo test -p genie-health check_http_rejects_non_http_tcp_banner`
- [x] `cargo test -p genie-health`
- [x] `cargo clippy -p genie-health -- -D warnings`

## Notes for reviewers

Test-only PR. The original #185 behavioral fix landed on `main` when `check_http` was refactored to use `genie_common::probe_configured_url`. This closes #185 with explicit regression coverage.