### PR TITLE
fix(api): return HTTP 500 when tegrastats DB read fails

### DIFF
--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -88,10 +88,15 @@ pub async fn get_tegrastats(config: &Config) -> Response {
             content_type: "application/json",
             body: json,
         },
-        _ => Response {
-            status: 200,
+        Ok(Err(e)) => Response {
+            status: 500,
             content_type: "application/json",
-            body: "[]".into(),
+            body: serde_json::json!({ "error": e }).to_string(),
+        },
+        Err(e) => Response {
+            status: 500,
+            content_type: "application/json",
+            body: serde_json::json!({ "error": e.to_string() }).to_string(),
         },
     }
 }
@@ -1117,5 +1122,22 @@ mod tests {
         );
         assert_eq!(wakeword.source, "config");
         assert_eq!(wakeword.sub_state, "disabled");
+    }
+
+    #[tokio::test]
+    async fn get_tegrastats_returns_error_when_db_missing() {
+        let mut config = test_config();
+        config.data_dir = std::env::temp_dir().join(format!(
+            "genie-api-tegrastats-missing-{}",
+            std::process::id()
+        ));
+
+        let response = get_tegrastats(&config).await;
+        assert_eq!(response.status, 500);
+        assert!(
+            response.body.contains("error"),
+            "expected JSON error body, got: {}",
+            response.body
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Return HTTP 500 with JSON `error` when `governor.db` tegrastats read fails
- Empty array is now reserved for successful reads with no rows

Fixes #247

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `laptop`

### What I ran

```bash
cargo test -p genie-api get_tegrastats_returns_error_when_db_missing
cargo test -p genie-api
```

### What I observed

- Missing DB path returns status 500 with JSON error body (not `200 []`)

## Test plan

- [x] `cargo test -p genie-api`
