### PR TITLE
Expose managed memory disclosure class

### DIFF
--- a/crates/genie-core/src/memory/mod.rs
+++ b/crates/genie-core/src/memory/mod.rs
@@ -100,6 +100,7 @@ pub struct ManagedMemoryEntry {
     pub scope: String,
     pub sensitivity: String,
     pub spoken_policy: String,
+    pub disclosure_class: String,
     pub namespace: String,
     pub canonical_note: Option<String>,
     pub display_order: i64,
@@ -565,14 +566,13 @@ impl Memory {
             .collect::<Vec<_>>();
 
         for entry in &mut entries {
-            entry.namespace = canonical_namespace(
-                &entry.kind,
-                policy::MemoryPolicyMetadata {
-                    scope: policy::MemoryScope::from_storage(&entry.scope),
-                    sensitivity: policy::MemorySensitivity::from_storage(&entry.sensitivity),
-                    spoken_policy: policy::SpokenMemoryPolicy::from_storage(&entry.spoken_policy),
-                },
-            );
+            let metadata = policy::MemoryPolicyMetadata {
+                scope: policy::MemoryScope::from_storage(&entry.scope),
+                sensitivity: policy::MemorySensitivity::from_storage(&entry.sensitivity),
+                spoken_policy: policy::SpokenMemoryPolicy::from_storage(&entry.spoken_policy),
+            };
+            entry.disclosure_class = policy::classify_memory(metadata).as_str().to_string();
+            entry.namespace = canonical_namespace(&entry.kind, metadata);
             entry.canonical_note = if entry.promoted {
                 Some(format!(
                     "memory/{}",
@@ -1207,6 +1207,7 @@ fn read_managed_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<ManagedMemory
         scope: row.get::<_, String>(7)?,
         sensitivity: row.get::<_, String>(8)?,
         spoken_policy: row.get::<_, String>(9)?,
+        disclosure_class: String::new(),
         namespace: String::new(),
         canonical_note: None,
         display_order: row.get::<_, i64>(10).unwrap_or(i64::MAX),
@@ -2001,6 +2002,7 @@ mod tests {
         let entries = mem.list_managed(10).unwrap();
         let entry = entries.into_iter().find(|entry| entry.id == id).unwrap();
         assert_eq!(entry.namespace, "household.preference");
+        assert_eq!(entry.disclosure_class, "household");
         assert_eq!(
             entry.canonical_note.as_deref(),
             Some("memory/namespaces/household/preference.md")

--- a/doc/http-and-cli.md
+++ b/doc/http-and-cli.md
@@ -318,7 +318,7 @@ Served by `crates/genie-api/src/routes.rs`.
 | `GET` | `/api/actuation/actions` | Recent executed actions from `genie-core` |
 | `GET` | `/api/actuation/audit` | Recent actuation audit events |
 | `POST` | `/api/actuation/confirm` | Confirm a pending actuation token |
-| `GET` | `/api/memories` | List saved memories for dashboard management |
+| `GET` | `/api/memories` | List saved memories with scope, sensitivity, disclosure class, and dashboard ordering |
 | `POST` | `/api/memories/update` | Update one memory row |
 | `POST` | `/api/memories/delete` | Delete one memory row |
 | `POST` | `/api/memories/reorder` | Persist memory display order |


### PR DESCRIPTION
## Summary
- Add disclosure_class to managed memory entries returned by the memory API path.
- Derive the field from persisted scope, sensitivity, and spoken policy metadata.
- Document that /api/memories includes the disclosure class for dashboard management.

## Real Behavior Proof
- [x] Verified locally on this machine.
- cargo fmt --check
- cargo test -p genie-core memory::tests::list_managed_reports_namespace_and_canonical_note -- --nocapture
- cargo test -p genie-core memory::policy -- --nocapture