### PR TITLE
docs: align repo with low-latency private home-agent goal

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,7 +17,11 @@ It sits below:
 - installer/operator tools
 - future household and developer-facing product surfaces
 
-The purpose of this repo is to make the local home AI useful, private, safe, and understandable. It should not grow into the OS, the full home automation engine, the CUDA inference runtime, or the product app.
+The purpose of this repo is to make the local home AI useful, private, safe,
+low-latency, and understandable. Accuracy should come from the right family
+memory, current home context, typed device state, and deterministic tools. It
+should not grow into the OS, the full home automation engine, the CUDA
+inference runtime, or the product app.
 
 The architectural invariant is now enforced in code as well as docs:
 
@@ -26,8 +30,9 @@ The architectural invariant is now enforced in code as well as docs:
   and optional-provider context against the Jetson 4096-token baseline.
 - `[agent]` selects the deployment profile while keeping `jetson` as the
   flagship default.
-- `[optional_ai_provider]` is opt-in and cannot become a production candidate
-  unless it remains limited-context compatible.
+- `[optional_ai_provider]` is opt-in and exists for testing, development
+  portability, and transitional validation only. It cannot bypass the
+  limited-context home-agent contract.
 
 ## Ecosystem Stack
 
@@ -40,7 +45,7 @@ GenieClaw Agent Layer
 
 Runtime Layer
   genie-voice-runtime: wake, VAD, STT, TTS, audio streaming
-  genie-home-runtime: device graph, automations, actuation safety, MCP
+  genie-home-runtime: local device graph, IoT adapters, automations, actuation safety, MCP
   genie-ai-runtime: Jetson-only LLM inference, CUDA kernels, model serving
 
 GenieOS Layer
@@ -68,7 +73,7 @@ The repo should optimize for repeated daily usefulness:
 
 - remember useful household context
 - answer and act quickly on Jetson-class hardware
-- control the home through a bounded runtime contract
+- control the home through a bounded local runtime contract
 - explain what happened
 - work when the internet is down
 
@@ -91,9 +96,9 @@ The current repo still contains pragmatic adapters used to ship on Jetson now.
 
 | Current adapter | Target boundary | Notes |
 | --- | --- | --- |
-| `genie-ai-runtime` OpenAI-compatible client (default on Jetson) | external `genie-ai-runtime` service | `llama.cpp` remains a selectable fallback/development backend. Both backends ship behind the `LlmClient` facade; per-deployment selection is via `[services.llm].backend` in `geniepod.toml`. Backend identity surfaces in `/api/health`, startup logs, and `genie-ctl status`. |
+| `genie-ai-runtime` OpenAI-compatible client (default on Jetson) | external `genie-ai-runtime` service | `llama.cpp` remains a selectable fallback/development backend. Both local backends ship behind the `LlmClient` facade; per-deployment selection is via `[services.llm].backend` in `geniepod.toml`. Backend identity surfaces in `/api/health`, startup logs, and `genie-ctl status`. |
 | In-repo voice pipeline under `crates/genie-core/src/voice/` and `voice_loop.rs` | [`genie-voice-runtime`](https://github.com/GeniePod/genie-voice-runtime) | Keep current code as a transitional Jetson bring-up path. New wake/VAD/STT/TTS/audio ownership should move to the external runtime. GenieClaw should consume transcripts and issue speak commands. |
-| Home Assistant provider | `genie-home-runtime` MCP/API client | Keep HA-specific behavior behind `ha/` and tools/home boundaries. |
+| Home Assistant provider | `genie-home-runtime` MCP/API client | Keep HA-specific behavior behind `ha/` and tools/home boundaries. Home Assistant is a transitional provider while the native local device graph and IoT boundary mature. |
 | Actuation safety in `genie-core` | final safety in `genie-home-runtime` | Keep current safety as an agent-side guard and confirmation layer. |
 | `genie-api` dashboard | application layer | Keep it operational and lightweight; avoid making it the long-term product app. |
 | `genie-governor` service lifecycle | GenieOS/system supervisor | Keep it useful for Jetson bring-up while OS ownership matures. |
@@ -214,9 +219,9 @@ contract portable enough for development and review on non-Jetson hardware.
 
 ## Optional Providers
 
-API-key AI providers are optional provider boundaries, not the default product
-runtime. They must satisfy all of these before being treated as production
-paths:
+API-key, OAuth-bearer, and OpenAI-compatible AI providers are optional
+development and transitional validation boundaries, not the product runtime.
+They must satisfy all of these before being used for serious test coverage:
 
 - configured under `[optional_ai_provider]`, disabled by default
 - API key comes from an environment variable, not the TOML value itself
@@ -225,8 +230,26 @@ paths:
 - prompt/tool/memory budget passes `genie_core::agent_harness`
 
 The flagship path remains local `genie-ai-runtime` on Jetson. Optional providers
-exist to make development, CI, and non-Jetson deployments easier without
-weakening the limited-context home-agent contract.
+exist to make development, CI, and non-Jetson testing easier during the
+transition. They must not become a reason to increase context by default, send
+household memory remotely by default, or weaken the limited-context home-agent
+contract.
+
+## Low-Latency Home Harness
+
+The harness should optimize for small, high-signal context rather than larger
+model inputs. A normal turn should assemble only:
+
+- compact policy and role instructions
+- the relevant family/speaker context
+- top-k memory facts
+- current room or device graph slice
+- recent action summary when it helps explain or undo behavior
+- the smallest useful tool manifest
+
+The LLM should not receive raw history, every memory, or stale device state.
+The agent should use deterministic quick routes and typed tools for repeated
+daily tasks before spending model tokens.
 
 ## Memory Ownership
 
@@ -280,9 +303,10 @@ The clean architecture path is incremental:
 
 1. Make boundary language consistent in docs and config.
 2. Keep Home Assistant and LLM backends behind narrow adapter traits (LLM side resolved via the `LlmClient` facade in `crates/genie-core/src/llm/`).
-3. Move physical actuation authority downward into `genie-home-runtime` when it exists.
-4. Keep Jetson model-server specialization in `genie-ai-runtime`.
-5. Move voice/audio pipeline ownership downward into `genie-voice-runtime`.
-6. Keep GenieClaw focused on agent policy, memory, skills, tools, channels, and household interaction.
+3. Tune the prompt/memory/tool harness for low-latency household context.
+4. Move physical actuation authority and direct local IoT/device graph ownership downward into `genie-home-runtime` when it exists.
+5. Keep Jetson model-server specialization in `genie-ai-runtime`.
+6. Move voice/audio pipeline ownership downward into `genie-voice-runtime`.
+7. Keep GenieClaw focused on agent policy, memory, skills, tools, channels, and household interaction.
 
 This prevents the agent repo from becoming a single large mixed runtime while still allowing today’s Jetson appliance to keep working.

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -44,8 +44,9 @@ The most important runtime path is:
 1. A request enters through the web UI, CLI, REPL, voice loop, or Telegram adapter.
 2. `genie-core` builds prompt context from conversation history and household memory.
 3. The LLM facade talks to the configured OpenAI-compatible backend. Jetson
-   deploys default to `genie-ai-runtime`; development configs can still use a
-   local `llama.cpp` server.
+   deploys default to local `genie-ai-runtime`; development configs can still
+   use a local `llama.cpp` server. Remote/API providers are transitional
+   testing adapters only.
 4. If the model emits a tool call, the tool parser and dispatcher execute the tool.
 5. Tool results may be returned directly or summarized, depending on the tool.
 6. Conversation state and extracted memory are persisted to SQLite.
@@ -115,8 +116,8 @@ The primary runtime. This is where most product behavior lives.
 | `crates/genie-core/src/llm/openai_compat.rs` | Raw bounded OpenAI-compatible HTTP client used by local and optional provider backends. |
 | `crates/genie-core/src/llm/genie_ai_runtime.rs` | Adapter for the default Jetson `genie-ai-runtime` backend and its request hints. |
 | `crates/genie-core/src/llm/llama_cpp.rs` | Adapter for the legacy/development `llama.cpp` backend. |
-| `crates/genie-core/src/llm/openai_compatible.rs` | Generic OpenAI-compatible provider adapter with bearer-token support. |
-| `crates/genie-core/src/llm/provider.rs` | Optional provider planning and limited-context readiness checks. |
+| `crates/genie-core/src/llm/openai_compatible.rs` | Generic OpenAI-compatible provider adapter with bearer-token support for development/testing validation. |
+| `crates/genie-core/src/llm/provider.rs` | Optional provider planning and limited-context readiness checks for transitional provider validation. |
 
 #### Home Assistant Integration
 

--- a/CONNECTIVITY.md
+++ b/CONNECTIVITY.md
@@ -1,6 +1,12 @@
 # ESP32-C6 Connectivity Boundary
 
-Design note for how `genie-core` should talk to an ESP32-C6 without turning the assistant runtime into a Linux network driver stack.
+Design note for how `genie-core` should talk to an ESP32-C6 without turning the
+assistant runtime into a Linux network driver stack.
+
+The product goal is still direct local wireless/IoT integration for a private
+home agent. The boundary here says where that work belongs: GenieClaw should
+see typed local capabilities, health, and device/control surfaces; lower layers
+should own radios, Linux interfaces, and protocol stacks.
 
 This document replaces the earlier SPI-first draft.
 
@@ -37,6 +43,10 @@ That split keeps `genie-core` focused on product behavior instead of bus bring-u
 
 If the Jetson should see a normal Wi-Fi or Bluetooth adapter, that is an OS concern, not a chat-runtime concern.
 
+If the user intent should become a safe home action, that should flow through
+GenieClaw's tool/policy/audit layer and then a typed home-runtime boundary, not
+raw wireless commands inside a prompt path.
+
 ## Current `genie-core` Scope
 
 In this repository, connectivity means:
@@ -44,6 +54,8 @@ In this repository, connectivity means:
 - optional ESP32-C6 sidecar over UART
 - health and diagnostics surface in `genie-core`
 - future small control-plane RPCs if product features need them
+- future typed IoT capability summaries that help the home-agent harness choose
+  safe tools without exposing raw radio internals
 
 It does not mean:
 
@@ -161,6 +173,8 @@ Bad candidates:
 - Linux interface creation
 - Bluetooth host stack ownership
 - large streaming payloads better handled by OS services
+- raw Matter/Thread/Zigbee/BLE actuation paths that should belong to
+  `genie-home-runtime` or lower connectivity services
 
 ## What Not To Do
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -4,6 +4,11 @@ This guide covers the current development and Jetson bring-up paths. The
 production Jetson default is `genie-ai-runtime`; the development config still
 uses any local OpenAI-compatible `llama.cpp` server on `:8080`.
 
+OpenAI-compatible API providers and other remote/alternate providers are for
+testing, development portability, and transitional validation only. The product
+path remains a private, low-latency, on-device home agent with limited context,
+family memory, typed tools, and local IoT/home-runtime boundaries.
+
 ## Option A: Development Machine
 
 Prerequisites:

--- a/LOW_LATENCY_HOME_AGENT.md
+++ b/LOW_LATENCY_HOME_AGENT.md
@@ -1,0 +1,173 @@
+# Low-Latency Private Home Agent Goal
+
+This repository is moving toward one product goal:
+
+GenieClaw should be the low-latency, limited-context, on-device AI harness for a
+private household agent. Accuracy should come from the right home context, typed
+memory, deterministic tools, and local device state, not from sending bigger
+prompts to a bigger remote model.
+
+## Product Target
+
+The flagship target is GeniePod Home on Jetson-class hardware.
+
+The agent should:
+
+- answer quickly on local hardware
+- stay useful inside a small context window
+- preserve household privacy by default
+- remember family and household facts as structured local memory
+- control IoT devices through typed local interfaces
+- degrade gracefully without the internet
+- expose audit, confirmation, and memory-management surfaces to the household
+
+Cloud or remote model providers are not the product default. OpenAI-compatible
+API providers, OpenAI, Anthropic, Gemini, custom providers, and similar adapters
+exist only for better testing, development portability, and transitional
+validation while the local runtime and harness mature.
+
+## Context Strategy
+
+The default Jetson contract remains 4096 tokens, but ordinary turns should use
+less than that whenever possible.
+
+The harness should prefer:
+
+- compact system prompt
+- short tool manifest
+- top-k relevant memory facts
+- current room/device state
+- recent action state
+- small response reserve
+- deterministic fast paths for obvious utility requests
+
+The harness should avoid:
+
+- dumping raw conversation history
+- injecting every memory
+- carrying stale room/device facts
+- using large remote context as a shortcut
+- making the model infer state that a typed tool already knows
+
+## Home Context Harness
+
+The home context passed to the model should be curated and explicit.
+
+Recommended shape:
+
+```text
+agent policy
+family identity and speaker context
+top relevant memories
+current room or device graph slice
+recent action summary
+available tools and confirmation policy
+user request
+```
+
+This keeps prompts small and makes answers more accurate. The model should see
+only the context needed for the current turn.
+
+## Family Memory
+
+Household memory is a first-class local subsystem.
+
+Memory should be:
+
+- local by default
+- structured with scope, sensitivity, and spoken policy
+- editable and forgettable by the household
+- retrieved by relevance, not dumped wholesale
+- safe for shared-room voice responses
+- independent of any particular LLM provider
+
+The memory path should optimize for high-signal facts:
+
+- names and family roles
+- preferences
+- recurring routines
+- household device aliases
+- safe durable facts
+- recent actions that help explain what happened
+
+Secrets, credentials, one-time codes, payment details, and hostile-user security
+decisions do not belong in ordinary agent memory.
+
+## Direct Local IoT Direction
+
+The long-term home-control path should be direct, local, and AI-friendly.
+
+GenieClaw should not become a wireless driver stack, but it should integrate
+with a first-party local device graph and actuation boundary. The target split
+is:
+
+- `genie-os` owns radios, Linux interfaces, drivers, and service supervision.
+- `genie-home-runtime` owns device graph, Matter/Thread/Zigbee/BLE adapters,
+  automations, and final physical actuation safety.
+- `genie-claw` owns user intent, memory, policy, confirmations, audit, and
+  tool routing.
+
+Home Assistant is useful today as a transitional provider. It should stay behind
+a provider boundary so it can be replaced by the native home runtime without
+rewriting prompt, memory, or channel code.
+
+## Latency Rules
+
+Low latency is a product requirement.
+
+Prioritize:
+
+- local `genie-ai-runtime`
+- prompt-prefix reuse and stable prompt hashes
+- short history windows
+- fast deterministic routing before LLM calls
+- hot local STT/TTS services when voice is enabled
+- bounded read/request timeouts
+- tool execution over model-only reasoning for known facts
+
+Do not optimize by:
+
+- raising context size by default
+- enabling remote providers by default
+- adding heavyweight retrieval to every request
+- making voice or chat wait for optional services
+- coupling core chat availability to wireless bring-up
+
+## Provider Policy
+
+Optional AI providers are transitional development and testing tools.
+
+They are useful for:
+
+- CI and contributor validation without Jetson hardware
+- comparing tool-call behavior
+- testing OAuth/API-key plumbing
+- debugging context-budget and streaming behavior
+- validating that the harness remains provider-agnostic
+
+They are not:
+
+- the default product path
+- a replacement for local `genie-ai-runtime`
+- a reason to increase default context
+- a place to send household memory by default
+- a way around local privacy and actuation policy
+
+Any provider path must pass the same limited-context harness before it is used
+for serious validation.
+
+## Acceptance Direction
+
+Future PRs should move the system toward:
+
+- smaller active prompt inputs for common turns
+- better memory selection instead of larger memory injection
+- more deterministic home intent routing
+- local device graph and wireless/IoT boundaries
+- stronger audit and confirmation behavior
+- better Jetson latency proof
+- portable test harnesses that do not weaken the final on-device product
+
+The long-term result should be a private, on-device, home-native agent that is
+fast because it knows the household context, not because it depends on a remote
+general-purpose assistant.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 [![Jetson cross-compile](https://github.com/GeniePod/genie-claw/actions/workflows/cross.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/cross.yml)
 [![Audit](https://github.com/GeniePod/genie-claw/actions/workflows/audit.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/audit.yml)
 
-**Limited-context AI harness for agentic smart homes: portable across SBCs and
-native to GeniePod Home.**
+**Low-latency, limited-context AI harness for private on-device homes: portable
+across SBCs and native to GeniePod Home.**
 
 GenieClaw is the Rust agent layer for GeniePod Home. It is built for small local
 models, tight VRAM budgets, and a 4096-token Jetson baseline. This repo owns
 prompt assembly, memory, tool routing, smart-home intent, safety policy, audit,
 and channel/session adapters.
+
+The product goal is a private household agent that is fast because it receives
+the right family memory, room/device state, and safety context, not because it
+sends large prompts to a remote model.
 
 GenieClaw is not the voice pipeline, the LLM runtime, the OS, the final
 home-control runtime, or the product app layer.
@@ -27,7 +31,7 @@ first.
 | Agent layer | `genie-claw` | Prompt policy, limited-context harness, memory, tools, skills, smart-home intent, safety, audit, channels |
 | LLM runtime | [`genie-ai-runtime`](https://github.com/GeniePod/genie-ai-runtime) | Jetson-first local inference runtime; `llama.cpp` remains selectable |
 | Voice runtime | [`genie-voice-runtime`](https://github.com/GeniePod/genie-voice-runtime) | Wake, VAD, STT, TTS, audio streaming, voice session protocol |
-| Home runtime | `genie-home-runtime` | Planned AI-native device graph and final actuation gate |
+| Home runtime | `genie-home-runtime` | Planned AI-native device graph, local IoT boundary, and final actuation gate |
 | Home Assistant | Transitional provider | Current integration target until `genie-home-runtime` exists |
 | OS and apps | External layers | `genie-os`, web, and mobile surfaces stay outside this repo |
 
@@ -51,7 +55,7 @@ genie-ai-runtime   Home Assistant today
 - local chat through `genie-core`
 - transitional voice-session adapter while voice moves to `genie-voice-runtime`
 - LLM backend facade for `genie-ai-runtime` and selectable `llama.cpp`
-- SQLite conversation history and household memory
+- SQLite conversation history and policy-aware family/household memory
 - Home Assistant adapter with confirmations, rate limits, and audit logging
 - local HTTP API, dashboard, CLI, health service, and governor service
 - optional `web_search` tool with DuckDuckGo or SearXNG
@@ -65,11 +69,12 @@ Current workspace version: `v1.0.0-alpha.9`.
 
 ## Current Focus
 
-- keep the agent reliable inside a 4096-token Jetson context
-- harden prompt, memory, tool, and safety contracts
+- keep the agent fast and reliable inside a 4096-token Jetson context
+- tune the AI harness around high-signal home context, family memory, and typed tools
+- improve accuracy through deterministic device state and memory retrieval, not larger prompts
 - split long-term wake/VAD/STT/TTS ownership into `genie-voice-runtime`
 - keep Home Assistant behind a provider boundary until `genie-home-runtime`
-- allow optional API-key providers only when they pass the same limited-context harness
+- use optional API/OAuth providers only for testing, development portability, and transitional validation
 - keep development usable on SBCs, laptops, and Macs without making Jetson less native
 
 ## Agent Contract
@@ -86,9 +91,10 @@ The repo now has explicit code-level contract surfaces for the new direction:
   cache metadata to runtimes that understand the `nvext` extension.
 - `[agent]` in `geniepod.toml` selects the runtime profile:
   `jetson`, `raspberry_pi`, `portable_sbc`, `laptop`, or `mac`.
-- `[optional_ai_provider]` is disabled by default. API-key and OAuth-bearer
-  providers must keep their configured context at or below
-  `[agent].context_window_tokens` before they are production candidates.
+- `[optional_ai_provider]` is disabled by default. API-key, OAuth-bearer, and
+  other remote/alternate providers exist only for better testing, development
+  portability, and transitional validation; they must keep their configured
+  context at or below `[agent].context_window_tokens`.
 
 ## Quick Start
 
@@ -118,6 +124,7 @@ For Jetson setup, deployment, and Home Assistant wiring, use
 ## Documentation
 
 - [`GETTING_STARTED.md`](GETTING_STARTED.md) - local dev, Docker, Jetson bring-up, and deploy
+- [`LOW_LATENCY_HOME_AGENT.md`](LOW_LATENCY_HOME_AGENT.md) - product goal for the low-latency private home harness
 - [`ARCHITECTURE.md`](ARCHITECTURE.md) - Genie ecosystem boundaries
 - [`doc/README.md`](doc/README.md) - documentation map
 - [`doc/implementation-status.md`](doc/implementation-status.md) - implemented, partial, external, and planned work

--- a/VECTOR_MEMORY.md
+++ b/VECTOR_MEMORY.md
@@ -1,6 +1,7 @@
 # Vector Memory Design
 
-Design note for adding semantic retrieval to GenieClaw without breaking the current Jetson-first architecture.
+Design note for adding semantic retrieval to GenieClaw without breaking the
+current Jetson-first, low-latency home-agent architecture.
 
 This document answers a specific question:
 
@@ -19,6 +20,7 @@ GenieClaw should instead:
 3. treat GPU vector search as an optional backend
 4. prefer borrowing ideas and interface patterns before copying code
 5. only reuse code in small, auditable pieces with preserved license notices
+6. inject fewer, better family/household facts instead of increasing prompt size
 
 This keeps the appliance path stable on Jetson while still allowing higher-end vector retrieval later.
 
@@ -316,6 +318,10 @@ For a semantic-enabled memory query:
 8. inject only the short, high-signal results into prompt context
 
 The core design point is that vector search returns candidates. GenieClaw still owns the final ranking.
+
+Semantic retrieval must serve the low-latency home harness. It is successful
+only if it improves the quality of the few facts injected into context; it
+should not become an excuse to send more memory to the model.
 
 ## Code Reuse Policy
 

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -266,8 +266,9 @@ pub struct AgentConfig {
     #[serde(default)]
     pub runtime_profile: AgentRuntimeProfile,
 
-    /// Non-negotiable context budget for the Jetson baseline. Stronger models
-    /// may adapt upward later, but production paths must pass this budget first.
+    /// Non-negotiable context budget for the Jetson baseline. Low latency and
+    /// accuracy should come from high-signal home context, family memory, and
+    /// typed tools before any path adapts upward.
     #[serde(default = "defaults::agent_context_window_tokens")]
     pub context_window_tokens: u32,
 
@@ -321,8 +322,9 @@ pub enum RuntimeBoundaryMode {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct OptionalAiProviderConfig {
-    /// API-key provider support is opt-in and must not change the default
-    /// Jetson local binary path.
+    /// API/OAuth provider support is opt-in for development, testing, and
+    /// transitional validation. It must not change the default Jetson local
+    /// product path.
     #[serde(default)]
     pub enabled: bool,
 
@@ -351,8 +353,8 @@ pub struct OptionalAiProviderConfig {
     #[serde(default = "defaults::optional_ai_provider_oauth_token_env")]
     pub oauth_token_env: String,
 
-    /// Provider path must pass the same limited-context harness before it is
-    /// promoted. Keep this at or below [agent].context_window_tokens.
+    /// Provider path must pass the same limited-context harness before serious
+    /// validation. Keep this at or below [agent].context_window_tokens.
     #[serde(default = "defaults::agent_context_window_tokens")]
     pub context_window_tokens: u32,
 
@@ -366,7 +368,7 @@ impl OptionalAiProviderConfig {
         !self.enabled || self.context_window_tokens <= agent.context_window_tokens
     }
 
-    pub fn production_candidate(&self, agent: &AgentConfig) -> bool {
+    pub fn transitional_test_candidate(&self, agent: &AgentConfig) -> bool {
         self.enabled
             && self.limited_context_compatible(agent)
             && !self.credential_env().trim().is_empty()
@@ -1742,7 +1744,7 @@ home_runtime_boundary = "external_runtime"
         assert!(
             !config
                 .optional_ai_provider
-                .production_candidate(&config.agent)
+                .transitional_test_candidate(&config.agent)
         );
     }
 
@@ -1762,7 +1764,7 @@ allow_remote_base_url = true
         .unwrap();
 
         assert!(!provider.limited_context_compatible(&agent));
-        assert!(!provider.production_candidate(&agent));
+        assert!(!provider.transitional_test_candidate(&agent));
     }
 
     #[test]
@@ -1783,7 +1785,7 @@ allow_remote_base_url = true
 
         assert_eq!(provider.auth_mode, OptionalAiProviderAuthMode::OAuthBearer);
         assert_eq!(provider.credential_env(), "OPENAI_OAUTH_ACCESS_TOKEN");
-        assert!(provider.production_candidate(&agent));
+        assert!(provider.transitional_test_candidate(&agent));
     }
 
     #[test]
@@ -1802,7 +1804,7 @@ allow_remote_base_url = false
         .unwrap();
 
         assert!(provider.limited_context_compatible(&agent));
-        assert!(!provider.production_candidate(&agent));
+        assert!(!provider.transitional_test_candidate(&agent));
     }
 
     #[test]

--- a/crates/genie-core/src/agent_harness.rs
+++ b/crates/genie-core/src/agent_harness.rs
@@ -2,7 +2,9 @@
 //!
 //! The goal is to keep prompt, tools, memory hydration, safety, and optional
 //! provider paths usable inside the Jetson 4096-token baseline before any
-//! deployment opts into a larger adaptive context.
+//! deployment opts into a larger adaptive context. Low latency and answer
+//! quality should come from selecting the right home context, not from widening
+//! prompts by default.
 
 use genie_common::config::{AgentConfig, OptionalAiProviderConfig};
 use serde::Serialize;
@@ -12,7 +14,7 @@ use crate::tools::dispatch::ToolDef;
 
 pub const RESPONSE_RESERVE_TOKENS: usize = 512;
 pub const TOOL_MANIFEST_BUDGET_TOKENS: usize = 900;
-pub const MEMORY_HYDRATION_BUDGET_TOKENS: usize = 900;
+pub const MEMORY_HYDRATION_BUDGET_TOKENS: usize = 700;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct HarnessCheck {
@@ -145,6 +147,7 @@ mod tests {
 
         assert!(report.pass, "{:?}", report.checks);
         assert!(report.estimated_total_tokens < 4096);
+        assert_eq!(MEMORY_HYDRATION_BUDGET_TOKENS, 700);
     }
 
     #[test]

--- a/crates/genie-core/src/runtime_boundary.rs
+++ b/crates/genie-core/src/runtime_boundary.rs
@@ -1,8 +1,9 @@
 //! Runtime boundary contracts for the GenieClaw agent layer.
 //!
-//! GenieClaw owns agent policy, prompt assembly, memory, tools, channels, and
-//! audit. It consumes lower runtime contracts for inference, voice I/O, and
-//! physical home control; it should not grow into those runtimes.
+//! GenieClaw owns agent policy, prompt assembly, family memory, tools,
+//! channels, and audit for a low-latency private home agent. It consumes lower
+//! runtime contracts for inference, voice I/O, and physical home control; it
+//! should not grow into those runtimes.
 
 use genie_common::config::{
     AgentConfig, AgentRuntimeProfile, OptionalAiProviderConfig, RuntimeBoundaryMode,
@@ -131,6 +132,6 @@ mod tests {
         };
 
         assert!(!provider_respects_agent_context(&provider, &agent));
-        assert!(!provider.production_candidate(&agent));
+        assert!(!provider.transitional_test_candidate(&agent));
     }
 }

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -10,9 +10,11 @@ ai_runtime_boundary = "external_runtime"       # genie-ai-runtime owns inference
 voice_runtime_boundary = "transitional_adapter" # In-repo voice path is temporary; target is genie-voice-runtime.
 home_runtime_boundary = "transitional_adapter"  # HA provider today; target is genie-home-runtime.
 
-# Optional API-key provider path. Disabled by default so the local Jetson image
-# and binary stay focused on genie-ai-runtime. Enable only after the provider
-# passes the same 4096-token home-agent harness.
+# Optional API/OAuth provider path. Disabled by default so the local Jetson
+# image and binary stay focused on genie-ai-runtime. This exists for better
+# testing, development portability, and transitional validation only; it is not
+# the product runtime. Enable only after the provider passes the same
+# 4096-token home-agent harness.
 [optional_ai_provider]
 enabled = false
 provider = "open_ai_compatible"   # "open_ai_compatible", "open_ai", "anthropic", "gemini", or "custom".

--- a/doc/README.md
+++ b/doc/README.md
@@ -18,6 +18,7 @@ Where current code is transitional, the docs call that out explicitly.
 ## Start Here
 
 - [overview.md](overview.md): product purpose, runtime modes, and the main request flows
+- [../LOW_LATENCY_HOME_AGENT.md](../LOW_LATENCY_HOME_AGENT.md): canonical low-latency private home-agent goal
 - [implementation-status.md](implementation-status.md): what is implemented, partial, external, and planned
 - [services-and-crates.md](services-and-crates.md): every crate, binary, and systemd service
 - [configuration.md](configuration.md): config sections, fields, and environment overrides
@@ -44,6 +45,9 @@ GenieClaw is a local-first home AI runtime centered on `genie-core`.
 - `genie-ai-runtime` is external to this Rust workspace and is the default
   Jetson LLM backend expected by the deploy assets; `llama.cpp` remains a
   selectable development/fallback backend.
+- Optional OpenAI-compatible/API/OAuth providers are transitional development
+  and testing adapters only. They do not replace the local on-device product
+  path.
 
 ## Canonical Deep Dives Still Kept At Repo Root
 
@@ -52,6 +56,7 @@ being deleted or moved abruptly.
 
 - [../README.md](../README.md): product summary and quick start
 - [../GETTING_STARTED.md](../GETTING_STARTED.md): bring-up guide for dev machines and Jetson
+- [../LOW_LATENCY_HOME_AGENT.md](../LOW_LATENCY_HOME_AGENT.md): low-latency private home-agent product goal
 - [../ARCHITECTURE.md](../ARCHITECTURE.md): Genie ecosystem and repo-boundary architecture
 - [../CODEBASE.md](../CODEBASE.md): broader code walkthrough
 - [../CONNECTIVITY.md](../CONNECTIVITY.md): ESP32-C6 boundary and split with `genie-os`

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -31,9 +31,11 @@ Runtime load path:
 
 ## `[optional_ai_provider]`
 
-This path is disabled by default. It records whether a remote or alternate
-OpenAI-compatible provider is eligible for future wiring without changing the
-local Jetson `genie-ai-runtime` default.
+This path is disabled by default. It exists for better testing, development
+portability, and transitional validation while preserving the local Jetson
+`genie-ai-runtime` default. Remote or alternate OpenAI-compatible providers are
+not the product runtime and must not become a shortcut around the small-context
+home harness.
 
 | Key | Purpose |
 | --- | --- |
@@ -47,7 +49,7 @@ local Jetson `genie-ai-runtime` default.
 | `allow_remote_base_url` | Required opt-in for non-loopback provider URLs |
 
 OAuth bearer mode never stores the token in TOML. For an OpenAI OAuth-token
-deployment, use a secret env var and point config at it:
+development/test deployment, use a secret env var and point config at it:
 
 ```toml
 [optional_ai_provider]
@@ -59,6 +61,11 @@ oauth_token_env = "OPENAI_OAUTH_ACCESS_TOKEN"
 context_window_tokens = 4096
 allow_remote_base_url = true
 ```
+
+Do not enable this path for household production by default. If a provider is
+used for validation, keep `context_window_tokens` at or below
+`[agent].context_window_tokens` and avoid sending household memory unless the
+operator has explicitly accepted that privacy tradeoff.
 
 ## `[core]`
 

--- a/doc/core-subsystems.md
+++ b/doc/core-subsystems.md
@@ -19,7 +19,8 @@ Responsibilities:
 - OpenAI-compatible HTTP calls to the configured model server
 - Jetson-default `genie-ai-runtime` request shaping and hint metadata
 - legacy/development `llama.cpp` fallback support
-- optional OpenAI-compatible provider auth/readiness planning
+- optional OpenAI-compatible provider auth/readiness planning for development,
+  testing, and transitional validation only
 - health checking
 - request serialization and response parsing
 - bounded connect/read/request timeouts for blocking and streaming calls
@@ -135,8 +136,9 @@ Responsibilities:
 - hydrate recent action history from the append-only actuation audit log on startup
 - separate "home control available" from "home control required for core usefulness"
 
-This repo treats Home Assistant as optional integration, not as the product's
-entire identity.
+This repo treats Home Assistant as optional transitional integration, not as the
+product's entire identity. The target is a native local device graph and IoT
+boundary owned below GenieClaw.
 
 ## Memory System
 
@@ -158,6 +160,7 @@ Responsibilities:
 - auto-capture from user facts
 - memory-policy filtering for sensitive content
 - recency/recall-aware ranking and decay
+- low-token, high-signal context injection for the home harness
 
 Current practical behavior:
 
@@ -178,6 +181,8 @@ Current practical behavior:
 - explicit "remember" requests can store structured facts
 - high-risk secrets are blocked
 - query-time memory injection reads the persisted policy metadata before adding memory to prompts
+- query-time memory injection should select only the relevant family/household
+  facts for the current turn rather than dumping all memory
 - memory recall also respects persisted policy metadata, with shared-room voice as the conservative default
 - static prompt and voice bootstrap context now use the same shared-room-safe memory filtering
 - promotion to `memory/MEMORY.md` is limited to memories that are safe for shared household disclosure

--- a/doc/deployment-and-ops.md
+++ b/doc/deployment-and-ops.md
@@ -9,6 +9,8 @@ The practical reason is simple:
 - local inference and local voice must fit in a constrained memory budget
 - service count must stay low
 - operational behavior has to remain understandable under pressure
+- ordinary home-agent turns should stay fast by using compact prompt context,
+  relevant memory, and typed tools instead of larger remote prompts
 
 ## Deploy Assets In This Repo
 
@@ -59,6 +61,10 @@ The practical reason is simple:
 Use `deploy/config/geniepod.dev.toml` and point `genie-core` at any local
 OpenAI-compatible model server. The checked-in dev config uses `llama.cpp`
 on `:8080`.
+
+Remote/API providers can help with development and transitional validation, but
+they are not the production product path. The Jetson target remains local
+`genie-ai-runtime` plus the limited-context home harness.
 
 Main references:
 
@@ -199,6 +205,8 @@ These are current system realities, not bugs in the docs:
 - Multilingual voice depends on installed STT/TTS models and per-language device testing.
 - Vector/cuVS semantic memory is design work; the implemented memory runtime uses SQLite FTS today.
 - Web search is intentionally limited to low-risk public lookups and can be disabled completely.
+- Optional OpenAI-compatible/API/OAuth providers are for testing and development
+  portability during transition, not for replacing the private on-device path.
 
 ## Suggested Health Checks
 

--- a/doc/implementation-status.md
+++ b/doc/implementation-status.md
@@ -42,7 +42,7 @@ Status labels:
 | Area | Status | What Exists | What Is Still Missing |
 | --- | --- | --- | --- |
 | Home Assistant integration | Partial / transitional | Provider boundary, status/control/history/undo, local action safety, HA token/config path | Home Assistant is not reimplemented in Rust here. Final device graph, automations, and deterministic physical safety belong in `genie-home-runtime`. |
-| LLM runtime | External / integrated | `crates/genie-core/src/llm/*`, `deploy/systemd/genie-ai-runtime.service`, `[services.llm].backend = "genie_ai_runtime"` | Jetson deploys default to the external `genie-ai-runtime` on `:8080`; `llama.cpp` remains a selectable fallback/development backend. |
+| LLM runtime | External / integrated | `crates/genie-core/src/llm/*`, `deploy/systemd/genie-ai-runtime.service`, `[services.llm].backend = "genie_ai_runtime"` | Jetson deploys default to the external `genie-ai-runtime` on `:8080`; `llama.cpp` remains a selectable fallback/development backend. OpenAI-compatible/API/OAuth providers are transitional development and testing adapters only. |
 | Voice multilingual support | Partial | STT language hint/auto mode, language detection, and optional per-language Piper model selection | Full quality for Chinese, Spanish, German, etc. depends on installed Whisper/Piper models and device testing. It is not a certified full-language product yet. |
 | Speaker recognition | Partial | Local acoustic fingerprints from WAV profiles and runtime matching | Not robust biometric authentication, anti-spoofing, enrollment UX, or security-grade identity. |
 | ESP32-C6 connectivity | Partial boundary | Config, status endpoint, capability model, UART path validation, Thread/Matter capability intent | No real UART protocol controller, no Thread/Matter stack, no ESP-Hosted-NG implementation in this repo. ESP-Hosted-NG belongs in `genie-os`; protocol ownership belongs in `genie-home-runtime`/connectivity services. |
@@ -70,8 +70,13 @@ Status labels:
 The workspace version is currently `1.0.0-alpha.9`.
 
 The current alpha line defaults Jetson deployments to `genie-ai-runtime`,
-preserves the 4096-token agent harness, and keeps optional remote/API providers
-behind explicit config, credential-env, and context-budget checks.
+preserves the 4096-token agent harness, and treats optional remote/API providers
+as development/testing paths behind explicit config, credential-env, remote-URL
+opt-in, and context-budget checks.
+
+The product direction is low-latency private home AI: keep context small,
+retrieve only high-signal family memory and device state, and use typed local
+tools/home-runtime boundaries instead of relying on larger remote prompts.
 
 ## How To Keep This Page Honest
 

--- a/doc/milestone-1-portable-home-agent.md
+++ b/doc/milestone-1-portable-home-agent.md
@@ -30,15 +30,16 @@ machines while preserving the final Jetson appliance shape.
 - GenieClaw remains a home automation AI agent, not a broad chatbot shell.
 - Jetson remains the default flagship target.
 - The full default-feature build must continue to represent the original
-  GeniePod Home goal: local runtime, voice, home control, memory, safety, audit,
-  and `genie-ai-runtime` integration.
+  GeniePod Home goal: local runtime, voice, home control, family memory, safety,
+  audit, and `genie-ai-runtime` integration.
 - Small context is a product constraint. The baseline target is currently 4096
   tokens.
 - Every provider path must work correctly under the small-context contract before
   larger adaptive context is treated as an optimization.
-- API-key providers must be optional and must not materially bloat the final
-  device image. Small config/type overhead is acceptable; heavy provider
-  dependencies should be feature-gated.
+- API-key, OAuth, and OpenAI-compatible providers must be optional development
+  and transitional validation paths. They must not materially bloat the final
+  device image or redefine the local on-device product path. Small config/type
+  overhead is acceptable; heavy provider dependencies should be feature-gated.
 - Voice remains optional for headless devices, laptops, CI, and remote
   development.
 
@@ -48,8 +49,8 @@ The project should name and test distinct runtime profiles.
 
 | Profile | Purpose |
 | --- | --- |
-| `geniepod-full` | Flagship deployment: Jetson, `genie-ai-runtime`, voice, home automation, memory, safety, and audit. |
-| `portable-home` | Development and non-Jetson installs: Home Assistant or fake home runtime, optional API-compatible LLM provider, headless or local UI. |
+| `geniepod-full` | Flagship deployment: Jetson, `genie-ai-runtime`, voice, home automation, family memory, safety, and audit. |
+| `portable-home` | Development and non-Jetson installs: Home Assistant or fake home runtime, optional API-compatible LLM provider for validation only, headless or local UI. |
 | `headless-agent` | No audio stack. Runs HTTP/chat/tool APIs and agent behavior for servers, laptops, CI, and SBCs. |
 | `contributor-ci` | Deterministic validation profile: mock LLM, fake home automation, fixed memory fixtures, no hardware or API keys. |
 
@@ -148,7 +149,8 @@ validation is needed.
 4. Introduce a mock LLM provider for deterministic agent tests.
 5. Introduce a fake home automation provider for tool and safety tests.
 6. Formalize provider capabilities and compliance tests.
-7. Add optional API-compatible provider support behind features.
+7. Add optional API-compatible provider support behind features for development
+   and transitional validation only.
 8. Keep `geniepod-full` as the flagship release target.
 
 ## Principle

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -9,14 +9,17 @@ The repo is optimized around a narrow goal:
 
 - run locally on Jetson-class hardware as the flagship target
 - preserve a 4096-token small-context baseline before larger adaptive contexts
+- favor low latency over larger default context windows
+- tune accuracy through family memory, current home state, and typed tools
 - keep the system understandable and debuggable
 - keep agent/provider/home behavior testable through deterministic harnesses
 - provide everyday household usefulness before broad platform ambition
 - preserve privacy, bounded behavior, and graceful degradation
 
 This is not a cloud orchestration shell and not a generic agent runtime. Remote
-or API-key providers can be useful optional adapters, but they must fit the
-limited-context home-agent contract rather than redefine the product.
+or API-key providers can be useful optional adapters for development, CI, and
+transitional validation, but they must fit the limited-context home-agent
+contract rather than redefine the product.
 
 ## Ecosystem Role
 
@@ -34,6 +37,11 @@ This repository is `genie-claw`. It integrates with external lower runtimes
 through narrow clients: `genie-ai-runtime` is the Jetson default LLM backend,
 `llama.cpp` remains a selectable development/fallback backend, and Home
 Assistant is the current transitional home provider.
+
+The intended accuracy path is a compact home context harness: identity and
+family facts, relevant memories, device graph slices, recent actions, and
+safety policy are selected before each turn instead of dumping raw history or
+using remote context as a shortcut.
 
 For the exact implemented/partial/planned breakdown, use
 [implementation-status.md](implementation-status.md). In short, this repo
@@ -102,6 +110,10 @@ genie-home-runtime
         v
 GenieOS + custom Jetson hardware
 ```
+
+The target home runtime owns direct local IoT interfaces and the final physical
+actuation gate. GenieClaw owns the agent decision, memory, confirmation, and
+audit layers above that boundary.
 
 ## Core User Flows
 

--- a/doc/repo-map.md
+++ b/doc/repo-map.md
@@ -6,6 +6,7 @@
 | --- | --- |
 | `README.md` | Product summary and quick start |
 | `GETTING_STARTED.md` | Bring-up guide |
+| `LOW_LATENCY_HOME_AGENT.md` | Canonical low-latency private home-agent goal |
 | `ARCHITECTURE.md` | Genie ecosystem and repo-boundary architecture |
 | `CODEBASE.md` | Narrative code walkthrough |
 | `CONNECTIVITY.md` | ESP32-C6 boundary and ownership split |
@@ -56,7 +57,7 @@
 This is the LLM backend facade. Jetson deploys default to the external
 `genie-ai-runtime`; `llama.cpp` remains selectable as a legacy fallback and
 development backend. Optional OpenAI-compatible providers are disabled by
-default and must pass the same limited-context harness before use.
+default and exist only for development, testing, and transitional validation.
 
 ### Prompt And Reasoning
 

--- a/doc/services-and-crates.md
+++ b/doc/services-and-crates.md
@@ -13,6 +13,8 @@ Jetson appliance deployment, but the long-term boundary is clear:
 - Home Assistant is the current transitional home-runtime adapter.
 - `genie-ai-runtime` is the default external Jetson LLM runtime; `llama.cpp`
   remains a selectable fallback and development backend.
+- Optional OpenAI-compatible/API providers are for development portability,
+  testing, and transitional validation only.
 - Future `genie-home-runtime` should replace the Home Assistant lower-runtime adapter.
 - `genie-voice-runtime` is the new external owner for wake/VAD/STT/TTS/audio behavior.
 
@@ -182,6 +184,8 @@ Not every unit is always active. Some are optional or deployment-specific.
 ## Optional Integration Boundaries
 
 - Home Assistant: transitional provider boundary in `crates/genie-core/src/ha/`
+- Optional AI providers: disabled-by-default development/test boundary under
+  `[optional_ai_provider]`
 - Telegram: feature-gated adapter in `crates/genie-core/src/telegram.rs`
 - ESP32-C6 connectivity sidecar: boundary in `crates/genie-core/src/connectivity/`
 - Web search providers: DuckDuckGo default, optional local SearXNG


### PR DESCRIPTION
## Summary

Aligns the repo around the low-latency private home-agent goal: limited context, family memory, typed local tools, and direct local IoT/home-runtime boundaries.

## Changes

- Add `LOW_LATENCY_HOME_AGENT.md` as the canonical product goal doc.
- Update README, architecture, docs, config comments, and connectivity/vector-memory notes around the private on-device home-agent direction.
- Make OpenAI-compatible/API/OAuth providers explicitly development/testing and transitional validation paths only.
- Rename the optional-provider readiness helper to `transitional_test_candidate`.
- Tighten the limited-context harness memory hydration budget from 900 to 700 tokens to match the small-context plan.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

```bash
cargo fmt --all
cargo test -p genie-common optional_ai_provider
cargo test -p genie-core agent_harness
cargo test -p genie-core runtime_boundary
cargo clippy -p genie-common -p genie-core --all-targets -- -D warnings
git diff --check
grep -RInE 'production candidate|production candidates|production paths|treated as production|production_candidate|optional API-key providers only|Optional OpenAI-compatible providers are disabled by default and must pass' README.md ARCHITECTURE.md CODEBASE.md GETTING_STARTED.md LOW_LATENCY_HOME_AGENT.md doc deploy crates --exclude-dir=target
```

### What I observed

All focused config, harness, and runtime-boundary tests passed. Clippy passed with `-D warnings`. `git diff --check` passed. The stale provider-production wording grep returned no matches.

This was not Jetson-tested because the PR changes docs, comments, and small harness/config helper semantics only; it does not deploy or restart device services.

## Test plan

- Review the new goal doc and linked docs for consistency.
- Validate CI.
- On Jetson, use the existing deploy flow when a later PR changes runtime behavior.