### PR TITLE
docs: generalize transitional runtime boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,9 +5,9 @@ GenieClaw is the agent layer of the broader Genie ecosystem.
 This repository should be understood as the Rust agent runtime that sits above:
 
 - custom Jetson hardware
-- GenieOS, the custom L4T and system image layer
-- `genie-voice-runtime`, the external voice runtime for wake/VAD/STT/TTS/audio
-- `genie-home-runtime`, the future AI-native home automation runtime
+- the platform/OS layer for custom L4T, system image, drivers, and supervision
+- an external voice boundary for wake/VAD/STT/TTS/audio
+- an external home boundary for AI-native home automation and final actuation
 - `genie-ai-runtime`, the external Jetson-first LLM inference runtime
 
 It sits below:
@@ -44,11 +44,11 @@ GenieClaw Agent Layer
   Agent policy, memory, tools, skills, channel adapters, spoken behavior
 
 Runtime Layer
-  genie-voice-runtime: wake, VAD, STT, TTS, audio streaming
-  genie-home-runtime: local device graph, IoT adapters, automations, actuation safety, MCP
+  voice boundary: wake, VAD, STT, TTS, audio streaming
+  home boundary: local device graph, IoT adapters, automations, actuation safety, MCP
   genie-ai-runtime: Jetson-only LLM inference, CUDA kernels, model serving
 
-GenieOS Layer
+Platform/OS Layer
   Custom L4T image, drivers, services, OTA, diagnostics
 
 Hardware Layer
@@ -81,11 +81,11 @@ The repo should optimize for repeated daily usefulness:
 
 These responsibilities belong in lower or upper layers:
 
-- Jetson board support, kernel/device-tree work, OTA base image ownership: `genie-os`
-- Matter/Thread/Zigbee/BLE device graph and automation engine: `genie-home-runtime`
-- final physical actuation safety checks: `genie-home-runtime`
+- Jetson board support, kernel/device-tree work, OTA base image ownership: platform/OS layer
+- Matter/Thread/Zigbee/BLE device graph and automation engine: external home boundary
+- final physical actuation safety checks: external home boundary
 - llama.cpp fork, CUDA kernels, model memory planner: `genie-ai-runtime`
-- wake word, VAD, STT, TTS, ALSA/audio-device handling, denoise, and AEC: `genie-voice-runtime`
+- wake word, VAD, STT, TTS, ALSA/audio-device handling, denoise, and AEC: external voice boundary
 - full product app, account UX, mobile push, installer workflows: application layer
 
 This repo can keep transitional implementations while those layers are still forming, but the code should be structured so those boundaries can be replaced by stable clients.
@@ -97,12 +97,12 @@ The current repo still contains pragmatic adapters used to ship on Jetson now.
 | Current adapter | Target boundary | Notes |
 | --- | --- | --- |
 | `genie-ai-runtime` OpenAI-compatible client (default on Jetson) | external `genie-ai-runtime` service | `llama.cpp` remains a selectable fallback/development backend. Both local backends ship behind the `LlmClient` facade; per-deployment selection is via `[services.llm].backend` in `geniepod.toml`. Backend identity surfaces in `/api/health`, startup logs, and `genie-ctl status`. |
-| In-repo voice pipeline under `crates/genie-core/src/voice/` and `voice_loop.rs` | [`genie-voice-runtime`](https://github.com/GeniePod/genie-voice-runtime) | Keep current code as a transitional Jetson bring-up path. New wake/VAD/STT/TTS/audio ownership should move to the external runtime. GenieClaw should consume transcripts and issue speak commands. |
-| Home Assistant provider | `genie-home-runtime` MCP/API client | Keep HA-specific behavior behind `ha/` and tools/home boundaries. Home Assistant is a transitional provider while the native local device graph and IoT boundary mature. |
-| Actuation safety in `genie-core` | final safety in `genie-home-runtime` | Keep current safety as an agent-side guard and confirmation layer. |
+| In-repo voice pipeline under `crates/genie-core/src/voice/` and `voice_loop.rs` | external voice boundary | Keep current code as a transitional Jetson bring-up path. New wake/VAD/STT/TTS/audio ownership should move behind the external boundary. GenieClaw should consume transcripts and issue speak commands. |
+| Home Assistant provider | external home boundary | Keep HA-specific behavior behind `ha/` and tools/home boundaries. Home Assistant is a transitional provider while the native local device graph and IoT boundary mature. |
+| Actuation safety in `genie-core` | final safety in the external home boundary | Keep current safety as an agent-side guard and confirmation layer. |
 | `genie-api` dashboard | application layer | Keep it operational and lightweight; avoid making it the long-term product app. |
-| `genie-governor` service lifecycle | GenieOS/system supervisor | Keep it useful for Jetson bring-up while OS ownership matures. |
-| ESP32-C6 UART boundary | GenieOS connectivity service | Agent sees health/capabilities, not raw radio/device-driver internals. |
+| `genie-governor` service lifecycle | platform/system supervisor | Keep it useful for Jetson bring-up while OS ownership matures. |
+| ESP32-C6 UART boundary | platform connectivity service | Agent sees health/capabilities, not raw radio/device-driver internals. |
 
 ## Desired Internal Shape
 
@@ -113,7 +113,7 @@ The repo should trend toward these conceptual modules, even if existing file nam
 | Agent orchestration | `crates/genie-core/src/server.rs`, `repl.rs`, `voice_loop.rs`, `reasoning.rs`, `prompt.rs` |
 | AI runtime client | `crates/genie-core/src/llm/` |
 | Home runtime client | `crates/genie-core/src/ha/`, `tools/home.rs` |
-| Voice runtime client | transitional `crates/genie-core/src/voice/`, `voice_loop.rs`; target external client for `genie-voice-runtime` |
+| Voice runtime client | transitional `crates/genie-core/src/voice/`, `voice_loop.rs`; target external voice-boundary client |
 | Memory system | `crates/genie-core/src/memory/`, `conversation.rs` |
 | Tool and skill routing | `crates/genie-core/src/tools/`, `skills/` |
 | Channel adapters | `server.rs`, `repl.rs`, `telegram.rs`, `genie-ctl` |
@@ -133,7 +133,7 @@ Code in memory, voice, prompt, and channels should not learn Home Assistant inte
 Voice code has one additional rule: GenieClaw may own spoken agent behavior,
 but it should not own the long-term audio pipeline. Wake word, VAD, STT, TTS,
 audio-device handling, denoise, AEC, and streaming voice events belong in
-`genie-voice-runtime`.
+the external voice boundary.
 
 ## Process Topology Today
 
@@ -162,7 +162,7 @@ Target deployment:
 genie-ai-runtime
         ^
         |
-genie-voice-runtime ---- transcript/speak events
+external voice boundary ---- transcript/speak events
         ^                         |
         |                         v
 genie-claw
@@ -170,10 +170,10 @@ genie-claw
         +---- web/mobile apps
         +---- skills and channels
         v
-genie-home-runtime
+external home boundary
         |
         v
-GenieOS + hardware
+platform/OS + hardware
 ```
 
 ## Safety Ownership
@@ -189,7 +189,7 @@ Current safety responsibilities in this repo:
 - write actuation audit events
 - avoid relying on the model prompt as a safety boundary
 
-Long-term safety responsibilities in `genie-home-runtime`:
+Long-term safety responsibilities in the external home boundary:
 
 - final deterministic actuation checks
 - device availability and state checks
@@ -295,10 +295,10 @@ Short-term rule:
 Long-term direction:
 
 - `genie-claw`: agent layer repository and product brain
-- `genie-voice-runtime`: voice I/O runtime for wake, VAD, STT, TTS, and audio streaming
-- `genie-home-runtime`: home automation and physical actuation runtime
+- external voice boundary: voice I/O runtime for wake, VAD, STT, TTS, and audio streaming
+- external home boundary: home automation and physical actuation runtime
 - `genie-ai-runtime`: Jetson-only inference runtime
-- `genie-os`: custom L4T image and hardware bring-up layer
+- platform/OS layer: custom L4T image and hardware bring-up layer
 
 ## Refactor Direction
 
@@ -307,9 +307,9 @@ The clean architecture path is incremental:
 1. Make boundary language consistent in docs and config.
 2. Keep Home Assistant and LLM backends behind narrow adapter traits (LLM side resolved via the `LlmClient` facade in `crates/genie-core/src/llm/`).
 3. Tune the prompt/memory/tool harness for low-latency household context.
-4. Move physical actuation authority and direct local IoT/device graph ownership downward into `genie-home-runtime` when it exists.
+4. Move physical actuation authority and direct local IoT/device graph ownership downward into the external home boundary when it is ready.
 5. Keep Jetson model-server specialization in `genie-ai-runtime`.
-6. Move voice/audio pipeline ownership downward into `genie-voice-runtime`.
+6. Move voice/audio pipeline ownership downward into the external voice boundary.
 7. Keep GenieClaw focused on agent policy, memory, skills, tools, channels, and household interaction.
 
 This prevents the agent repo from becoming a single large mixed runtime while still allowing today’s Jetson appliance to keep working.

--- a/LOW_LATENCY_HOME_AGENT.md
+++ b/LOW_LATENCY_HOME_AGENT.md
@@ -108,9 +108,10 @@ GenieClaw should not become a wireless driver stack, but it should integrate
 with a first-party local device graph and actuation boundary. The target split
 is:
 
-- `genie-os` owns radios, Linux interfaces, drivers, and service supervision.
-- `genie-home-runtime` owns device graph, Matter/Thread/Zigbee/BLE adapters,
-  automations, and final physical actuation safety.
+- The platform/OS layer owns radios, Linux interfaces, drivers, and service
+  supervision.
+- The external home boundary owns device graph, Matter/Thread/Zigbee/BLE
+  adapters, automations, and final physical actuation safety.
 - `genie-claw` owns user intent, memory, policy, confirmations, audit, and
   tool routing.
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ profiles, but the agent contract should remain usable and testable.
 |-------|-------|-------|
 | Agent layer | `genie-claw` | Prompt policy, limited-context harness, memory, tools, skills, smart-home intent, safety, audit, channels |
 | LLM runtime | [`genie-ai-runtime`](https://github.com/GeniePod/genie-ai-runtime) | Jetson-first local inference runtime; `llama.cpp` remains selectable |
-| Voice runtime | [`genie-voice-runtime`](https://github.com/GeniePod/genie-voice-runtime) | Wake, VAD, STT, TTS, audio streaming, voice session protocol |
-| Home runtime | `genie-home-runtime` | Planned AI-native device graph, local IoT boundary, and final actuation gate |
-| Home Assistant | Transitional provider | Current integration target until `genie-home-runtime` exists |
-| OS and apps | External layers | `genie-os`, web, and mobile surfaces stay outside this repo |
+| Voice boundary | External/runtime layer | Wake, VAD, STT, TTS, audio streaming, voice session protocol |
+| Home boundary | External/runtime layer | AI-native device graph, local IoT boundary, and final actuation gate |
+| Home Assistant | Transitional provider | Current integration target behind the home-provider boundary |
+| Platform and apps | External layers | OS/platform, web, and mobile surfaces stay outside this repo |
 
 Full stack shape:
 
@@ -54,13 +54,13 @@ user channel / voice runtime
     |        |        |
     v        v        v
 genie-ai-runtime   Home Assistant today
-                   genie-home-runtime later
+                   native home boundary later
 ```
 
 ## What Works Today
 
 - local chat through `genie-core`
-- transitional voice-session adapter while voice moves to `genie-voice-runtime`
+- transitional voice-session adapter while voice/audio moves behind an external boundary
 - LLM backend facade for `genie-ai-runtime` and selectable `llama.cpp`
 - SQLite conversation history and policy-aware family/household memory
 - Home Assistant adapter with confirmations, rate limits, and audit logging
@@ -79,8 +79,8 @@ Current workspace version: `v1.0.0-alpha.9`.
 - keep the agent fast and reliable inside a 4096-token Jetson context
 - tune the AI harness around high-signal home context, family memory, and typed tools
 - improve accuracy through deterministic device state and memory retrieval, not larger prompts
-- split long-term wake/VAD/STT/TTS ownership into `genie-voice-runtime`
-- keep Home Assistant behind a provider boundary until `genie-home-runtime`
+- split long-term wake/VAD/STT/TTS ownership behind an external voice boundary
+- keep Home Assistant behind a provider boundary during the transition
 - use optional API/OAuth providers only for testing, development portability, and transitional validation
 - keep maintained SBC profiles, laptops, and Macs usable without making Jetson less native
 

--- a/crates/genie-core/src/connectivity/mod.rs
+++ b/crates/genie-core/src/connectivity/mod.rs
@@ -13,8 +13,8 @@ use std::path::Path;
 /// The current target is an ESP32-C6 connected to Jetson over UART for
 /// Thread/Matter sidecar work.
 ///
-/// OS-level networking such as `esp-hosted-ng` belongs in `genie-os`, not in
-/// the core assistant runtime.
+/// OS-level networking such as `esp-hosted-ng` belongs in the platform/OS
+/// layer, not in the core assistant runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectivityState {

--- a/crates/genie-core/src/runtime_boundary.rs
+++ b/crates/genie-core/src/runtime_boundary.rs
@@ -48,7 +48,7 @@ pub fn runtime_boundaries(agent: &AgentConfig) -> Vec<RuntimeBoundaryContract> {
         },
         RuntimeBoundaryContract {
             layer: "voice_runtime",
-            owner: "genie-voice-runtime",
+            owner: "external_voice_boundary",
             mode: format!("{:?}", agent.voice_runtime_boundary),
             contract: "transcript-in and speak-out session protocol",
             local_default: matches!(
@@ -58,7 +58,7 @@ pub fn runtime_boundaries(agent: &AgentConfig) -> Vec<RuntimeBoundaryContract> {
         },
         RuntimeBoundaryContract {
             layer: "home_runtime",
-            owner: "genie-home-runtime",
+            owner: "external_home_boundary",
             mode: format!("{:?}", agent.home_runtime_boundary),
             contract: "intent handoff plus final physical actuation gate",
             local_default: matches!(
@@ -112,8 +112,8 @@ mod tests {
 
         assert_eq!(boundaries.len(), 3);
         assert_eq!(boundaries[0].owner, "genie-ai-runtime");
-        assert_eq!(boundaries[1].owner, "genie-voice-runtime");
-        assert_eq!(boundaries[2].owner, "genie-home-runtime");
+        assert_eq!(boundaries[1].owner, "external_voice_boundary");
+        assert_eq!(boundaries[2].owner, "external_home_boundary");
         assert!(boundaries.iter().all(|boundary| !boundary.layer.is_empty()));
     }
 

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -11,8 +11,8 @@ runtime_profile = "jetson"        # "jetson", "raspberry_pi", "portable_sbc", "l
                                   # home-provider boundaries.
 context_window_tokens = 4096      # Non-negotiable Jetson baseline before any adaptive larger context.
 ai_runtime_boundary = "external_runtime"       # genie-ai-runtime owns inference.
-voice_runtime_boundary = "transitional_adapter" # In-repo voice path is temporary; target is genie-voice-runtime.
-home_runtime_boundary = "transitional_adapter"  # HA provider today; target is genie-home-runtime.
+voice_runtime_boundary = "transitional_adapter" # In-repo voice path is temporary; target is the external voice boundary.
+home_runtime_boundary = "transitional_adapter"  # HA provider today; target is the external home boundary.
 
 # Optional API/OAuth provider path. Disabled by default so the local Jetson
 # image and binary stay focused on genie-ai-runtime. This exists for better

--- a/doc/README.md
+++ b/doc/README.md
@@ -11,7 +11,7 @@ repo boundary inside the larger Genie ecosystem:
 - core subsystems such as memory, voice, security, and connectivity
 - deployment assets and operational guidance
 - repository layout and code ownership map
-- long-term boundary with `genie-os`, `genie-voice-runtime`, `genie-home-runtime`, `genie-ai-runtime`, and app layers
+- long-term boundary with platform/OS, voice, home, `genie-ai-runtime`, and app layers
 
 Where current code is transitional, the docs call that out explicitly.
 
@@ -59,7 +59,7 @@ being deleted or moved abruptly.
 - [../LOW_LATENCY_HOME_AGENT.md](../LOW_LATENCY_HOME_AGENT.md): low-latency private home-agent product goal
 - [../ARCHITECTURE.md](../ARCHITECTURE.md): Genie ecosystem and repo-boundary architecture
 - [../CODEBASE.md](../CODEBASE.md): broader code walkthrough
-- [../CONNECTIVITY.md](../CONNECTIVITY.md): ESP32-C6 boundary and split with `genie-os`
+- [../CONNECTIVITY.md](../CONNECTIVITY.md): ESP32-C6 boundary and split with the platform/OS layer
 - [../VECTOR_MEMORY.md](../VECTOR_MEMORY.md): vector-memory design and rollout guidance
 - Local-only `ROADMAP.md`, if present: private product and execution planning
 - [../skills/SKILL-DEVELOPER-GUIDE.md](../skills/SKILL-DEVELOPER-GUIDE.md): native skill authoring
@@ -76,6 +76,6 @@ There are a few intentional limits:
 - `genie-ai-runtime`, `llama.cpp`, Home Assistant, Piper, Whisper, and Telegram
   Bot API internals are external dependencies. This repo documents how
   GenieClaw integrates with them, not their full upstream behavior.
-- `genie-os`, `genie-voice-runtime`, `genie-home-runtime`, and
+- The platform/OS layer, external voice boundary, external home boundary, and
   `genie-ai-runtime` are documented as architectural boundaries unless code in
   this repo already implements a client or transitional adapter.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -333,7 +333,7 @@ Behavior notes:
 | `response_timeout_ms` | UART response timeout |
 
 Legacy alias support exists for `esp32c6_spi`, but the current boundary is
-UART-oriented and the detailed SPI hosted work belongs in `genie-os`.
+UART-oriented and the detailed SPI hosted work belongs in the platform/OS layer.
 
 ## Environment Overrides And Related Runtime Variables
 

--- a/doc/core-subsystems.md
+++ b/doc/core-subsystems.md
@@ -211,7 +211,7 @@ Current transitional source:
 
 Long-term owner:
 
-- [`genie-voice-runtime`](https://github.com/GeniePod/genie-voice-runtime)
+- external voice boundary
 
 GenieClaw should own:
 
@@ -221,7 +221,7 @@ GenieClaw should own:
 - memory/tool/home-intent policy for voice-origin requests
 - shared-room safety policy
 
-`genie-voice-runtime` should own:
+The external voice boundary should own:
 
 - wake word
 - VAD
@@ -245,9 +245,9 @@ Notable modules:
 - `aec.rs`
 - `vad.rs`
 
-These modules remain a Jetson alpha bring-up path until the external runtime is
-production-ready. New voice-pipeline implementation should target
-`genie-voice-runtime` unless it is strictly an agent-layer behavior change.
+These modules remain a Jetson alpha bring-up path until the external voice
+boundary is production-ready. New voice-pipeline implementation should target
+that boundary unless it is strictly an agent-layer behavior change.
 
 ## Security And Guardrails
 

--- a/doc/deployment-and-ops.md
+++ b/doc/deployment-and-ops.md
@@ -219,7 +219,7 @@ These are current system realities, not bugs in the docs:
 
 - LLM context size is constrained by Jetson memory and model choice.
 - Voice mode is more sensitive to process scheduling, audio-device selection, and GPU time-sharing than plain chat mode.
-- The connectivity boundary exists, but full ESP-Hosted-NG OS ownership belongs in `genie-os`, not in this runtime repo.
+- The connectivity boundary exists, but full ESP-Hosted-NG OS ownership belongs in the platform/OS layer, not in this runtime repo.
 - The ESP32-C6 UART path is currently a health/capability boundary, not a full Thread/Matter controller implementation.
 - Local speaker identity is useful for household memory routing, not security-grade authentication.
 - Multilingual voice depends on installed STT/TTS models and per-language device testing.

--- a/doc/implementation-status.md
+++ b/doc/implementation-status.md
@@ -28,7 +28,7 @@ Status labels:
 | Home action safety in agent layer | Implemented | `crates/genie-core/src/tools/actuation.rs`, `crates/genie-core/src/ha/policy.rs` | Origin allowlist, target confidence thresholds, sensitive-action confirmation tokens, rate limits, action ledger, bounded undo, and append-only audit log. |
 | Runtime contract | Implemented | `crates/genie-core/src/runtime_contract.rs`, `crates/genie-core/src/server.rs` | Prompt/tool/policy/hydration fingerprints, optional drift detection, and boot contract log. |
 | Household security posture | Implemented | `crates/genie-api/src/routes.rs`, `crates/genie-core/src/security/*` | Dashboard exposes redacted posture instead of raw config. Security helpers include audit, credential isolation, env sanitization, injection scanning, loop guard, sandbox helpers, and taint tracking. |
-| Voice pipeline modules | Transitional | `crates/genie-core/src/voice_loop.rs`, `crates/genie-core/src/voice/*` | Current Jetson alpha bring-up path. Long-term ownership belongs in `genie-voice-runtime`; GenieClaw should consume transcripts and issue speak commands rather than own wake/VAD/STT/TTS/audio. |
+| Voice pipeline modules | Transitional | `crates/genie-core/src/voice_loop.rs`, `crates/genie-core/src/voice/*` | Current Jetson alpha bring-up path. Long-term ownership belongs behind an external voice boundary; GenieClaw should consume transcripts and issue speak commands rather than own wake/VAD/STT/TTS/audio. |
 | Optional local speaker identity | Implemented | `crates/genie-core/src/voice/identity.rs`, `crates/genie-ctl/src/main.rs` | Local WAV-derived profile enrollment/matching and voice memory-context routing. This is household routing, not hostile-user authentication. |
 | Native skill loading | Implemented | `crates/genie-core/src/skills/*`, `crates/genie-skill-sdk/*` | Loads native `.so` skills through a narrow ABI, exposes skills as tools, and audits sidecar manifest metadata. |
 | Skill policy | Implemented | `crates/genie-common/src/config.rs`, `crates/genie-core/src/skills/loader.rs` | Can require manifests, require signature material presence, and deny permission labels. Cryptographic signature verification is not implemented. |
@@ -41,24 +41,24 @@ Status labels:
 
 | Area | Status | What Exists | What Is Still Missing |
 | --- | --- | --- | --- |
-| Home Assistant integration | Partial / transitional | Provider boundary, status/control/history/undo, local action safety, HA token/config path | Home Assistant is not reimplemented in Rust here. Final device graph, automations, and deterministic physical safety belong in `genie-home-runtime`. |
+| Home Assistant integration | Partial / transitional | Provider boundary, status/control/history/undo, local action safety, HA token/config path | Home Assistant is not reimplemented in Rust here. Final device graph, automations, and deterministic physical safety belong behind an external home boundary. |
 | LLM runtime | External / integrated | `crates/genie-core/src/llm/*`, `deploy/systemd/genie-ai-runtime.service`, `[services.llm].backend = "genie_ai_runtime"` | Jetson deploys default to the external `genie-ai-runtime` on `:8080`; `llama.cpp` remains a selectable fallback/development backend. OpenAI-compatible/API/OAuth providers are transitional development and testing adapters only. |
 | Voice multilingual support | Partial | STT language hint/auto mode, language detection, and optional per-language Piper model selection | Full quality for Chinese, Spanish, German, etc. depends on installed Whisper/Piper models and device testing. It is not a certified full-language product yet. |
 | Speaker recognition | Partial | Local acoustic fingerprints from WAV profiles and runtime matching | Not robust biometric authentication, anti-spoofing, enrollment UX, or security-grade identity. |
-| ESP32-C6 connectivity | Partial boundary | Config, status endpoint, capability model, UART path validation, Thread/Matter capability intent | No real UART protocol controller, no Thread/Matter stack, no ESP-Hosted-NG implementation in this repo. ESP-Hosted-NG belongs in `genie-os`; protocol ownership belongs in `genie-home-runtime`/connectivity services. |
+| ESP32-C6 connectivity | Partial boundary | Config, status endpoint, capability model, UART path validation, Thread/Matter capability intent | No real UART protocol controller, no Thread/Matter stack, no ESP-Hosted-NG implementation in this repo. ESP-Hosted-NG belongs in the platform/OS layer; protocol ownership belongs in external home/connectivity services. |
 | Native skill security | Partial | ABI boundary, manifest audit, configurable load policy, signature material presence check | No cryptographic signature verification, process isolation, syscall sandbox, marketplace, or full permission broker. |
 | Memory dashboard | Partial / implemented admin surface | HTTP endpoints and dashboard proxy for list/update/delete/reorder | Product-grade UI/UX, conflict resolution, and multi-device sync are app-layer work. |
 | Web/mobile application layer | Partial | Lightweight local dashboard and chat UI | Full installer, setup, mobile app, push notifications, and polished memory manager are not implemented here. |
-| OTA/update flow | Partial | Update-check module and CLI command | Full signed OTA channels, rollback, fleet management, and image-level update ownership belong to `genie-os`. |
+| OTA/update flow | Partial | Update-check module and CLI command | Full signed OTA channels, rollback, fleet management, and image-level update ownership belong to the platform/OS layer. |
 
 ## Not Implemented In This Repo
 
 | Area | Status | Correct Owner |
 | --- | --- | --- |
-| `genie-home-runtime` | Planned / separate repo | Rust AI-native home automation engine, device graph, automations, MCP server, deterministic final physical safety layer. |
+| External home boundary | Planned | AI-native home automation engine, device graph, automations, MCP/server API, deterministic final physical safety layer. |
 | `genie-ai-runtime` | External / separate repo | Jetson-only inference runtime, CUDA kernels, memory planner, and OpenAI-compatible serving surface. GenieClaw owns the client contract, not the runtime implementation. |
-| `genie-voice-runtime` | Initial / separate repo | External voice runtime for wake, VAD, STT, TTS, audio streaming, and voice session protocol. |
-| `genie-os` | Planned / separate repo | Custom L4T image, board bring-up, drivers, OTA base image, service supervision, ESP-Hosted-NG OS integration. |
+| External voice boundary | Initial / planned | External voice runtime for wake, VAD, STT, TTS, audio streaming, and voice session protocol. |
+| Platform/OS layer | Planned | Custom L4T image, board bring-up, drivers, OTA base image, service supervision, ESP-Hosted-NG OS integration. |
 | Full Matter/Thread/Zigbee/BLE production stack | Planned outside this repo | Lower connectivity/home-runtime layers. |
 | Full vector/cuVS semantic memory backend | Planned design only | `VECTOR_MEMORY.md` describes the rollout. Current runtime uses SQLite FTS, not embeddings/vector search. |
 | Cryptographic skill signing and sandboxed marketplace | Planned | Later signed skill platform. Current code only audits manifests and signature material presence. |

--- a/doc/milestone-1-portable-home-agent.md
+++ b/doc/milestone-1-portable-home-agent.md
@@ -14,7 +14,7 @@ The original target remains specific:
 - GeniePod Home on Jetson-class hardware
 - local-first voice interaction
 - `genie-ai-runtime` as the flagship local LLM runtime
-- Home Assistant today, `genie-home-runtime` as the longer-term home boundary
+- Home Assistant today, external home boundary as the longer-term direction
 - private memory, safety gates, audit trails, and bounded physical actuation
 - small context windows because VRAM and latency are tight on edge hardware
 

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -28,9 +28,9 @@ contract rather than redefine the product.
 The long-term Genie stack is split by responsibility:
 
 - custom Jetson hardware
-- `genie-os` for custom L4T, drivers, OTA, diagnostics, and service supervision
-- `genie-voice-runtime` for wake/VAD/STT/TTS/audio streaming and voice session events
-- `genie-home-runtime` for device graph, automations, MCP, and final actuation safety
+- a platform/OS layer for custom L4T, drivers, OTA, diagnostics, and service supervision
+- an external voice boundary for wake/VAD/STT/TTS/audio streaming and voice session events
+- an external home boundary for device graph, automations, MCP, and final actuation safety
 - `genie-ai-runtime` for Jetson-only LLM inference optimization
 - `genie-claw` for agent policy, memory, tools, skills, smart-home intent, and interaction
 - web/mobile apps for setup, control, memory management, and confirmations
@@ -54,8 +54,8 @@ For the exact implemented/partial/planned breakdown, use
 [implementation-status.md](implementation-status.md). In short, this repo
 implements the agent runtime, memory, tools, a transitional voice adapter,
 local HTTP/CLI surfaces, safety gates, and deploy assets. It does not implement
-the final `genie-voice-runtime`, `genie-home-runtime`, `genie-ai-runtime`,
-`genie-os`, or full Matter/Thread device stack.
+the final voice runtime, home runtime, `genie-ai-runtime`, platform/OS layer,
+or full Matter/Thread device stack.
 
 ## Main Runtime Modes
 
@@ -69,7 +69,7 @@ the final `genie-voice-runtime`, `genie-home-runtime`, `genie-ai-runtime`,
    daemon-only behavior.
 3. Voice mode
    Enabled by config, `--voice`, or `GENIEPOD_VOICE=1`. Today this still uses a
-   transitional in-repo voice path. Long term, `genie-voice-runtime` owns
+   transitional in-repo voice path. Long term, the external voice boundary owns
    microphone -> STT and TTS -> speaker, while GenieClaw owns transcript ->
    prompt/tool execution -> response text.
 
@@ -104,7 +104,7 @@ Target topology:
 genie-ai-runtime
         ^
         |
-genie-voice-runtime
+external voice boundary
         ^
         |
 genie-claw
@@ -112,10 +112,10 @@ genie-claw
         +---- web/mobile apps and local channels
         +---- memory, tools, skills
         v
-genie-home-runtime
+external home boundary
         |
         v
-GenieOS + custom Jetson hardware
+platform/OS + custom Jetson hardware
 ```
 
 The target home runtime owns direct local IoT interfaces and the final physical

--- a/doc/repo-map.md
+++ b/doc/repo-map.md
@@ -72,7 +72,7 @@ default and exist only for development, testing, and transitional validation.
 - `ha/policy.rs`
 
 This is the current home-runtime adapter. It points at Home Assistant today and
-should point at `genie-home-runtime` later.
+should point at the external home boundary later.
 
 ### Tools
 

--- a/doc/services-and-crates.md
+++ b/doc/services-and-crates.md
@@ -15,8 +15,8 @@ Jetson appliance deployment, but the long-term boundary is clear:
   remains a selectable fallback and development backend.
 - Optional OpenAI-compatible/API providers are for development portability,
   testing, and transitional validation only.
-- Future `genie-home-runtime` should replace the Home Assistant lower-runtime adapter.
-- `genie-voice-runtime` is the new external owner for wake/VAD/STT/TTS/audio behavior.
+- A future external home boundary should replace the Home Assistant lower-runtime adapter.
+- An external voice boundary should own wake/VAD/STT/TTS/audio behavior.
 
 For the current truth matrix, see
 [implementation-status.md](implementation-status.md).
@@ -46,7 +46,7 @@ Primary responsibilities:
 - select and execute built-in tools
 - load and execute native skills
 - integrate Home Assistant through a provider boundary
-- run the transitional voice adapter until `genie-voice-runtime` is the production voice path
+- run the transitional voice adapter until the external voice boundary is the production voice path
 - expose connectivity health from the coprocessor boundary
 - optionally run the Telegram adapter
 
@@ -143,8 +143,8 @@ Key files:
 - `genie-core`: `:3000`
 - LLM backend: `:8080`; Jetson default is `genie-ai-runtime`, fallback/dev is
   `llama.cpp` `llama-server`
-- Home Assistant: commonly `:8123` today; future replacement is `genie-home-runtime`
-- `genie-voice-runtime`: external voice runtime; protocol and port are still stabilizing
+- Home Assistant: commonly `:8123` today; future replacement is the external home boundary
+- external voice runtime: protocol and port are still stabilizing
 - `genie-api`: separate dashboard service port, depending on deploy setup
 
 ### Local IPC


### PR DESCRIPTION
## Summary

Generalizes transitional/future runtime boundary wording so the docs do not name future home/voice/OS repos during the development transition. Keeps the core goal intact: low-latency private home AI with maintained SBC profiles.

## Changes

- Replace named future home/voice/platform repo references with generic external boundary language.
- Keep current shipped deploy surfaces concrete, including `genie-ai-runtime` where it is the active local LLM runtime.
- Update `runtime_boundary` owner labels to generic `external_voice_boundary` and `external_home_boundary`.
- Sync README, architecture, low-latency goal, implementation status, services, config, and connectivity docs.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

```bash
cargo fmt --all
cargo test -p genie-core runtime_boundary
cargo clippy -p genie-core --all-targets -- -D warnings
git diff --check
grep -RInE 'genie-home-runtime|genie-voice-runtime|genie-os|GenieOS' README.md ARCHITECTURE.md LOW_LATENCY_HOME_AGENT.md doc deploy crates --exclude-dir=target
grep -RInE 'maintained.*SBC|SBC profiles|external home boundary|external voice boundary|platform/OS layer' README.md ARCHITECTURE.md LOW_LATENCY_HOME_AGENT.md doc deploy crates --exclude-dir=target
```

### What I observed

The runtime-boundary tests passed, clippy passed with `-D warnings`, and `git diff --check` passed. The removed-name grep returned no matches. The boundary/SBC grep shows the docs now use generic transition language while preserving the maintained-SBC and core low-latency home-agent direction.

Not Jetson-tested because this PR changes docs, comments, and boundary metadata labels only; no deployed service behavior was exercised.

## Test plan

- Review rendered docs for generic transition wording.
- Confirm CI passes.