### PR TITLE
fix: return 500 when tegrastats DB read fails instead of empty 200

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 # macOS metadata
 .DS_Store
 **/.DS_Store
+data/

--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -88,10 +88,28 @@ pub async fn get_tegrastats(config: &Config) -> Response {
             content_type: "application/json",
             body: json,
         },
-        _ => Response {
-            status: 200,
-            content_type: "application/json",
-            body: "[]".into(),
+        Ok(Err(e)) => {
+            tracing::error!(%e, "failed to read tegrastats from governor.db");
+            Response {
+                status: 500,
+                content_type: "application/json",
+                body: serde_json::json!({
+                    "error": "failed to read tegrastats data",
+                    "detail": e
+                })
+                .to_string(),
+            }
+        },
+        Err(e) => {
+            tracing::error!(%e, "tegrastats spawn_blocking panicked or was cancelled");
+            Response {
+                status: 500,
+                content_type: "application/json",
+                body: serde_json::json!({
+                    "error": "internal error reading tegrastats"
+                })
+                .to_string(),
+            }
         },
     }
 }
@@ -1117,5 +1135,18 @@ mod tests {
         );
         assert_eq!(wakeword.source, "config");
         assert_eq!(wakeword.sub_state, "disabled");
+    }
+
+    #[tokio::test]
+    async fn tegrastats_returns_500_when_db_does_not_exist() {
+        let mut config = test_config();
+        // Point to a path that definitely doesn't exist
+        config.data_dir = std::path::PathBuf::from("/tmp/nonexistent-tegrastats-test-12345");
+
+        let response = get_tegrastats(&config).await;
+
+        assert_eq!(response.status, 500);
+        assert!(response.body.contains("error"));
+        assert!(response.body.contains("failed to read tegrastats data"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #247 — `/api/tegrastats` returned HTTP 200 with an empty array `[]` when the governor.db SQLite read failed, hiding the failure from callers. Now it returns 500 with a descriptive error body.

## Changes

- Split the `match result` in `get_tegrastats` to handle `Ok(Err(_))` and `Err(_)` separately, each returning HTTP 500 with a JSON error body
- Added `tracing::error!` calls so DB failures are logged server-side
- Added `.gitignore` entry for `data/` directory (runtime artifacts)
- Added test `tegrastats_returns_500_when_db_does_not_exist`

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

`cargo test -p genie-api` on WSL2 Ubuntu 22.04 on Windows 10 (profile: `laptop`).

### What I observed

All existing tests passed. New test `tegrastats_returns_500_when_db_does_not_exist` passed — confirms a missing governor.db returns HTTP 500 with `{"error":"failed to read tegrastats data","detail":"..."}` instead of HTTP 200 with `[]`.

Validation gap: this change is purely in the HTTP response layer for a SQLite read error. No Jetson-specific hardware or tegrastats parser behavior is affected. The error path is exercised via a non-existent DB path in the test, which covers the same code branches that would run on Jetson when the DB is corrupted or inaccessible.

## Test plan

1. Run `cargo test -p genie-api` — all tests pass
2. Optionally, point `data_dir` at a non-existent path and hit `/api/tegrastats` — observe 500 response

## Notes for reviewers

None.