### PR TITLE
Align memory-store prompt secret guidance

### DIFF
--- a/crates/genie-core/src/llm/openai_compat.rs
+++ b/crates/genie-core/src/llm/openai_compat.rs
@@ -1156,7 +1156,7 @@ fn compact_genie_runtime_rules(system_text: &str) -> String {
         "If no tool is needed, answer naturally in 1-3 short sentences.",
         "Use calculate for math, get_weather for weather, get_time for time, and system_info for system/Home Assistant/memory diagnostics.",
         "Use memory_recall when the user asks what you remember, what you know about them, or asks for their name.",
-        "Use memory_store only when the user explicitly asks you to remember/save something; never store secrets.",
+        "Use memory_store only when explicitly asked; never store secrets, access codes, lock combinations, or sensitive locations.",
     ];
 
     if system_text.contains("web_search") {

--- a/crates/genie-core/src/prompt.rs
+++ b/crates/genie-core/src/prompt.rs
@@ -155,7 +155,7 @@ Available tools:
 - When the user asks what you remember, what you know about them, or asks for their name back, use the memory_recall tool.
 - When the user asks about memory database health, memory index health, or memory diagnostics, use the memory_status tool.
 - Only use memory_store when the user explicitly asks you to remember or save something.
-- Do not store passwords, one-time codes, payment details, API keys, tokens, or private secrets as memory.
+- Do not store passwords, one-time codes, payment details, API keys, tokens, household access codes, lock combinations, sensitive document/key locations, or private secrets as memory.
 - If the user casually shares a fact like "my name is Jared", answer naturally and do not call memory_store just for that. The memory system can capture that automatically.
 - Assume replies may be heard in a shared room. Do not volunteer secrets or highly sensitive details.
 
@@ -263,7 +263,7 @@ Never send private secrets, passwords, tokens, API keys, local credentials, or o
 If the user asks what you remember, what you know about them, or asks for their name back, use memory_recall.
 If the user asks about memory database health, memory index health, or memory diagnostics, use memory_status.
 Only use memory_store when the user explicitly asks you to remember or save something.
-Do not store passwords, one-time codes, payment details, API keys, tokens, or private secrets as memory.
+Do not store passwords, one-time codes, payment details, API keys, tokens, household access codes, lock combinations, sensitive document/key locations, or private secrets as memory.
 If no tool is needed, just answer briefly (1-2 sentences).
 Assume replies may be heard in a shared room. Do not volunteer secrets or highly sensitive details.
 
@@ -525,6 +525,7 @@ mod tests {
         assert!(prompt.contains("\"memory_status\""));
         assert!(prompt.contains("memory database health"));
         assert!(prompt.contains("Only use memory_store when the user explicitly asks"));
+        assert!(prompt.contains("household access codes"));
         assert!(prompt.contains("my name is Jared"));
     }
 

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -465,7 +465,7 @@ impl ToolDispatcher {
 
         defs.push(ToolDef {
             name: "memory_store".into(),
-            description: "Explicitly store a safe household fact or preference. Use when the user says 'remember that...' or asks you to save something. Do not store passwords, one-time codes, payment details, keys, tokens, or private secrets.".into(),
+            description: "Explicitly store a safe household fact or preference. Use when the user says 'remember that...' or asks you to save something. Do not store passwords, one-time codes, payment details, keys, tokens, household access codes, lock combinations, sensitive document/key locations, or private secrets.".into(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## Summary
- Update capable and small-model prompts to avoid storing household access codes, lock combinations, and sensitive document/key locations.
- Align compact OpenAI-compatible rules with the runtime memory policy.
- Update the memory_store tool description and prompt test coverage.

## Real Behavior Proof
- [x] Verified locally on this machine.
- cargo fmt --check
- cargo test -p genie-core prompt::tests::prompt_guides_memory_recall_and_store_correctly -- --nocapture
- cargo test -p genie-core tools::dispatch::tests::tool_defs_hide_home_tools_when_unavailable -- --nocapture
- cargo test -p genie-core --test prompt_sha_test -- --nocapture