### PR TITLE
fix(tools/timer): cap active timers and bound set_timer duration (closes #209)

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -908,7 +908,9 @@ impl ToolDispatcher {
             .get("label")
             .and_then(|v| v.as_str())
             .unwrap_or("timer");
-        self.timers.set(seconds, label);
+        self.timers
+            .set(seconds, label)
+            .map_err(|e| anyhow::anyhow!(e))?;
         Ok(format!("Timer set for {} seconds: {}", seconds, label))
     }
 

--- a/crates/genie-core/src/tools/timer.rs
+++ b/crates/genie-core/src/tools/timer.rs
@@ -1,5 +1,10 @@
 use std::sync::{Arc, Mutex};
 
+/// Maximum number of concurrent in-memory timers per process.
+pub const MAX_ACTIVE_TIMERS: usize = 64;
+/// Longest duration the timer tool accepts, in seconds (7 days).
+pub const MAX_TIMER_SECONDS: u64 = 7 * 24 * 3600;
+
 #[derive(Debug, Clone)]
 struct Timer {
     label: String,
@@ -27,15 +32,38 @@ impl TimerManager {
         Self::default()
     }
 
-    pub fn set(&self, seconds: u64, label: &str) {
-        let end_ms = now_ms() + seconds * 1000;
-        let timer = Timer {
+    /// Register a countdown timer.
+    ///
+    /// Returns an error (instead of growing memory unbounded or wrapping the
+    /// end timestamp) when the duration is zero/oversized or when the active
+    /// timer cap is already reached.
+    pub fn set(&self, seconds: u64, label: &str) -> Result<(), String> {
+        if seconds == 0 {
+            return Err("timer duration must be at least 1 second".to_string());
+        }
+        if seconds > MAX_TIMER_SECONDS {
+            return Err(format!(
+                "timer duration cannot exceed {MAX_TIMER_SECONDS} seconds (7 days)"
+            ));
+        }
+
+        let end_ms = seconds
+            .checked_mul(1000)
+            .and_then(|ms| now_ms().checked_add(ms))
+            .ok_or_else(|| "timer end time overflowed".to_string())?;
+
+        let mut timers = self.timers.lock().unwrap();
+        if timers.len() >= MAX_ACTIVE_TIMERS {
+            return Err(format!(
+                "too many active timers (max {MAX_ACTIVE_TIMERS}); wait for one to fire before setting another"
+            ));
+        }
+        timers.push(Timer {
             label: label.to_string(),
             end_ms,
-        };
-        let mut timers = self.timers.lock().unwrap();
-        timers.push(timer);
-        tracing::info!(seconds, label, "timer set");
+        });
+        tracing::info!(seconds, label, active = timers.len(), "timer set");
+        Ok(())
     }
 
     /// Check and drain any fired timers.
@@ -66,4 +94,77 @@ fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_accepts_valid_duration() {
+        let mgr = TimerManager::new();
+        assert!(mgr.set(60, "pasta").is_ok());
+        assert_eq!(mgr.count(), 1);
+    }
+
+    #[test]
+    fn set_rejects_zero_duration() {
+        let mgr = TimerManager::new();
+        let err = mgr.set(0, "instant").unwrap_err();
+        assert!(err.contains("at least 1 second"), "got: {err}");
+        assert_eq!(mgr.count(), 0);
+    }
+
+    #[test]
+    fn set_rejects_duration_above_cap() {
+        let mgr = TimerManager::new();
+        let err = mgr.set(MAX_TIMER_SECONDS + 1, "too-long").unwrap_err();
+        assert!(err.contains("cannot exceed"), "got: {err}");
+        assert_eq!(mgr.count(), 0);
+    }
+
+    #[test]
+    fn set_accepts_max_duration_boundary() {
+        let mgr = TimerManager::new();
+        assert!(mgr.set(MAX_TIMER_SECONDS, "max").is_ok());
+        assert_eq!(mgr.count(), 1);
+    }
+
+    #[test]
+    fn set_rejects_overflowing_duration() {
+        let mgr = TimerManager::new();
+        // u64::MAX would wrap the end timestamp with unchecked arithmetic.
+        let err = mgr.set(u64::MAX, "overflow").unwrap_err();
+        // Caught by the duration cap before the multiply, but either way it must error.
+        assert!(!err.is_empty());
+        assert_eq!(mgr.count(), 0);
+    }
+
+    #[test]
+    fn set_enforces_active_timer_cap() {
+        let mgr = TimerManager::new();
+        for i in 0..MAX_ACTIVE_TIMERS {
+            mgr.set(60, &format!("t{i}")).unwrap();
+        }
+        let err = mgr.set(60, "one-too-many").unwrap_err();
+        assert!(err.contains("too many active timers"), "got: {err}");
+        assert_eq!(mgr.count(), MAX_ACTIVE_TIMERS);
+    }
+
+    #[test]
+    fn check_fired_drains_expired_and_keeps_pending() {
+        let mgr = TimerManager::new();
+        {
+            let mut timers = mgr.timers.lock().unwrap();
+            timers.push(Timer {
+                label: "expired".into(),
+                end_ms: 0,
+            });
+        }
+        mgr.set(3600, "pending").unwrap();
+
+        let fired = mgr.check_fired();
+        assert_eq!(fired, vec!["expired".to_string()]);
+        assert_eq!(mgr.count(), 1);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #209. `TimerManager::set` appended to an unbounded `Vec` with no cap, so repeated `set_timer` tool calls could grow process memory without limit. It also computed the deadline with unchecked `seconds * 1000`, so an oversized duration could overflow and wrap the end timestamp into the past, firing the timer immediately.

## Changes

- **`crates/genie-core/src/tools/timer.rs`**
  - Add `MAX_ACTIVE_TIMERS = 64` and `MAX_TIMER_SECONDS = 7 * 24 * 3600` (7 days).
  - `set` now returns `Result<(), String>`: rejects `seconds == 0` and durations above the 7-day cap, computes the end time with `checked_mul(1000)` + `checked_add(now_ms())`, and refuses to push when the active-timer cap is reached.
  - `tracing::info!` on a successful set now also records `active` (current timer count).
  - 7 unit tests: valid set, zero duration, over-cap duration, max-duration boundary, overflow (`u64::MAX`), active-timer cap, and `check_fired` draining expired while keeping pending timers.
- **`crates/genie-core/src/tools/dispatch.rs`**
  - `exec_set_timer` maps the new error to `anyhow` and returns it, so an over-limit / invalid request surfaces to the tool caller instead of silently mutating state.

No public API surface beyond `set`'s return type changed; the only in-tree caller (`exec_set_timer`) is updated in the same change.

## Real Behavior Proof

- [x] I have built and run the affected code locally.
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Built and tested on a Linux toolchain (Ubuntu via WSL2, `rustc 1.95.0`) on an x86_64 laptop — no Jetson available. This change is pure in-memory state/arithmetic in `tools/timer.rs`; it does not touch ALSA, Home Assistant, voice, or the runtime backend, so per CONTRIBUTING.md verification option 3 the changed path is exercised by the new unit tests and the aarch64 cross-compile CI job will confirm it builds on the deploy target.

```
$ cargo fmt -p genie-core -- --check
# clean, no diff

$ cargo clippy -p genie-core --all-targets --locked -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)
# exit 0, 0 warnings

$ cargo test -p genie-core --lib tools::timer --locked
running 7 tests
test tools::timer::tests::set_accepts_valid_duration ... ok
test tools::timer::tests::set_rejects_zero_duration ... ok
test tools::timer::tests::set_rejects_duration_above_cap ... ok
test tools::timer::tests::set_accepts_max_duration_boundary ... ok
test tools::timer::tests::set_rejects_overflowing_duration ... ok
test tools::timer::tests::set_enforces_active_timer_cap ... ok
test tools::timer::tests::check_fired_drains_expired_and_keeps_pending ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 536 filtered out

$ cargo test -p genie-core --no-default-features --lib tools::timer --locked
running 7 tests
... 7 passed; 0 failed; 0 ignored; 0 measured; 446 filtered out

$ cargo test --workspace --locked --all-targets --no-run
# exit 0 — entire workspace test suite compiles clean
```

### What I observed

- All 7 new tests pass under both default and `--no-default-features` feature sets; clippy is clean with `-D warnings` and `cargo fmt` reports no diff.
- `set_enforces_active_timer_cap` confirms the 65th concurrent timer is rejected and `count()` stays pinned at 64 — the unbounded-growth path from the issue is closed.
- `set_rejects_zero_duration`, `set_rejects_duration_above_cap`, and `set_rejects_overflowing_duration` confirm invalid durations error out instead of being stored, and `set_accepts_max_duration_boundary` confirms the exact 7-day boundary is still accepted.
- `check_fired_drains_expired_and_keeps_pending` confirms normal fire/drain behavior is unchanged for valid timers.

A maintainer with a Jetson can verify end-to-end by issuing repeated `set_timer` voice/tool calls past 64 active timers and confirming the agent reports "too many active timers" rather than continuing to accept them, and by requesting a 0-second or absurdly long timer and confirming it's refused.

## Test plan

- [ ] CI green: `cargo fmt`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked --all-targets`, the `--no-default-features` clippy/test job, and the aarch64 cross-compile.
- [ ] Re-verify locally: `cargo test -p genie-core --lib tools::timer --locked` — expect 7/7 pass.
- [ ] Optional Jetson check: drive `set_timer` past the active cap and with a zero/oversized duration; confirm the agent surfaces the error instead of silently accepting it.

## Notes for reviewers

- The 64-timer cap and 7-day max are conservative defaults that comfortably cover real "set a timer for N minutes" usage while bounding worst-case memory; happy to tune either constant if you'd prefer different limits.
- The overflow test passes `u64::MAX`, which is caught by the duration cap before the multiply; `checked_mul`/`checked_add` are still used as defense-in-depth so the arithmetic is overflow-safe regardless of how the cap evolves.