### PR TITLE
Block shared-room storage of household secrets

### DIFF
--- a/VECTOR_MEMORY.md
+++ b/VECTOR_MEMORY.md
@@ -175,6 +175,8 @@ Suggested shape:
   - promoted memories
   - imported profile/doc facts
   - high-signal notes
+- skip memories that policy marks restricted, app-only, or not safe for the
+  target disclosure class
 
 Do not embed every turn by default.
 
@@ -266,6 +268,8 @@ If semantic memory is added on Jetson, these rules should stay in force:
 - the default deployment must not require a vector backend
 - semantic indexing must be opt-in
 - embeddings should be computed selectively, not for every utterance
+- restricted memories, credentials, access codes, and sensitive document/key
+  locations must not be embedded
 - vector memory must not reduce LLM reliability
 - if GPU memory is tight, semantic search must disable itself automatically
 

--- a/crates/genie-core/src/memory/policy.rs
+++ b/crates/genie-core/src/memory/policy.rs
@@ -2,7 +2,8 @@
 //!
 //! This is the code-level version of the product memory policy:
 //! household memory is useful by default, private memory is opt-in, and
-//! high-risk secrets should not be captured through room voice.
+//! high-risk secrets and sensitive household locations should not be
+//! captured through room voice.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryScope {
@@ -340,6 +341,29 @@ fn restricted_secret_reason(lower: &str) -> Option<&'static str> {
     if contains_any(
         lower,
         &[
+            "gate code",
+            "door code",
+            "garage code",
+            "alarm code",
+            "security code",
+            "safe code",
+            "safe combination",
+            "lock combination",
+            "lock combo",
+            "bike lock combo",
+            "bicycle lock combo",
+            "bike lock combination",
+            "bicycle lock combination",
+        ],
+    ) {
+        return Some(
+            "I should not store household access codes or lock combinations as voice memory.",
+        );
+    }
+
+    if contains_any(
+        lower,
+        &[
             "credit card",
             "card number",
             "cvv",
@@ -357,7 +381,74 @@ fn restricted_secret_reason(lower: &str) -> Option<&'static str> {
         );
     }
 
+    if describes_sensitive_location(lower) {
+        return Some(
+            "I should not store sensitive document, key, or safe locations as voice memory.",
+        );
+    }
+
     None
+}
+
+fn describes_sensitive_location(lower: &str) -> bool {
+    let sensitive_object = contains_any(
+        lower,
+        &[
+            "passport",
+            "passports",
+            "birth certificate",
+            "birth certificates",
+            "social security card",
+            "ssn card",
+            "government id",
+            "house key",
+            "spare key",
+            "safe key",
+            "car title",
+            "property deed",
+        ],
+    );
+    if sensitive_object && contains_location_phrase(lower) {
+        return true;
+    }
+
+    contains_any(
+        lower,
+        &[
+            "documents are in the safe",
+            "documents are inside the safe",
+            "important documents are in",
+            "important documents are kept",
+            "valuables are in the safe",
+            "valuables are inside the safe",
+        ],
+    )
+}
+
+fn contains_location_phrase(lower: &str) -> bool {
+    contains_any(
+        lower,
+        &[
+            " is in ",
+            " are in ",
+            " is inside ",
+            " are inside ",
+            " is kept in ",
+            " are kept in ",
+            " is kept at ",
+            " are kept at ",
+            " is stored in ",
+            " are stored in ",
+            " is stored at ",
+            " are stored at ",
+            " is hidden in ",
+            " are hidden in ",
+            " is hidden under ",
+            " are hidden under ",
+            " under ",
+            " behind ",
+        ],
+    )
 }
 
 fn contains_any(haystack: &str, needles: &[&str]) -> bool {
@@ -384,6 +475,24 @@ mod tests {
         assert!(!decision.allowed);
         assert_eq!(decision.disclosure, MemoryDisclosure::Deny);
         assert!(decision.reason.contains("passwords"));
+    }
+
+    #[test]
+    fn household_access_code_memory_is_rejected() {
+        let decision = assess_memory_write("fact", "the gate code is 5829");
+
+        assert!(!decision.allowed);
+        assert_eq!(decision.disclosure, MemoryDisclosure::Deny);
+        assert!(decision.reason.contains("access codes"));
+    }
+
+    #[test]
+    fn sensitive_location_memory_is_rejected() {
+        let decision = assess_memory_write("fact", "the passports are in the safe");
+
+        assert!(!decision.allowed);
+        assert_eq!(decision.disclosure, MemoryDisclosure::Deny);
+        assert!(decision.reason.contains("sensitive document"));
     }
 
     #[test]

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -2134,6 +2134,30 @@ mod tests {
     }
 
     #[test]
+    fn memory_store_rejects_household_access_code() {
+        let db = std::env::temp_dir().join(format!(
+            "memory-store-access-code-test-{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db);
+        let memory = crate::memory::Memory::open(&db).unwrap();
+        let dispatcher =
+            ToolDispatcher::new(None).with_memory(Arc::new(std::sync::Mutex::new(memory)));
+
+        let result = dispatcher
+            .exec_memory_store(&serde_json::json!({
+                "content": "remember that the gate code is 5829",
+                "category": "fact"
+            }))
+            .unwrap();
+
+        assert!(result.contains("should not store household access codes"));
+
+        let mem = dispatcher.memory.as_ref().unwrap().lock().unwrap();
+        assert!(mem.search("gate", 5).unwrap().is_empty());
+    }
+
+    #[test]
     fn memory_recall_formats_name_answers_naturally() {
         let db = std::env::temp_dir().join(format!("memory-recall-test-{}.db", std::process::id()));
         let _ = std::fs::remove_file(&db);

--- a/doc/household-security.md
+++ b/doc/household-security.md
@@ -55,12 +55,39 @@ memory as product data with visibility rules:
 - household facts can be recalled in shared spaces
 - personal facts need speaker/profile context before disclosure
 - sensitive facts should not be volunteered by voice
+- secrets, access codes, credentials, and sensitive document/key locations are
+  not valid shared-room memory
 - dashboard memory management should show editable saved memories, not raw
   database rows or config files
 
 Speaker recognition improves routing; it is not a hard security boundary unless
 the deployment explicitly adds biometric enrollment, local profile storage,
 fallback policy, and user-visible review.
+
+## Memory Retrieval Is Not Authorization
+
+Recall answers the question "what candidate facts might be relevant?" It does
+not answer "may this fact be revealed?" or "may this action execute?"
+
+GenieClaw keeps these decisions separate:
+
+- recall layer: structured records, SQLite `FTS5`, and optional semantic
+  retrieval can find candidate memories
+- classification layer: each memory is scoped and tagged by sensitivity before
+  it is injected, spoken, or shown
+- policy layer: the current origin, room context, speaker confidence, and
+  memory metadata decide whether disclosure is allowed, confirm-required,
+  app-only, or denied
+- action layer: device control, media, purchases, security, network, and other
+  side effects pass through tool policy and actuation safety even if memory
+  retrieval found the right target
+- audit layer: tool execution records the tool name, origin, success state, and
+  argument keys without logging secret values
+
+This means a memory hit can still produce a refusal or confirmation request.
+For example, a remembered allergy may be safe to reveal to a caregiver, while a
+gate code, Wi-Fi password, safe location, or purchase request must not be
+treated as ordinary recall.
 
 ## Practical Rules
 


### PR DESCRIPTION
## Summary
- Reject household access codes and lock combinations in voice/tool memory storage.
- Reject sensitive document, key, and safe-location memories before they become recallable notes.
- Document that memory retrieval is not authorization and that vector memory must not embed restricted household secrets.

## Real Behavior Proof
- [x] Verified locally on this machine.
- cargo fmt --check
- cargo test -p genie-core memory::policy -- --nocapture
- cargo test -p genie-core tools::dispatch::tests::memory_store_rejects_household_access_code -- --nocapture
- cargo test -p genie-core --test memory_recall -- --nocapture