### PR TITLE
fix(http): bind loopback Host allowlist to peer IP; require auth on sensitive GET routes

### DIFF
--- a/crates/genie-api/src/http.rs
+++ b/crates/genie-api/src/http.rs
@@ -107,6 +107,7 @@ async fn handle_connection(
     limits: &HttpLimits,
     guard: &RequestGuard,
 ) -> Result<()> {
+    let peer_ip = stream.peer_addr().ok().map(|addr| addr.ip());
     let (reader, mut writer) = stream.into_split();
     let mut buf_reader = BufReader::new(reader);
 
@@ -125,7 +126,7 @@ async fn handle_connection(
     };
 
     // Cross-origin / DNS-rebinding gate ahead of routing (issue #228).
-    let echo_origin = match guard.check_request(&request) {
+    let echo_origin = match guard.check_request(&request, peer_ip) {
         OriginDecision::Allow(origin) => origin,
         OriginDecision::Reject(rejection) => {
             tracing::debug!(reason = rejection.reason(), "request gated out");
@@ -137,9 +138,10 @@ async fn handle_connection(
     let method = request.method.as_str();
     let path = request.path.as_str();
 
-    // Mutating/actuating endpoints additionally require the shared local token.
-    if is_mutating(method, path) && !guard.token_ok(&request) {
-        tracing::debug!("mutating request without a valid local API token");
+    if requires_local_auth(method, path, peer_ip)
+        && (!guard.enforces_token() || !guard.token_ok(&request))
+    {
+        tracing::debug!("request without a valid local API token");
         let response = guard_rejection(GuardRejection::MissingToken);
         return write_response(&mut writer, &response, echo_origin.as_deref()).await;
     }
@@ -179,8 +181,6 @@ async fn handle_connection(
     write_response(&mut writer, &response, echo_origin.as_deref()).await
 }
 
-/// State-changing / actuating routes that require the shared local API token
-/// when one is configured (issue #228).
 fn is_mutating(method: &str, path: &str) -> bool {
     method == "POST"
         && matches!(
@@ -191,6 +191,27 @@ fn is_mutating(method: &str, path: &str) -> bool {
                 | "/api/memories/reorder"
                 | "/api/mode"
         )
+}
+
+fn is_sensitive_read(method: &str, path: &str) -> bool {
+    method == "GET"
+        && matches!(
+            path,
+            "/api/memories"
+                | "/api/actuation/pending"
+                | "/api/actuation/actions"
+                | "/api/actuation/audit"
+        )
+}
+
+fn requires_local_auth(method: &str, path: &str, peer: Option<std::net::IpAddr>) -> bool {
+    if is_mutating(method, path) {
+        return true;
+    }
+    if is_sensitive_read(method, path) {
+        return !peer.is_some_and(|p| p.is_loopback());
+    }
+    false
 }
 
 /// `403` response for a gated-out request, reusing the shared rejection reason.

--- a/crates/genie-common/src/http.rs
+++ b/crates/genie-common/src/http.rs
@@ -425,21 +425,33 @@ impl RequestGuard {
     /// Validate `Host` and `Origin` ahead of routing.
     ///
     /// A missing `Host` (non-browser client) is allowed; a present-but-unlisted
-    /// `Host` is rejected. A missing `Origin` (same-origin navigation / non-
-    /// browser) is allowed with nothing reflected; a present `Origin` is
-    /// reflected verbatim when allowlisted, else rejected.
-    pub fn check_request(&self, request: &HttpRequest) -> OriginDecision {
+    /// `Host` is rejected. Loopback-looking `Host` / `Origin` values are only
+    /// accepted when `peer` is a loopback address (issue #303).
+    pub fn check_request(
+        &self,
+        request: &HttpRequest,
+        peer: Option<std::net::IpAddr>,
+    ) -> OriginDecision {
         if let Some(host) = request.header("host") {
             let host = host.trim().to_ascii_lowercase();
-            if !host.is_empty() && !self.allowed_hosts.iter().any(|h| h == &host) {
-                return OriginDecision::Reject(GuardRejection::DisallowedHost);
+            if !host.is_empty() {
+                if !self.allowed_hosts.iter().any(|h| h == &host) {
+                    return OriginDecision::Reject(GuardRejection::DisallowedHost);
+                }
+                if host_looks_loopback(&host) && !peer_is_loopback(peer) {
+                    return OriginDecision::Reject(GuardRejection::DisallowedHost);
+                }
             }
         }
 
         match request.header("origin") {
             None => OriginDecision::Allow(None),
             Some(origin) => {
-                if self.allowed_origins.contains(&normalize_origin(origin)) {
+                let normalized = normalize_origin(origin);
+                if self.allowed_origins.contains(&normalized) {
+                    if origin_looks_loopback(&normalized) && !peer_is_loopback(peer) {
+                        return OriginDecision::Reject(GuardRejection::DisallowedOrigin);
+                    }
                     OriginDecision::Allow(Some(origin.trim().to_string()))
                 } else {
                     OriginDecision::Reject(GuardRejection::DisallowedOrigin)
@@ -522,6 +534,32 @@ fn derive_hosts_and_origins(listen_host: &str, listen_port: u16) -> (Vec<String>
 /// config might).
 fn normalize_origin(origin: &str) -> String {
     origin.trim().trim_end_matches('/').to_ascii_lowercase()
+}
+
+/// True when the Host header names a loopback-only target (not LAN extras).
+fn host_looks_loopback(host: &str) -> bool {
+    let host_only = if let Some(rest) = host.strip_prefix('[') {
+        rest.find(']')
+            .map(|idx| &host[..=idx + 1])
+            .unwrap_or(host)
+    } else {
+        host.split(':').next().unwrap_or(host)
+    };
+    matches!(host_only, "localhost" | "127.0.0.1" | "::1" | "[::1]")
+        || host_only.starts_with("127.")
+}
+
+fn origin_looks_loopback(origin: &str) -> bool {
+    origin.starts_with("http://127.")
+        || origin.starts_with("http://localhost")
+        || origin.starts_with("http://[::1]")
+        || origin.starts_with("https://127.")
+        || origin.starts_with("https://localhost")
+        || origin.starts_with("https://[::1]")
+}
+
+fn peer_is_loopback(peer: Option<std::net::IpAddr>) -> bool {
+    peer.is_some_and(|p| p.is_loopback())
 }
 
 /// Extract the token from an `Authorization: Bearer <token>` header value,
@@ -724,6 +762,13 @@ mod tests {
         RequestGuard::new("127.0.0.1", 3000, &[], &[], "")
     }
 
+    const LOOPBACK_PEER: Option<std::net::IpAddr> = Some(std::net::IpAddr::V4(
+        std::net::Ipv4Addr::LOCALHOST,
+    ));
+    const LAN_PEER: Option<std::net::IpAddr> = Some(std::net::IpAddr::V4(
+        std::net::Ipv4Addr::new(192, 168, 1, 50),
+    ));
+
     #[test]
     fn loopback_host_and_origin_for_bound_port_are_allowed() {
         let g = guard();
@@ -734,24 +779,43 @@ mod tests {
             "localhost",
         ] {
             assert_eq!(
-                g.check_request(&req(&[("Host", host)])),
+                g.check_request(&req(&[("Host", host)]), LOOPBACK_PEER),
                 OriginDecision::Allow(None),
                 "host {host} should be allowed"
             );
         }
         assert_eq!(
-            g.check_request(&req(&[
-                ("Host", "localhost:3000"),
-                ("Origin", "http://localhost:3000"),
-            ])),
+            g.check_request(
+                &req(&[
+                    ("Host", "localhost:3000"),
+                    ("Origin", "http://localhost:3000"),
+                ]),
+                LOOPBACK_PEER,
+            ),
             OriginDecision::Allow(Some("http://localhost:3000".into())),
+        );
+    }
+
+    #[test]
+    fn loopback_host_from_lan_peer_is_rejected() {
+        let g = guard();
+        assert_eq!(
+            g.check_request(&req(&[("Host", "localhost:3000")]), LAN_PEER),
+            OriginDecision::Reject(GuardRejection::DisallowedHost),
+        );
+        assert_eq!(
+            g.check_request(
+                &req(&[("Origin", "http://localhost:3000")]),
+                LAN_PEER,
+            ),
+            OriginDecision::Reject(GuardRejection::DisallowedOrigin),
         );
     }
 
     #[test]
     fn missing_host_and_origin_are_allowed_for_non_browser_clients() {
         assert_eq!(
-            guard().check_request(&req(&[])),
+            guard().check_request(&req(&[]), LOOPBACK_PEER),
             OriginDecision::Allow(None)
         );
     }
@@ -760,21 +824,22 @@ mod tests {
     fn cross_site_origin_is_rejected_not_reflected() {
         let g = guard();
         assert_eq!(
-            g.check_request(&req(&[
-                ("Host", "localhost:3000"),
-                ("Origin", "http://evil.example"),
-            ])),
+            g.check_request(
+                &req(&[
+                    ("Host", "localhost:3000"),
+                    ("Origin", "http://evil.example"),
+                ]),
+                LOOPBACK_PEER,
+            ),
             OriginDecision::Reject(GuardRejection::DisallowedOrigin),
         );
     }
 
     #[test]
     fn rebound_host_is_rejected() {
-        // DNS-rebinding: the page is evil.example resolving to 127.0.0.1, so the
-        // Host carries the attacker name — it must not match the allowlist.
         let g = guard();
         assert_eq!(
-            g.check_request(&req(&[("Host", "evil.example:3000")])),
+            g.check_request(&req(&[("Host", "evil.example:3000")]), LOOPBACK_PEER),
             OriginDecision::Reject(GuardRejection::DisallowedHost),
         );
     }
@@ -789,10 +854,13 @@ mod tests {
             "",
         );
         assert_eq!(
-            g.check_request(&req(&[
-                ("Host", "genie.local:3000"),
-                ("Origin", "http://genie.local:3000"),
-            ])),
+            g.check_request(
+                &req(&[
+                    ("Host", "genie.local:3000"),
+                    ("Origin", "http://genie.local:3000"),
+                ]),
+                LAN_PEER,
+            ),
             OriginDecision::Allow(Some("http://genie.local:3000".into())),
         );
     }

--- a/crates/genie-core/src/server.rs
+++ b/crates/genie-core/src/server.rs
@@ -294,8 +294,7 @@ enum RequestRoute<'a> {
 
 impl RequestRoute<'_> {
     /// True for state-changing / actuating endpoints, which require the shared
-    /// local API token when one is configured (issue #228). Read-only routes
-    /// are guarded by the Origin/Host gate alone.
+    /// local API token when one is configured (issue #228).
     fn is_mutating(&self) -> bool {
         matches!(
             self,
@@ -309,6 +308,30 @@ impl RequestRoute<'_> {
                 | RequestRoute::MemoriesReorder
                 | RequestRoute::OpenAiChat
         )
+    }
+
+    /// Household data / actuation state readable over HTTP (issue #303).
+    fn is_sensitive_read(&self) -> bool {
+        matches!(
+            self,
+            RequestRoute::History
+                | RequestRoute::Conversations
+                | RequestRoute::Export(_)
+                | RequestRoute::MemoriesList
+                | RequestRoute::ActuationPending
+                | RequestRoute::ActuationActions
+        )
+    }
+
+    /// Require a configured local API token when the peer is not loopback.
+    fn requires_local_auth(&self, peer: Option<std::net::IpAddr>) -> bool {
+        if self.is_mutating() {
+            return true;
+        }
+        if self.is_sensitive_read() {
+            return !peer.is_some_and(|p| p.is_loopback());
+        }
+        false
     }
 }
 
@@ -599,7 +622,7 @@ async fn handle_request(
     // disallowed Host/Origin is rejected; an allowlisted Origin is reflected in
     // the response (no more wildcard). Mutating/actuating routes additionally
     // require the shared local token when one is configured.
-    let echo_origin = match guard.check_request(&request) {
+    let echo_origin = match guard.check_request(&request, peer_ip) {
         OriginDecision::Allow(origin) => origin,
         OriginDecision::Reject(rejection) => {
             tracing::debug!(reason = rejection.reason(), "request gated out");
@@ -608,8 +631,10 @@ async fn handle_request(
         }
     };
     let route = classify_route(&request.method, &request.path);
-    if route.is_mutating() && !guard.token_ok(&request) {
-        tracing::debug!("mutating request without a valid local API token");
+    if route.requires_local_auth(peer_ip)
+        && (!guard.enforces_token() || !guard.token_ok(&request))
+    {
+        tracing::debug!("request without a valid local API token");
         let _ = write_guard_rejection(
             &mut writer,
             GuardRejection::MissingToken,


### PR DESCRIPTION
## Summary

Closes #303. After #228, LAN clients could send `Host: localhost:3080` from a non-loopback peer and read sensitive GET routes (memories, actuation pending, audit) without a `local_api_token`. This PR ties loopback `Host`/`Origin` to loopback peers and requires a configured local API token for sensitive reads from off-loopback peers.

## Changes

- `crates/genie-common/src/http.rs`: `check_request()` takes peer IP; reject loopback-looking `Host`/`Origin` unless the peer is loopback; add unit tests.
- `crates/genie-core/src/server.rs`: `requires_local_auth()` for sensitive GET routes from non-loopback peers (in addition to mutating routes).
- `crates/genie-api/src/http.rs`: same peer-aware gate and sensitive-route auth on dashboard proxies.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] `CI-only / docs-only`
- [ ] `Not run locally`

### What I ran

Ubuntu x86_64 dev host, Rust stable from rustup. On branch `fix/http-host-spoof-303` at commit `8c704a4`:

```bash
cd genie-claw
cargo test -p genie-common loopback_host
cargo test -p genie-api
```

### What I observed

`cargo test -p genie-common loopback_host`: 2 tests passed (`loopback_host_and_origin_for_bound_port_are_allowed`, `loopback_host_from_lan_peer_is_rejected`).

`cargo test -p genie-api`: 13 tests passed, including `cross_origin_is_gated_and_wildcard_is_gone` and `mutating_dashboard_endpoint_requires_token_when_configured`.

No Jetson or second-LAN-machine curl run in this session; verification is unit/integration tests plus code review of the Host/peer and `requires_local_auth` paths.

## Test plan

1. `cargo test -p genie-common loopback_host`
2. `cargo test -p genie-api`
3. (Optional, owned LAN) From a second host, `curl http://<LAN-IP>:3080/api/memories -H 'Host: localhost:3080'` should fail without token; loopback dashboard on the device should still work.

## Notes for reviewers

Distinct from closed #228 (browser confused-deputy / DNS rebinding). Does not redact actuation tokens from JSON yet; blocks LAN Host spoof and requires token on sensitive GET off-loopback. Orthogonal to open #245 (pending queue cap).
