### PR TITLE
docs: mark SBC profiles as maintained

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -202,20 +202,23 @@ The agent may propose or request actions. The home runtime decides whether physi
 
 ## Portable Profiles
 
-GenieClaw supports portable development without changing the native product
+GenieClaw supports maintained SBC profiles without changing the native product
 shape. `[agent].runtime_profile` describes where the same agent harness is
 running:
 
 | Profile | Purpose |
 | --- | --- |
 | `jetson` | Flagship GeniePod Home path; 4096-token baseline and local runtime default |
-| `raspberry_pi` | SBC development profile for headless agent and provider work |
-| `portable_sbc` | Generic SBC profile where voice/home runtimes may be absent |
+| `raspberry_pi` | Maintained SBC profile for the headless agent, memory, tools, HTTP/CLI, and home-provider boundaries |
+| `portable_sbc` | Maintained generic SBC profile where voice, CUDA, and full home runtimes may be absent |
 | `laptop` | Developer profile for local tests, docs, and provider integration |
 | `mac` | macOS developer profile; no Jetson-specific runtime assumptions |
 
-Profiles do not change ownership. They only make the same limited-context agent
-contract portable enough for development and review on non-Jetson hardware.
+Profiles do not change ownership. They keep the same limited-context agent
+contract portable enough for development, review, and maintained non-Jetson SBC
+deployments. Jetson-only acceleration and voice/audio behavior may degrade or
+be disabled, but prompt, memory, tools, safety policy, and home-runtime
+boundaries should keep working.
 
 ## Optional Providers
 

--- a/LOW_LATENCY_HOME_AGENT.md
+++ b/LOW_LATENCY_HOME_AGENT.md
@@ -11,6 +11,12 @@ prompts to a bigger remote model.
 
 The flagship target is GeniePod Home on Jetson-class hardware.
 
+Raspberry Pi and generic portable SBC profiles are maintained as smaller
+deployment and validation targets. They do not need to expose every
+Jetson-specific voice, CUDA, or model-runtime feature, but they should keep the
+headless agent, family memory, tools, HTTP/CLI surfaces, and home-runtime
+boundaries usable.
+
 The agent should:
 
 - answer quickly on local hardware
@@ -20,6 +26,7 @@ The agent should:
 - control IoT devices through typed local interfaces
 - degrade gracefully without the internet
 - expose audit, confirmation, and memory-management surfaces to the household
+- preserve the same limited-context contract across maintained SBC profiles
 
 Cloud or remote model providers are not the product default. OpenAI-compatible
 API providers, OpenAI, Anthropic, Gemini, custom providers, and similar adapters

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Jetson cross-compile](https://github.com/GeniePod/genie-claw/actions/workflows/cross.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/cross.yml)
 [![Audit](https://github.com/GeniePod/genie-claw/actions/workflows/audit.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/audit.yml)
 
-**Low-latency, limited-context AI harness for private on-device homes: portable
-across SBCs and native to GeniePod Home.**
+**Low-latency, limited-context AI harness for private on-device homes: native to
+GeniePod Home and maintained across SBC profiles.**
 
 GenieClaw is the Rust agent layer for GeniePod Home. It is built for small local
 models, tight VRAM budgets, and a 4096-token Jetson baseline. This repo owns
@@ -23,6 +23,13 @@ The default agent contract is intentionally small: the Jetson profile uses
 `[agent].context_window_tokens = 4096`. Larger adaptive contexts can exist for
 stronger models, but provider/runtime paths must pass the 4096-token harness
 first.
+
+Jetson remains the flagship GeniePod Home target, but SBC support is maintained
+as part of the product architecture. The `raspberry_pi` and `portable_sbc`
+profiles must continue to run the headless agent, memory, tools, HTTP/CLI
+surfaces, and home-provider boundaries without assuming Jetson-only voice,
+CUDA, or systemd behavior. Hardware-specific features may be absent on those
+profiles, but the agent contract should remain usable and testable.
 
 ## Boundary
 
@@ -75,7 +82,7 @@ Current workspace version: `v1.0.0-alpha.9`.
 - split long-term wake/VAD/STT/TTS ownership into `genie-voice-runtime`
 - keep Home Assistant behind a provider boundary until `genie-home-runtime`
 - use optional API/OAuth providers only for testing, development portability, and transitional validation
-- keep development usable on SBCs, laptops, and Macs without making Jetson less native
+- keep maintained SBC profiles, laptops, and Macs usable without making Jetson less native
 
 ## Agent Contract
 
@@ -89,7 +96,7 @@ The repo now has explicit code-level contract surfaces for the new direction:
 - `genie_core::llm::LlmRequestHints` carries session id, expected output
   length, priority, short-lived cache TTL, and stable system-prompt prefix
   cache metadata to runtimes that understand the `nvext` extension.
-- `[agent]` in `geniepod.toml` selects the runtime profile:
+- `[agent]` in `geniepod.toml` selects the maintained runtime profile:
   `jetson`, `raspberry_pi`, `portable_sbc`, `laptop`, or `mac`.
 - `[optional_ai_provider]` is disabled by default. API-key, OAuth-bearer, and
   other remote/alternate providers exist only for better testing, development

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -261,8 +261,9 @@ impl Default for CoreConfig {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct AgentConfig {
-    /// Primary deployment profile. Jetson stays the flagship default, but the
-    /// agent contract must also run on portable dev hosts and SBCs.
+    /// Primary deployment profile. Jetson stays the flagship default, while
+    /// Raspberry Pi and generic portable SBCs remain maintained headless agent
+    /// profiles.
     #[serde(default)]
     pub runtime_profile: AgentRuntimeProfile,
 

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -5,6 +5,10 @@ data_dir = "/opt/geniepod/data"
 
 [agent]
 runtime_profile = "jetson"        # "jetson", "raspberry_pi", "portable_sbc", "laptop", or "mac".
+                                  # Jetson is flagship; raspberry_pi and
+                                  # portable_sbc are maintained headless/SBC
+                                  # profiles for agent, memory, tools, and
+                                  # home-provider boundaries.
 context_window_tokens = 4096      # Non-negotiable Jetson baseline before any adaptive larger context.
 ai_runtime_boundary = "external_runtime"       # genie-ai-runtime owns inference.
 voice_runtime_boundary = "transitional_adapter" # In-repo voice path is temporary; target is genie-voice-runtime.

--- a/doc/deployment-and-ops.md
+++ b/doc/deployment-and-ops.md
@@ -56,6 +56,26 @@ The practical reason is simple:
 
 ## Supported Bring-Up Styles
 
+### Maintained SBC Profiles
+
+Jetson remains the flagship deployment target, but Raspberry Pi and generic
+portable SBC profiles are maintained for the headless agent path.
+
+Maintained means these surfaces should remain usable without Jetson-only
+assumptions:
+
+- config loading with `[agent].runtime_profile = "raspberry_pi"` or
+  `"portable_sbc"`
+- `genie-core` HTTP/chat surfaces
+- `genie-ctl` CLI surfaces
+- memory and tool routing
+- Home Assistant or fake home-provider boundaries
+- optional provider/test harness paths
+
+Voice, CUDA acceleration, `genie-ai-runtime`, and Jetson-specific systemd
+behavior may be unavailable or replaced by lighter local services on those
+profiles.
+
 ### Dev Machine
 
 Use `deploy/config/geniepod.dev.toml` and point `genie-core` at any local

--- a/doc/milestone-1-portable-home-agent.md
+++ b/doc/milestone-1-portable-home-agent.md
@@ -29,6 +29,8 @@ machines while preserving the final Jetson appliance shape.
 
 - GenieClaw remains a home automation AI agent, not a broad chatbot shell.
 - Jetson remains the default flagship target.
+- Raspberry Pi and generic portable SBC profiles remain maintained targets for
+  the headless agent, memory, tools, HTTP/CLI, and home-provider boundaries.
 - The full default-feature build must continue to represent the original
   GeniePod Home goal: local runtime, voice, home control, family memory, safety,
   audit, and `genie-ai-runtime` integration.
@@ -50,8 +52,8 @@ The project should name and test distinct runtime profiles.
 | Profile | Purpose |
 | --- | --- |
 | `geniepod-full` | Flagship deployment: Jetson, `genie-ai-runtime`, voice, home automation, family memory, safety, and audit. |
-| `portable-home` | Development and non-Jetson installs: Home Assistant or fake home runtime, optional API-compatible LLM provider for validation only, headless or local UI. |
-| `headless-agent` | No audio stack. Runs HTTP/chat/tool APIs and agent behavior for servers, laptops, CI, and SBCs. |
+| `portable-home` | Maintained non-Jetson installs: Home Assistant or fake home runtime, optional API-compatible LLM provider for validation only, headless or local UI. |
+| `headless-agent` | No audio stack. Runs HTTP/chat/tool APIs and agent behavior for servers, laptops, CI, Raspberry Pi, and generic SBCs. |
 | `contributor-ci` | Deterministic validation profile: mock LLM, fake home automation, fixed memory fixtures, no hardware or API keys. |
 
 These profiles are validation and packaging tools. They do not change the

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -8,6 +8,8 @@ broader Genie ecosystem.
 The repo is optimized around a narrow goal:
 
 - run locally on Jetson-class hardware as the flagship target
+- maintain Raspberry Pi and generic portable SBC profiles for the headless
+  agent, memory, tools, HTTP/CLI, and home-provider boundaries
 - preserve a 4096-token small-context baseline before larger adaptive contexts
 - favor low latency over larger default context windows
 - tune accuracy through family memory, current home state, and typed tools
@@ -37,6 +39,11 @@ This repository is `genie-claw`. It integrates with external lower runtimes
 through narrow clients: `genie-ai-runtime` is the Jetson default LLM backend,
 `llama.cpp` remains a selectable development/fallback backend, and Home
 Assistant is the current transitional home provider.
+
+The Jetson profile is the native product path. The `raspberry_pi` and
+`portable_sbc` profiles are maintained compatibility targets for smaller
+on-device installs where Jetson-only voice, CUDA, or service behavior may be
+absent.
 
 The intended accuracy path is a compact home context harness: identity and
 family facts, relevant memories, device graph slices, recent actions, and


### PR DESCRIPTION
## Summary

Updates the main README and supporting docs to make SBC support explicit: Jetson remains the flagship target, while Raspberry Pi and generic portable SBC profiles are maintained headless/agent profiles.

## Changes

- Update the main README headline and product contract around maintained SBC profiles.
- Clarify that `raspberry_pi` and `portable_sbc` should keep headless agent, memory, tools, HTTP/CLI, and home-provider boundaries working.
- Sync architecture, low-latency goal, overview, milestone, deployment docs, config comments, and config source comments.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

```bash
cargo fmt --all
cargo test -p genie-common portable_agent_profile_parses
git diff --check
grep -RInE 'maintained.*SBC|SBC profiles|portable_sbc|raspberry_pi' README.md ARCHITECTURE.md LOW_LATENCY_HOME_AGENT.md doc deploy/config/geniepod.toml crates/genie-common/src/config.rs --exclude-dir=target
```

### What I observed

The portable profile config test passed, formatting completed, diff whitespace check passed, and the repo scan shows the README plus supporting docs now describe maintained SBC profiles consistently.

No Jetson or SBC hardware test was run because this PR changes docs and comments only.

## Test plan

- Review rendered README and docs for clear Jetson-first plus maintained-SBC wording.
- Let CI validate the docs/comment-only branch.