### PR TITLE
fix: distinguish 503 (transient) and 500 (permanent) for tegrastats DB errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 # macOS metadata
 .DS_Store
 **/.DS_Store
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 # macOS metadata
 .DS_Store
 **/.DS_Store
-data/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +342,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
  "tracing",
@@ -782,6 +789,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +1133,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1380,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/genie-api/Cargo.toml
+++ b/crates/genie-api/Cargo.toml
@@ -20,4 +20,5 @@ anyhow = { workspace = true }
 rusqlite = { workspace = true }
 
 [dev-dependencies]
+tempfile = "3.27.0"
 toml = { workspace = true }

--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -88,10 +88,28 @@ pub async fn get_tegrastats(config: &Config) -> Response {
             content_type: "application/json",
             body: json,
         },
-        _ => Response {
-            status: 200,
-            content_type: "application/json",
-            body: "[]".into(),
+        Ok(Err(e)) => {
+            tracing::error!(%e, "failed to read tegrastats from governor.db");
+            Response {
+                status: 500,
+                content_type: "application/json",
+                body: serde_json::json!({
+                    "error": "failed to read tegrastats data",
+                    "detail": e
+                })
+                .to_string(),
+            }
+        },
+        Err(e) => {
+            tracing::error!(%e, "tegrastats spawn_blocking panicked or was cancelled");
+            Response {
+                status: 500,
+                content_type: "application/json",
+                body: serde_json::json!({
+                    "error": "internal error reading tegrastats"
+                })
+                .to_string(),
+            }
         },
     }
 }
@@ -1175,5 +1193,35 @@ mod tests {
             error.contains(&format!("core response exceeds {max} bytes")),
             "expected size cap error, got: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn tegrastats_returns_500_when_db_does_not_exist() {
+        let tmp = tempfile::TempDir::new().expect("failed to create temp dir");
+        let mut config = test_config();
+        config.data_dir = tmp.path().to_path_buf();
+
+        let response = get_tegrastats(&config).await;
+
+        assert_eq!(response.status, 500);
+        assert!(response.body.contains("error"));
+        assert!(response.body.contains("failed to read tegrastats data"));
+    }
+
+    #[test]
+    fn classify_sqlite_error_transient() {
+        let (status, msg) = classify_sqlite_error("database is locked");
+        assert_eq!(status, 503);
+        assert_eq!(msg, "tegrastats data temporarily unavailable");
+
+        let (status, _) = classify_sqlite_error("Database is Busy");
+        assert_eq!(status, 503);
+    }
+
+    #[test]
+    fn classify_sqlite_error_permanent() {
+        let (status, msg) = classify_sqlite_error("unable to open database file");
+        assert_eq!(status, 500);
+        assert_eq!(msg, "failed to read tegrastats data");
     }
 }

--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -44,6 +44,17 @@ pub async fn get_status(_config: &Config) -> Response {
     }
 }
 
+/// Classify a SQLite error string and return an HTTP status code + error message.
+fn classify_sqlite_error(err: &str) -> (u16, String) {
+    let lower = err.to_lowercase();
+    let is_transient = lower.contains("database is locked") || lower.contains("database is busy");
+    if is_transient {
+        (503, "tegrastats data temporarily unavailable".into())
+    } else {
+        (500, "failed to read tegrastats data".into())
+    }
+}
+
 /// GET /api/tegrastats — recent history from governor's SQLite.
 pub async fn get_tegrastats(config: &Config) -> Response {
     let db_path = config.data_dir.join("governor.db");
@@ -89,25 +100,18 @@ pub async fn get_tegrastats(config: &Config) -> Response {
             body: json,
         },
         Ok(Err(e)) => {
-            // Distinguish transient errors (locked DB) from permanent ones.
-            let is_transient = e.to_lowercase().contains("database is locked")
-                || e.to_lowercase().contains("database is busy");
-            let status = if is_transient { 503 } else { 500 };
+            let (status, error_msg) = classify_sqlite_error(&e);
             tracing::error!(%e, "failed to read tegrastats from governor.db");
             Response {
                 status,
                 content_type: "application/json",
                 body: serde_json::json!({
-                    "error": if is_transient {
-                        "tegrastats data temporarily unavailable"
-                    } else {
-                        "failed to read tegrastats data"
-                    },
+                    "error": error_msg,
                     "detail": e
                 })
                 .to_string(),
             }
-        },
+        }
         Err(e) => {
             tracing::error!(%e, "tegrastats spawn_blocking panicked or was cancelled");
             Response {
@@ -118,7 +122,7 @@ pub async fn get_tegrastats(config: &Config) -> Response {
                 })
                 .to_string(),
             }
-        },
+        }
     }
 }
 

--- a/crates/genie-api/src/routes.rs
+++ b/crates/genie-api/src/routes.rs
@@ -89,12 +89,20 @@ pub async fn get_tegrastats(config: &Config) -> Response {
             body: json,
         },
         Ok(Err(e)) => {
+            // Distinguish transient errors (locked DB) from permanent ones.
+            let is_transient = e.to_lowercase().contains("database is locked")
+                || e.to_lowercase().contains("database is busy");
+            let status = if is_transient { 503 } else { 500 };
             tracing::error!(%e, "failed to read tegrastats from governor.db");
             Response {
-                status: 500,
+                status,
                 content_type: "application/json",
                 body: serde_json::json!({
-                    "error": "failed to read tegrastats data",
+                    "error": if is_transient {
+                        "tegrastats data temporarily unavailable"
+                    } else {
+                        "failed to read tegrastats data"
+                    },
                     "detail": e
                 })
                 .to_string(),


### PR DESCRIPTION

<img width="1121" height="467" alt="503terminal" src="https://github.com/user-attachments/assets/6b018cc5-29c4-43e3-8822-73ac0889a4d0" />
<img width="1521" height="1153" alt="fix500" src="https://github.com/user-attachments/assets/627a5255-0a81-4992-b481-64b461ab743a" />
<img width="1486" height="1066" alt="fix503" src="https://github.com/user-attachments/assets/08e2bfe0-3ef7-4970-9af4-4b953db97d4b" />
<img width="1528" height="1291" alt="reproduce" src="https://github.com/user-attachments/assets/e4d84207-2c10-4336-91db-0961dbbf9898" />
<!--
Thanks for contributing to GenieClaw! Please fill this template in honestly.
The "Real Behavior Proof" section is required and enforced by CI.
See CONTRIBUTING.md for the full rules.
-->

## Summary

Fixes #247 — `/api/tegrastats` returned HTTP 200 with an empty array `[]` when
the governor.db SQLite read failed, hiding the failure from callers. Now it
returns 500 for permanent errors (missing DB, permission denied, schema mismatch)
and 503 for transient errors (database is locked / busy), following the same
pattern as `get_actuation_audit`.

## Changes

- Split the `match result` in `get_tegrastats` to handle `Ok(Err(_))` and
  `Err(_)` separately.
- Permanent errors → HTTP 500 with `{"error":"failed to read tegrastats data","detail":"…"}`.
- Transient errors (database locked / busy) → HTTP 503 with
  `{"error":"tegrastats data temporarily unavailable","detail":"…"}`.
- spawn_blocking failure → HTTP 500 with `{"error":"internal error reading tegrastats"}`.
- Added `tracing::error!` logging for all error paths.
- Added `.gitignore` entry for `data/` directory (runtime artifacts).
- Added test `tegrastats_returns_500_when_db_does_not_exist`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

**Scenario 1 – Missing DB (500):**
- Moved `./data/governor.db` out of the way.
- `curl -v http://127.0.0.1:3080/api/tegrastats`
- Response: `HTTP/1.1 500 Internal Server Error`  
  Body: `{"error":"failed to read tegrastats data","detail":"unable to open database file: ./data/governor.db"}`

**Scenario 2 – Locked DB (503):**
- Opened `sqlite3 ./data/governor.db` in another terminal and ran `BEGIN EXCLUSIVE;`.
- `curl -v http://127.0.0.1:3080/api/tegrastats`
- Response: `HTTP/1.1 503 Service Unavailable`  
  Body: `{"error":"tegrastats data temporarily unavailable","detail":"database is locked"}`
- Server log: `ERROR failed to read tegrastats from governor.db e=database is locked`

**Unit tests:** `cargo test -p genie-api` — all 14 tests passed.

### What I observed

The endpoint now correctly reports errors with the appropriate HTTP status code
(500 for permanent errors, 503 for transient locks), instead of silently
returning `200` with an empty array. Error messages are logged and returned to
the client.

Validation gap: The change only affects the HTTP response layer and does not
depend on Jetson‑specific hardware. SQLite errors and spawn_blocking behaviour
are identical across platforms.

## Test plan

1. Run `cargo test -p genie-api` — all tests pass.
2. Manual verification:
   - Remove `governor.db` → GET `/api/tegrastats` → 500.
   - Lock `governor.db` with `BEGIN EXCLUSIVE;` → GET `/api/tegrastats` → 503.
   - Restore DB → GET → 200 with data.

## Notes for reviewers

None.
