### PR TITLE
feat(memory): add local semantic recall

### DIFF
--- a/crates/genie-core/src/memory/embedding.rs
+++ b/crates/genie-core/src/memory/embedding.rs
@@ -1,0 +1,153 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+pub const DEFAULT_EMBEDDING_DIMENSIONS: usize = 64;
+pub const DEFAULT_EMBEDDING_MODEL: &str = "local-hash-home-v1";
+pub const SEMANTIC_MIN_SCORE: f64 = 0.42;
+
+pub trait EmbeddingProvider {
+    fn model_name(&self) -> &'static str;
+    fn dimensions(&self) -> usize;
+    fn embed(&self, text: &str) -> Vec<f32>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LocalHashEmbeddingProvider;
+
+impl EmbeddingProvider for LocalHashEmbeddingProvider {
+    fn model_name(&self) -> &'static str {
+        DEFAULT_EMBEDDING_MODEL
+    }
+
+    fn dimensions(&self) -> usize {
+        DEFAULT_EMBEDDING_DIMENSIONS
+    }
+
+    fn embed(&self, text: &str) -> Vec<f32> {
+        let mut values = vec![0.0; self.dimensions()];
+        let expanded = expand_home_semantic_text(text);
+        for token in embedding_tokens(&expanded) {
+            let idx = token_bucket(&token, self.dimensions());
+            values[idx] += token_weight(&token);
+        }
+        normalize(&mut values);
+        values
+    }
+}
+
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
+    if a.is_empty() || b.is_empty() || a.len() != b.len() {
+        return 0.0;
+    }
+    let mut dot = 0.0f64;
+    let mut a_norm = 0.0f64;
+    let mut b_norm = 0.0f64;
+    for (left, right) in a.iter().zip(b) {
+        let left = f64::from(*left);
+        let right = f64::from(*right);
+        dot += left * right;
+        a_norm += left * left;
+        b_norm += right * right;
+    }
+    if a_norm == 0.0 || b_norm == 0.0 {
+        0.0
+    } else {
+        dot / (a_norm.sqrt() * b_norm.sqrt())
+    }
+}
+
+pub fn expand_home_semantic_text(text: &str) -> String {
+    let lower = text.to_ascii_lowercase();
+    let mut expanded = text.to_string();
+
+    if contains_any(&lower, &["cold", "chilly", "freezing"]) {
+        expanded.push_str(" thermostat temperature warm heat room comfort preference");
+    }
+    if contains_any(&lower, &["thermostat", "temperature", "heat", "warmer"]) {
+        expanded.push_str(" cold warm room comfort preference");
+    }
+    if lower.contains("snack") || lower.contains("lunchbox") || lower.contains("lunch box") {
+        expanded.push_str(" shopping grocery lunch school granola bars fruit snacks");
+    }
+    if lower.contains("detergent") {
+        expanded.push_str(" shopping grocery household laundry order");
+    }
+    if contains_any(&lower, &["movie", "watched", "robot", "real boy"]) {
+        expanded.push_str(" film watched kids robot real boy iron giant");
+    }
+    if lower.contains("coffee") && contains_any(&lower, &["machine", "maker", "brew"]) {
+        expanded.push_str(" device manual instructions brew strength start");
+    }
+
+    expanded
+}
+
+fn embedding_tokens(text: &str) -> Vec<String> {
+    let stop = [
+        "a", "an", "and", "are", "as", "at", "be", "by", "can", "did", "do", "does", "for", "from",
+        "have", "how", "i", "in", "is", "it", "me", "my", "of", "on", "or", "our", "please",
+        "that", "the", "this", "to", "was", "we", "what", "whats", "when", "where", "who", "with",
+        "you", "your",
+    ];
+    text.to_ascii_lowercase()
+        .split(|ch: char| !ch.is_alphanumeric())
+        .filter(|token| token.len() > 1 && !stop.contains(token))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
+}
+
+fn token_bucket(token: &str, dimensions: usize) -> usize {
+    let mut hasher = DefaultHasher::new();
+    token.hash(&mut hasher);
+    (hasher.finish() as usize) % dimensions
+}
+
+fn token_weight(token: &str) -> f32 {
+    match token {
+        "thermostat" | "temperature" | "snack" | "lunchbox" | "movie" | "robot" | "detergent"
+        | "coffee" => 1.8,
+        "preference" | "shopping" | "watched" | "manual" => 1.4,
+        _ => 1.0,
+    }
+}
+
+fn normalize(values: &mut [f32]) {
+    let norm = values
+        .iter()
+        .map(|value| f64::from(*value) * f64::from(*value))
+        .sum::<f64>()
+        .sqrt();
+    if norm == 0.0 {
+        return;
+    }
+    for value in values {
+        *value = (f64::from(*value) / norm) as f32;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_hash_embedding_is_stable_and_normalized() {
+        let provider = LocalHashEmbeddingProvider;
+        let first = provider.embed("Jared prefers the living room thermostat at 72F");
+        let second = provider.embed("Jared prefers the living room thermostat at 72F");
+        assert_eq!(first, second);
+        assert_eq!(first.len(), DEFAULT_EMBEDDING_DIMENSIONS);
+        assert!(cosine_similarity(&first, &second) > 0.99);
+    }
+
+    #[test]
+    fn home_semantic_expansion_links_cold_to_thermostat() {
+        let provider = LocalHashEmbeddingProvider;
+        let query = provider.embed("I'm feeling cold");
+        let memory = provider.embed("Jared prefers the living room thermostat at 72F");
+        assert!(cosine_similarity(&query, &memory) >= SEMANTIC_MIN_SCORE);
+    }
+}

--- a/crates/genie-core/src/memory/mod.rs
+++ b/crates/genie-core/src/memory/mod.rs
@@ -1,10 +1,12 @@
 pub mod decay;
+pub mod embedding;
 pub mod extract;
 pub mod inject;
 pub mod policy;
 pub mod recall;
 
 use anyhow::Result;
+use embedding::{EmbeddingProvider, LocalHashEmbeddingProvider};
 use rusqlite::{Connection, OpenFlags, params_from_iter};
 use serde::Serialize;
 use std::path::Path;
@@ -154,6 +156,13 @@ pub struct AppOnlySecretReference {
     pub secret_type: String,
     pub label: String,
     pub location_hint: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SemanticMemoryHit {
+    pub entry: MemoryEntry,
+    pub score: f64,
+    pub embedding_model: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -311,6 +320,18 @@ impl Memory {
             CREATE INDEX IF NOT EXISTS idx_app_only_secret_references_lookup
                 ON app_only_secret_references(secret_type, normalized_label, updated_ms DESC);
 
+            CREATE TABLE IF NOT EXISTS embedded_memories (
+                source_memory_id INTEGER PRIMARY KEY,
+                memory_type      TEXT NOT NULL,
+                embedding_model  TEXT NOT NULL,
+                dimensions       INTEGER NOT NULL,
+                embedding        TEXT NOT NULL,
+                updated_ms       INTEGER NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_embedded_memories_type
+                ON embedded_memories(memory_type, updated_ms DESC);
+
             CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
                 content,
                 content='memories',
@@ -426,6 +447,7 @@ impl Memory {
         rebuild_household_rules(&conn)?;
         rebuild_household_notes(&conn)?;
         rebuild_app_only_secret_references(&conn)?;
+        rebuild_embedded_memories(&conn)?;
 
         // Older databases may predate the FTS update trigger or may have been
         // edited by a recovery tool. Rebuild once at open so recall and forget
@@ -1071,6 +1093,71 @@ impl Memory {
         Ok(entries)
     }
 
+    pub fn semantic_search(&self, query: &str, limit: usize) -> Result<Vec<SemanticMemoryHit>> {
+        let query = query.trim();
+        if query.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let provider = LocalHashEmbeddingProvider;
+        let query_embedding = provider.embed(query);
+        let now = now_ms();
+        let query_hash = hash_query(query);
+        let mut stmt = self.conn.prepare(
+            "SELECT m.id, m.kind, m.content, m.created_ms, m.accessed_ms,
+                    m.recall_count, m.max_score, m.promoted, m.scope,
+                    m.sensitivity, m.spoken_policy,
+                    e.embedding_model, e.dimensions, e.embedding
+             FROM embedded_memories e
+             JOIN memories m ON m.id = e.source_memory_id
+             WHERE e.embedding_model = ?1",
+        )?;
+
+        let mut hits = stmt
+            .query_map([provider.model_name()], |row| {
+                let entry = read_entry(row)?;
+                let embedding_model: String = row.get(11)?;
+                let dimensions: i64 = row.get(12)?;
+                let embedding_json: String = row.get(13)?;
+                Ok((entry, embedding_model, dimensions as usize, embedding_json))
+            })?
+            .filter_map(|row| row.ok())
+            .filter_map(|(entry, embedding_model, dimensions, embedding_json)| {
+                parse_embedding(&embedding_json, dimensions).map(|embedding| {
+                    let score = embedding::cosine_similarity(&query_embedding, &embedding);
+                    SemanticMemoryHit {
+                        entry,
+                        score,
+                        embedding_model,
+                    }
+                })
+            })
+            .filter(|hit| hit.score >= embedding::SEMANTIC_MIN_SCORE)
+            .collect::<Vec<_>>();
+
+        hits.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| b.entry.id.cmp(&a.entry.id))
+        });
+        hits.truncate(limit.max(1));
+
+        for hit in &hits {
+            if let Err(error) =
+                self.update_recall_tracking(hit.entry.id, now, hit.score, &query_hash)
+            {
+                tracing::error!(
+                    memory_id = hit.entry.id,
+                    error = %error,
+                    "semantic memory recall tracking update failed"
+                );
+            }
+        }
+
+        Ok(hits)
+    }
+
     pub fn structured_household_answer(&self, query: &str) -> Result<Option<String>> {
         if let Some((name, attribute)) = profile_attribute_query(query) {
             let attrs = self.profile_attributes(&name, attribute)?;
@@ -1231,6 +1318,14 @@ impl Memory {
                 now_ms(),
             )?;
             upsert_app_only_secret_reference_from_memory(
+                &self.conn,
+                id,
+                &next_kind,
+                &content,
+                metadata,
+                now_ms(),
+            )?;
+            upsert_embedded_memory_from_memory(
                 &self.conn,
                 id,
                 &next_kind,
@@ -1485,6 +1580,7 @@ impl Memory {
         upsert_household_rules_from_memory(&self.conn, id, content, metadata, now)?;
         upsert_household_note_from_memory(&self.conn, id, kind, content, metadata, now)?;
         upsert_app_only_secret_reference_from_memory(&self.conn, id, kind, content, metadata, now)?;
+        upsert_embedded_memory_from_memory(&self.conn, id, kind, content, metadata, now)?;
         Ok(id)
     }
 
@@ -1853,6 +1949,16 @@ fn rebuild_app_only_secret_references(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn rebuild_embedded_memories(conn: &Connection) -> Result<()> {
+    conn.execute("DELETE FROM embedded_memories", [])?;
+    let rows = shared_safe_memory_rows_with_kind(conn)?;
+    let now = now_ms();
+    for (id, kind, content, metadata) in rows {
+        upsert_embedded_memory_from_memory(conn, id, &kind, &content, metadata, now)?;
+    }
+    Ok(())
+}
+
 fn shared_safe_memory_rows(
     conn: &Connection,
 ) -> Result<Vec<(i64, String, policy::MemoryPolicyMetadata)>> {
@@ -2077,6 +2183,44 @@ fn upsert_app_only_secret_reference_from_memory(
     Ok(())
 }
 
+fn upsert_embedded_memory_from_memory(
+    conn: &Connection,
+    source_memory_id: i64,
+    kind: &str,
+    content: &str,
+    metadata: policy::MemoryPolicyMetadata,
+    updated_ms: u64,
+) -> Result<()> {
+    conn.execute(
+        "DELETE FROM embedded_memories WHERE source_memory_id = ?1",
+        [source_memory_id],
+    )?;
+
+    if !should_embed_memory(kind, content, metadata) {
+        return Ok(());
+    }
+
+    let provider = LocalHashEmbeddingProvider;
+    let embedding_text = embedding_text_for_memory(kind, content);
+    let embedding = provider.embed(&embedding_text);
+    let embedding_json = serde_json::to_string(&embedding)?;
+
+    conn.execute(
+        "INSERT INTO embedded_memories (
+            source_memory_id, memory_type, embedding_model, dimensions, embedding, updated_ms
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![
+            source_memory_id,
+            semantic_memory_type(kind, content),
+            provider.model_name(),
+            provider.dimensions() as i64,
+            embedding_json,
+            updated_ms
+        ],
+    )?;
+    Ok(())
+}
+
 fn delete_structured_household_rows(conn: &Connection, source_memory_id: i64) -> Result<()> {
     conn.execute(
         "DELETE FROM household_profile_attributes WHERE source_memory_id = ?1",
@@ -2092,6 +2236,10 @@ fn delete_structured_household_rows(conn: &Connection, source_memory_id: i64) ->
     )?;
     conn.execute(
         "DELETE FROM app_only_secret_references WHERE source_memory_id = ?1",
+        [source_memory_id],
+    )?;
+    conn.execute(
+        "DELETE FROM embedded_memories WHERE source_memory_id = ?1",
         [source_memory_id],
     )?;
     Ok(())
@@ -2440,6 +2588,63 @@ fn household_note_title(content: &str) -> String {
         "note".into()
     } else {
         title
+    }
+}
+
+fn should_embed_memory(kind: &str, content: &str, metadata: policy::MemoryPolicyMetadata) -> bool {
+    if secret_type_from_text(&content.to_ascii_lowercase()).is_some() {
+        return false;
+    }
+    if !policy::assess_memory_read(metadata, policy::MemoryReadContext::shared_room_voice()).allowed
+    {
+        return false;
+    }
+
+    let kind = kind.to_ascii_lowercase();
+    let lower = content.to_ascii_lowercase();
+    matches!(
+        kind.as_str(),
+        "preference" | "context" | "fact" | "note" | "document" | "manual" | "shopping" | "movie"
+    ) || content.len() >= 48
+        || lower.contains("thermostat")
+        || lower.contains("lunchbox")
+        || lower.contains("lunch box")
+        || lower.contains("snack")
+        || lower.contains("movie")
+        || lower.contains("watched")
+        || lower.contains("detergent")
+        || lower.contains("coffee machine")
+}
+
+fn semantic_memory_type(kind: &str, content: &str) -> String {
+    let lower = content.to_ascii_lowercase();
+    if lower.contains("thermostat") || lower.contains("temperature") {
+        "home_comfort".into()
+    } else if lower.contains("lunchbox")
+        || lower.contains("lunch box")
+        || lower.contains("snack")
+        || lower.contains("detergent")
+    {
+        "shopping".into()
+    } else if lower.contains("movie") || lower.contains("watched") {
+        "media".into()
+    } else if lower.contains("manual") || lower.contains("coffee machine") {
+        "device_manual".into()
+    } else {
+        kind.trim().to_ascii_lowercase()
+    }
+}
+
+fn embedding_text_for_memory(kind: &str, content: &str) -> String {
+    format!("{} {}", semantic_memory_type(kind, content), content)
+}
+
+fn parse_embedding(value: &str, dimensions: usize) -> Option<Vec<f32>> {
+    let embedding = serde_json::from_str::<Vec<f32>>(value).ok()?;
+    if embedding.len() == dimensions {
+        Some(embedding)
+    } else {
+        None
     }
 }
 
@@ -3713,6 +3918,70 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn semantic_search_links_cold_to_thermostat_preference() {
+        let mem = temp_memory();
+        mem.store(
+            "preference",
+            "Jared prefers the living room thermostat at 72F.",
+        )
+        .unwrap();
+
+        let hits = mem.semantic_search("I'm feeling cold", 3).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].entry.content.contains("thermostat"));
+    }
+
+    #[test]
+    fn semantic_search_links_lunchbox_snacks() {
+        let mem = temp_memory();
+        mem.store(
+            "shopping",
+            "Leo's lunchbox snacks include granola bars and fruit snacks.",
+        )
+        .unwrap();
+
+        let hits = mem
+            .semantic_search("We need more snacks for Leo's lunchbox", 3)
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].entry.content.contains("granola bars"));
+    }
+
+    #[test]
+    fn semantic_search_links_robot_movie_hint() {
+        let mem = temp_memory();
+        mem.store(
+            "note",
+            "Watched The Iron Giant with the kids - they loved it.",
+        )
+        .unwrap();
+
+        let hits = mem
+            .semantic_search("What movie had a robot that wanted to be a real boy?", 3)
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].entry.content.contains("Iron Giant"));
+    }
+
+    #[test]
+    fn semantic_embeddings_rebuild_on_reopen() {
+        let path = temp_memory_path("semantic-reopen");
+        {
+            let mem = Memory::open(&path).unwrap();
+            mem.store(
+                "preference",
+                "Jared prefers the living room thermostat at 72F.",
+            )
+            .unwrap();
+        }
+
+        let reopened = Memory::open(&path).unwrap();
+        let hits = reopened.semantic_search("I'm feeling cold", 3).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].entry.content.contains("thermostat"));
     }
 
     #[test]

--- a/crates/genie-core/src/memory/recall.rs
+++ b/crates/genie-core/src/memory/recall.rs
@@ -160,7 +160,14 @@ pub fn recall_with_context(
     limit: usize,
     context: policy::MemoryReadContext,
 ) -> Result<Vec<RecallableMemory>> {
-    let results = memory.search(query, limit)?;
+    let mut results = memory.search(query, limit)?;
+    let semantic_hits = memory.semantic_search(query, limit)?;
+    for hit in semantic_hits {
+        if !results.iter().any(|entry| entry.id == hit.entry.id) {
+            results.push(hit.entry);
+        }
+    }
+    results.truncate(limit.max(1));
     let raw_hits = results.len();
     let recalled = filter_recall_results(results, context);
 
@@ -325,5 +332,35 @@ mod tests {
             identified[0].decision.disclosure,
             policy::MemoryDisclosure::Speak
         );
+    }
+
+    #[test]
+    fn recall_with_context_uses_semantic_hits_when_lexical_query_misses() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static CTR: AtomicU32 = AtomicU32::new(0);
+        let id = CTR.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-recall-semantic-{}-{}.db",
+            std::process::id(),
+            id
+        ));
+        let _ = std::fs::remove_file(&path);
+        let mem = Memory::open(&path).unwrap();
+        mem.store(
+            "preference",
+            "Jared prefers the living room thermostat at 72F.",
+        )
+        .unwrap();
+
+        let recalled = recall_with_context(
+            &mem,
+            "I'm feeling cold",
+            10,
+            policy::MemoryReadContext::shared_room_voice(),
+        )
+        .unwrap();
+
+        assert_eq!(recalled.len(), 1);
+        assert!(recalled[0].entry.content.contains("thermostat"));
     }
 }

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -2496,6 +2496,89 @@ mod tests {
     }
 
     #[test]
+    fn memory_recall_answers_semantic_home_comfort_query() {
+        let db = std::env::temp_dir().join(format!(
+            "memory-recall-semantic-comfort-test-{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db);
+        let memory = crate::memory::Memory::open(&db).unwrap();
+        memory
+            .store(
+                "preference",
+                "Jared prefers the living room thermostat at 72F.",
+            )
+            .unwrap();
+        let dispatcher =
+            ToolDispatcher::new(None).with_memory(Arc::new(std::sync::Mutex::new(memory)));
+
+        let output = dispatcher
+            .exec_memory_recall(
+                &serde_json::json!({"query": "I'm feeling cold"}),
+                ToolExecutionContext::default(),
+            )
+            .unwrap();
+
+        assert!(output.contains("thermostat"));
+        assert!(output.contains("72F"));
+    }
+
+    #[test]
+    fn memory_recall_answers_semantic_lunchbox_query() {
+        let db = std::env::temp_dir().join(format!(
+            "memory-recall-semantic-lunchbox-test-{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db);
+        let memory = crate::memory::Memory::open(&db).unwrap();
+        memory
+            .store(
+                "shopping",
+                "Leo's lunchbox snacks include granola bars and fruit snacks.",
+            )
+            .unwrap();
+        let dispatcher =
+            ToolDispatcher::new(None).with_memory(Arc::new(std::sync::Mutex::new(memory)));
+
+        let output = dispatcher
+            .exec_memory_recall(
+                &serde_json::json!({"query": "We need more snacks for Leo's lunchbox"}),
+                ToolExecutionContext::default(),
+            )
+            .unwrap();
+
+        assert!(output.contains("granola bars"));
+        assert!(output.contains("fruit snacks"));
+    }
+
+    #[test]
+    fn memory_recall_answers_semantic_movie_query() {
+        let db = std::env::temp_dir().join(format!(
+            "memory-recall-semantic-movie-test-{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db);
+        let memory = crate::memory::Memory::open(&db).unwrap();
+        memory
+            .store(
+                "note",
+                "Watched The Iron Giant with the kids - they loved it.",
+            )
+            .unwrap();
+        let dispatcher =
+            ToolDispatcher::new(None).with_memory(Arc::new(std::sync::Mutex::new(memory)));
+
+        let output = dispatcher
+            .exec_memory_recall(
+                &serde_json::json!({"query": "what was the movie about a robot that wanted to be a real boy"}),
+                ToolExecutionContext::default(),
+            )
+            .unwrap();
+
+        assert!(output.contains("Iron Giant"));
+    }
+
+    #[test]
     fn memory_recall_hides_person_memory_in_shared_room_context() {
         let db = std::env::temp_dir().join(format!(
             "memory-recall-shared-room-test-{}.db",

--- a/crates/genie-core/src/tools/quick.rs
+++ b/crates/genie-core/src/tools/quick.rs
@@ -158,6 +158,10 @@ fn memory_recall_query(text: &str) -> Option<String> {
         return Some(text.to_string());
     }
 
+    if is_semantic_household_memory_question(text) {
+        return Some(text.to_string());
+    }
+
     for prefix in [
         "what do you remember about ",
         "what do you know about ",
@@ -216,6 +220,13 @@ fn is_household_note_question(text: &str) -> bool {
         || text.starts_with("what did i watch about ")
         || text.starts_with("what movie ")
         || text.starts_with("what was that movie ")
+}
+
+fn is_semantic_household_memory_question(text: &str) -> bool {
+    (text.contains("feeling cold") || text.contains("feel cold") || text.contains("i am cold"))
+        || (text.contains("snack") && (text.contains("lunchbox") || text.contains("lunch box")))
+        || (text.contains("detergent") && contains_any(text, &["like", "order", "more"]))
+        || (text.contains("movie") && text.contains("robot"))
 }
 
 fn is_app_only_secret_question(text: &str) -> bool {
@@ -798,6 +809,23 @@ mod tests {
         let call = route("Where is the gate code?").unwrap();
         assert_eq!(call.name, "memory_recall");
         assert_eq!(call.arguments["query"], "where is the gate code");
+    }
+
+    #[test]
+    fn routes_semantic_household_memory_questions_to_memory_recall() {
+        let call = route("I'm feeling cold").unwrap();
+        assert_eq!(call.name, "memory_recall");
+        assert_eq!(call.arguments["query"], "i m feeling cold");
+
+        let call = route("We need more snacks for Leo's lunchbox").unwrap();
+        assert_eq!(call.name, "memory_recall");
+        assert_eq!(
+            call.arguments["query"],
+            "we need more snacks for leo s lunchbox"
+        );
+
+        let call = route("What was the movie about a robot?").unwrap();
+        assert_eq!(call.name, "memory_recall");
     }
 
     #[test]

--- a/doc/household-security.md
+++ b/doc/household-security.md
@@ -117,6 +117,8 @@ treated as ordinary recall.
 - Keep tool policy and actuation safety enabled.
 - Require confirmation for high-risk home actions.
 - Use separate hosts or OS users for people who should not share authority.
+- Keep fuzzy household recall local-first: embedded-memory rows are metadata in
+  the local SQLite store, not a remote vector service dependency.
 
 ## Runtime Contract
 

--- a/doc/http-and-cli.md
+++ b/doc/http-and-cli.md
@@ -429,6 +429,9 @@ Memory tools are policy-aware:
   index for direct questions such as "find my note about..." or "where are..."
 - password/code questions can resolve to app-only secret references without
   exposing the value in shared-room chat
+- selected safe preferences, notes, shopping, media, and manual memories also
+  maintain local embeddings for fuzzy household recall such as comfort,
+  lunchbox, and movie questions when exact words are missing
 - person/private/restricted memories may be withheld unless stronger read context is supplied
 - memory status reports canonical artifact counts plus policy-scope counts
 


### PR DESCRIPTION
## Summary
- Add a local embedding provider trait and deterministic on-device hash embedding provider for household memory.
- Store selective safe embedded-memory rows in SQLite at store/update/reopen time.
- Merge semantic hits into memory recall for fuzzy home queries: comfort/thermostat, lunchbox snacks, and robot movie recall.
- Document local-first embedded recall behavior.

## Real Behavior Proof
- [x] Tested profile/hardware: local workstation.
- [x] `cargo test -p genie-core semantic -- --nocapture`
- [x] `cargo test -p genie-core`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo clippy -p genie-core -p genie-ctl --no-default-features --all-targets --locked -- -D warnings`
- [x] `cargo fmt --check`
- [x] `git diff --check`

Observed behavior: "I'm feeling cold" recalls Jared's thermostat preference, "more snacks for Leo's lunchbox" recalls granola bars and fruit snacks, and the robot movie query recalls The Iron Giant even when the exact stored words are different.