### PR TITLE
Classify tool action results

### DIFF
--- a/crates/genie-core/src/lib.rs
+++ b/crates/genie-core/src/lib.rs
@@ -80,4 +80,4 @@ pub use ha::{HaClient, HomeAssistantProvider, HomeAutomationProvider};
 pub use llm::{LlmClient, Message};
 pub use memory::{Memory, SharedMemory};
 pub use prompt::PromptBuilder;
-pub use tools::{ToolCall, ToolDispatcher, ToolResult};
+pub use tools::{ToolActionClass, ToolCall, ToolDispatcher, ToolResult};

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -36,8 +36,39 @@ pub struct ToolDef {
 #[derive(Debug, Serialize)]
 pub struct ToolResult {
     pub tool: String,
+    pub action_class: ToolActionClass,
     pub success: bool,
     pub output: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolActionClass {
+    ReadOnly,
+    Diagnostic,
+    MemoryRead,
+    MemoryWrite,
+    HomeActuation,
+    Media,
+    Network,
+    Timer,
+    Skill,
+}
+
+impl ToolActionClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read_only",
+            Self::Diagnostic => "diagnostic",
+            Self::MemoryRead => "memory_read",
+            Self::MemoryWrite => "memory_write",
+            Self::HomeActuation => "home_actuation",
+            Self::Media => "media",
+            Self::Network => "network",
+            Self::Timer => "timer",
+            Self::Skill => "skill",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -82,6 +113,7 @@ struct ActuationRateLimiter {
 struct ToolAuditEvent {
     ts_ms: u64,
     tool: String,
+    action_class: ToolActionClass,
     origin: RequestOrigin,
     success: bool,
     duration_ms: u64,
@@ -495,11 +527,13 @@ impl ToolDispatcher {
         exec_ctx: ToolExecutionContext,
     ) -> ToolResult {
         let started = Instant::now();
+        let action_class = tool_action_class(&call.name);
         if let Err(err) =
             tool_origin_allowed(&self.tool_policy, exec_ctx.request_origin, &call.name)
         {
             let tool_result = ToolResult {
                 tool: call.name.clone(),
+                action_class,
                 success: false,
                 output: format!("Tool blocked by origin policy: {err}"),
             };
@@ -529,11 +563,13 @@ impl ToolDispatcher {
         let tool_result = match result {
             Ok(output) => ToolResult {
                 tool: call.name.clone(),
+                action_class,
                 success: true,
                 output,
             },
             Err(e) => ToolResult {
                 tool: call.name.clone(),
+                action_class,
                 success: false,
                 output: e.to_string(),
             },
@@ -554,6 +590,7 @@ impl ToolDispatcher {
         self.tool_audit_logger.append(ToolAuditEvent {
             ts_ms: now_ms(),
             tool: call.name.clone(),
+            action_class: result.action_class,
             origin: exec_ctx.request_origin,
             success: result.success,
             duration_ms: started.elapsed().as_millis() as u64,
@@ -1114,6 +1151,20 @@ impl ToolDispatcher {
                 ))
             }
         }
+    }
+}
+
+pub fn tool_action_class(name: &str) -> ToolActionClass {
+    match name {
+        "home_control" | "home_undo" => ToolActionClass::HomeActuation,
+        "play_media" => ToolActionClass::Media,
+        "memory_recall" => ToolActionClass::MemoryRead,
+        "memory_forget" | "memory_store" => ToolActionClass::MemoryWrite,
+        "memory_status" | "system_info" | "action_history" => ToolActionClass::Diagnostic,
+        "web_search" | "get_weather" => ToolActionClass::Network,
+        "set_timer" => ToolActionClass::Timer,
+        "home_status" | "get_time" | "calculate" => ToolActionClass::ReadOnly,
+        _ => ToolActionClass::Skill,
     }
 }
 
@@ -1746,7 +1797,27 @@ mod tests {
         };
         let result = dispatcher.execute(&call).await;
         assert!(result.success);
+        assert_eq!(result.action_class, ToolActionClass::ReadOnly);
         assert!(!result.output.is_empty());
+    }
+
+    #[test]
+    fn tool_action_class_maps_side_effecting_tools() {
+        assert_eq!(
+            tool_action_class("home_control"),
+            ToolActionClass::HomeActuation
+        );
+        assert_eq!(
+            tool_action_class("memory_store"),
+            ToolActionClass::MemoryWrite
+        );
+        assert_eq!(
+            tool_action_class("memory_recall"),
+            ToolActionClass::MemoryRead
+        );
+        assert_eq!(tool_action_class("web_search"), ToolActionClass::Network);
+        assert_eq!(tool_action_class("custom_skill"), ToolActionClass::Skill);
+        assert_eq!(ToolActionClass::HomeActuation.as_str(), "home_actuation");
     }
 
     #[tokio::test]
@@ -1775,6 +1846,7 @@ mod tests {
         let line = std::fs::read_to_string(&path).unwrap();
         let event: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
         assert_eq!(event["tool"], "calculate");
+        assert_eq!(event["action_class"], "read_only");
         assert_eq!(event["origin"], "api");
         assert_eq!(event["success"], false);
         assert_eq!(event["argument_keys"], serde_json::json!(["expression"]));

--- a/crates/genie-core/src/tools/mod.rs
+++ b/crates/genie-core/src/tools/mod.rs
@@ -10,5 +10,5 @@ mod weather;
 pub(crate) mod web_search;
 
 pub use actuation::{PendingConfirmation, RequestOrigin};
-pub use dispatch::{ToolCall, ToolDispatcher, ToolExecutionContext, ToolResult};
+pub use dispatch::{ToolActionClass, ToolCall, ToolDispatcher, ToolExecutionContext, ToolResult};
 pub use parser::{try_tool_call, try_tool_call_with_context};

--- a/doc/household-security.md
+++ b/doc/household-security.md
@@ -81,7 +81,9 @@ GenieClaw keeps these decisions separate:
   app-only, or denied
 - action layer: device control, media, purchases, security, network, and other
   side effects pass through tool policy and actuation safety even if memory
-  retrieval found the right target
+  retrieval found the right target; tool results and audit events carry an
+  action class such as `read_only`, `memory_write`, `home_actuation`, network, media,
+  timer, or diagnostic
 - audit layer: tool execution records the tool name, origin, success state, and
   argument keys without logging secret values
 

--- a/doc/http-and-cli.md
+++ b/doc/http-and-cli.md
@@ -412,6 +412,8 @@ Home-control execution now has three separate safety layers:
 - first-pass local action policy
 - final runtime actuation gate plus append-only audit logging
 - recent action ledger for "what did you do?" and bounded undo
+- tool audit events include an `action_class` such as `read_only`,
+  `memory_write`, `home_actuation`, `network`, `media`, or `diagnostic`
 
 Memory tools are policy-aware:
 


### PR DESCRIPTION
## Summary
- add a typed tool action class to tool results and audit events
- classify read-only, memory, home actuation, media, network, timer, diagnostic, and skill tools
- document the action-class metadata for audit and policy boundaries

## Real Behavior Proof
- [x] `cargo fmt --check`
- [x] `cargo test -p genie-core tools::dispatch -- --nocapture`
- [x] `cargo test -p genie-core --test tool_gate_integration_test -- --nocapture`