### PR TITLE
fix(governor): propagate zram setup script failures

### DIFF
--- a/crates/genie-governor/src/service_ctl.rs
+++ b/crates/genie-governor/src/service_ctl.rs
@@ -150,7 +150,8 @@ impl ServiceCtl {
         let output = Command::new("sh").args(["-c", script]).output().await?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            tracing::warn!(%stderr, "zram setup may have partially failed");
+            tracing::error!(%stderr, "zram setup failed");
+            anyhow::bail!("zram setup failed: {}", stderr.trim());
         }
         Ok(())
     }
@@ -187,5 +188,17 @@ mod tests {
             llm_override_dir_for_unit("genie-ai-runtime.service"),
             "/etc/systemd/system/genie-ai-runtime.service.d"
         );
+    }
+
+    #[tokio::test]
+    async fn enable_zram_returns_err_with_message_when_setup_fails() {
+        let result = ServiceCtl::enable_zram().await;
+        if let Err(err) = result {
+            let message = err.to_string();
+            assert!(
+                message.contains("zram setup failed"),
+                "expected propagated failure message, got: {message}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `enable_zram` returns `Err` when the setup script exits non-zero
- Prevents `handle_pressure` from latching `zram_enabled` on failed zram setup

Fixes #246

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `laptop`

### What I ran

```bash
cargo test -p genie-governor enable_zram_returns_err_with_message_when_setup_fails
```

### What I observed

- On dev host without zram privileges, `enable_zram` returns `Err` containing `zram setup failed`

## Test plan

- [x] `cargo test -p genie-governor`