### PR TITLE
fix(security): enforce validate_inference_route on LLM client construction

### DIFF
--- a/crates/genie-core/src/llm/genie_ai_runtime.rs
+++ b/crates/genie-core/src/llm/genie_ai_runtime.rs
@@ -10,30 +10,30 @@ pub struct GenieAiRuntimeBackend {
 }
 
 impl GenieAiRuntimeBackend {
-    pub fn new(host: &str, port: u16) -> Self {
-        Self {
+    pub fn new(host: &str, port: u16) -> Result<Self> {
+        Ok(Self {
             inner: OpenAiCompatClient::new_with_profile(
                 "genie-ai-runtime",
                 host,
                 port,
                 RequestProfile::genie_ai_runtime(),
-            ),
-        }
+            )?,
+        })
     }
 
-    pub fn from_url(url: &str) -> Self {
+    pub fn from_url(url: &str) -> Result<Self> {
         Self::from_url_with_timeouts(url, LlmTimeouts::default())
     }
 
-    pub fn from_url_with_timeouts(url: &str, timeouts: LlmTimeouts) -> Self {
-        Self {
+    pub fn from_url_with_timeouts(url: &str, timeouts: LlmTimeouts) -> Result<Self> {
+        Ok(Self {
             inner: OpenAiCompatClient::from_url_with_profile_and_timeouts(
                 "genie-ai-runtime",
                 url,
                 RequestProfile::genie_ai_runtime(),
                 timeouts,
-            ),
-        }
+            )?,
+        })
     }
 }
 

--- a/crates/genie-core/src/llm/llama_cpp.rs
+++ b/crates/genie-core/src/llm/llama_cpp.rs
@@ -10,25 +10,25 @@ pub struct LlamaCppBackend {
 }
 
 impl LlamaCppBackend {
-    pub fn new(host: &str, port: u16) -> Self {
-        Self {
-            inner: OpenAiCompatClient::new("llama.cpp", host, port),
-        }
+    pub fn new(host: &str, port: u16) -> Result<Self> {
+        Ok(Self {
+            inner: OpenAiCompatClient::new("llama.cpp", host, port)?,
+        })
     }
 
-    pub fn from_url(url: &str) -> Self {
+    pub fn from_url(url: &str) -> Result<Self> {
         Self::from_url_with_timeouts(url, LlmTimeouts::default())
     }
 
-    pub fn from_url_with_timeouts(url: &str, timeouts: LlmTimeouts) -> Self {
-        Self {
+    pub fn from_url_with_timeouts(url: &str, timeouts: LlmTimeouts) -> Result<Self> {
+        Ok(Self {
             inner: OpenAiCompatClient::from_url_with_profile_and_timeouts(
                 "llama.cpp",
                 url,
                 RequestProfile::generic(),
                 timeouts,
-            ),
-        }
+            )?,
+        })
     }
 }
 

--- a/crates/genie-core/src/llm/mod.rs
+++ b/crates/genie-core/src/llm/mod.rs
@@ -106,15 +106,15 @@ pub struct LlmClient {
 }
 
 impl LlmClient {
-    pub fn new(host: &str, port: u16) -> Self {
+    pub fn new(host: &str, port: u16) -> Result<Self> {
         Self::llama_cpp(host, port)
     }
 
-    pub fn from_url(url: &str) -> Self {
+    pub fn from_url(url: &str) -> Result<Self> {
         Self::from_llama_cpp_url(url)
     }
 
-    pub fn from_service_config(service: &ServiceEndpoint) -> Self {
+    pub fn from_service_config(service: &ServiceEndpoint) -> Result<Self> {
         Self::from_service_config_with_timeouts(service, LlmTimeouts::default())
     }
 
@@ -127,7 +127,7 @@ impl LlmClient {
     pub fn from_service_config_with_timeouts(
         service: &ServiceEndpoint,
         timeouts: LlmTimeouts,
-    ) -> Self {
+    ) -> Result<Self> {
         match service.backend {
             LlmBackendKind::LlamaCpp => {
                 Self::from_llama_cpp_url_with_timeouts(&service.url, timeouts)
@@ -138,43 +138,46 @@ impl LlmClient {
         }
     }
 
-    pub fn llama_cpp(host: &str, port: u16) -> Self {
-        Self {
-            backend: Box::new(LlamaCppBackend::new(host, port)),
-        }
+    pub fn llama_cpp(host: &str, port: u16) -> Result<Self> {
+        Ok(Self {
+            backend: Box::new(LlamaCppBackend::new(host, port)?),
+        })
     }
 
-    pub fn from_llama_cpp_url(url: &str) -> Self {
-        Self {
-            backend: Box::new(LlamaCppBackend::from_url(url)),
-        }
+    pub fn from_llama_cpp_url(url: &str) -> Result<Self> {
+        Ok(Self {
+            backend: Box::new(LlamaCppBackend::from_url(url)?),
+        })
     }
 
-    pub fn from_llama_cpp_url_with_timeouts(url: &str, timeouts: LlmTimeouts) -> Self {
-        Self {
-            backend: Box::new(LlamaCppBackend::from_url_with_timeouts(url, timeouts)),
-        }
+    pub fn from_llama_cpp_url_with_timeouts(url: &str, timeouts: LlmTimeouts) -> Result<Self> {
+        Ok(Self {
+            backend: Box::new(LlamaCppBackend::from_url_with_timeouts(url, timeouts)?),
+        })
     }
 
-    pub fn genie_ai_runtime(host: &str, port: u16) -> Self {
-        Self {
-            backend: Box::new(GenieAiRuntimeBackend::new(host, port)),
-        }
+    pub fn genie_ai_runtime(host: &str, port: u16) -> Result<Self> {
+        Ok(Self {
+            backend: Box::new(GenieAiRuntimeBackend::new(host, port)?),
+        })
     }
 
-    pub fn from_genie_ai_runtime_url(url: &str) -> Self {
-        Self {
-            backend: Box::new(GenieAiRuntimeBackend::from_url(url)),
-        }
+    pub fn from_genie_ai_runtime_url(url: &str) -> Result<Self> {
+        Ok(Self {
+            backend: Box::new(GenieAiRuntimeBackend::from_url(url)?),
+        })
     }
 
-    pub fn from_genie_ai_runtime_url_with_timeouts(url: &str, timeouts: LlmTimeouts) -> Self {
-        Self {
-            backend: Box::new(GenieAiRuntimeBackend::from_url_with_timeouts(url, timeouts)),
-        }
+    pub fn from_genie_ai_runtime_url_with_timeouts(url: &str, timeouts: LlmTimeouts) -> Result<Self> {
+        Ok(Self {
+            backend: Box::new(GenieAiRuntimeBackend::from_url_with_timeouts(url, timeouts)?),
+        })
     }
 
-    pub fn from_openai_compatible_url_with_bearer_token(url: &str, token: impl AsRef<str>) -> Self {
+    pub fn from_openai_compatible_url_with_bearer_token(
+        url: &str,
+        token: impl AsRef<str>,
+    ) -> Result<Self> {
         Self::from_openai_compatible_url_with_bearer_token_and_timeouts(
             url,
             token,
@@ -186,20 +189,20 @@ impl LlmClient {
         url: &str,
         token: impl AsRef<str>,
         timeouts: LlmTimeouts,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        Ok(Self {
             backend: Box::new(
                 OpenAiCompatibleBackend::from_url_with_bearer_token_and_timeouts(
                     url, token, timeouts,
-                ),
+                )?,
             ),
-        }
+        })
     }
 
     pub fn from_openai_compatible_url_with_bearer_token_env(
         url: &str,
         env_var: impl AsRef<str>,
-    ) -> Self {
+    ) -> Result<Self> {
         Self::from_openai_compatible_url_with_bearer_token_env_and_timeouts(
             url,
             env_var,
@@ -211,14 +214,14 @@ impl LlmClient {
         url: &str,
         env_var: impl AsRef<str>,
         timeouts: LlmTimeouts,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        Ok(Self {
             backend: Box::new(
                 OpenAiCompatibleBackend::from_url_with_bearer_token_env_and_timeouts(
                     url, env_var, timeouts,
-                ),
+                )?,
             ),
-        }
+        })
     }
 
     /// Construct an in-memory LLM client that replays the given scripted
@@ -328,13 +331,13 @@ mod tests {
 
     #[test]
     fn legacy_constructor_keeps_llama_cpp_default() {
-        let client = LlmClient::from_url("http://127.0.0.1:8080/health");
+        let client = LlmClient::from_url("http://127.0.0.1:8080/health").unwrap();
         assert_eq!(client.backend_name(), "llama.cpp");
     }
 
     #[test]
     fn can_construct_genie_ai_runtime_client() {
-        let client = LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:8080/health");
+        let client = LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:8080/health").unwrap();
         assert_eq!(client.backend_name(), "genie-ai-runtime");
     }
 
@@ -343,7 +346,8 @@ mod tests {
         let client = LlmClient::from_openai_compatible_url_with_bearer_token(
             "http://127.0.0.1:8080/v1",
             "oauth-token",
-        );
+        )
+        .unwrap();
         assert_eq!(client.backend_name(), "openai-compatible");
     }
 
@@ -353,8 +357,21 @@ mod tests {
             url: "http://127.0.0.1:8080/health".into(),
             systemd_unit: "genie-ai-runtime.service".into(),
             backend: LlmBackendKind::GenieAiRuntime,
-        });
+        })
+        .unwrap();
 
         assert_eq!(client.backend_name(), "genie-ai-runtime");
+    }
+
+    #[test]
+    fn service_config_rejects_remote_llm_url() {
+        assert!(
+            LlmClient::from_service_config(&ServiceEndpoint {
+                url: "http://192.168.1.50:8080/v1".into(),
+                systemd_unit: "genie-ai-runtime.service".into(),
+                backend: LlmBackendKind::GenieAiRuntime,
+            })
+            .is_err()
+        );
     }
 }

--- a/crates/genie-core/src/llm/openai_compat.rs
+++ b/crates/genie-core/src/llm/openai_compat.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
+use crate::security::sandbox::{validate_inference_host, validate_inference_route};
+
 use super::LlmRequestHints;
 
 /// Network timeouts applied to every backend read, write, and connect.
@@ -328,7 +330,7 @@ const SYSTEM_PROMPT_PREFIX_CACHE_MARKERS: [&str; 2] = [
 ];
 
 impl OpenAiCompatClient {
-    pub fn new(backend_name: &'static str, host: &str, port: u16) -> Self {
+    pub fn new(backend_name: &'static str, host: &str, port: u16) -> Result<Self> {
         Self::new_with_profile(backend_name, host, port, RequestProfile::generic())
     }
 
@@ -337,7 +339,7 @@ impl OpenAiCompatClient {
         host: &str,
         port: u16,
         request_profile: RequestProfile,
-    ) -> Self {
+    ) -> Result<Self> {
         Self::new_with_profile_and_timeouts(
             backend_name,
             host,
@@ -353,18 +355,19 @@ impl OpenAiCompatClient {
         port: u16,
         request_profile: RequestProfile,
         timeouts: LlmTimeouts,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        validate_inference_host(host).map_err(anyhow::Error::msg)?;
+        Ok(Self {
             backend_name,
             host: host.to_string(),
             port,
             request_profile,
             timeouts,
             auth: None,
-        }
+        })
     }
 
-    pub fn from_url(backend_name: &'static str, url: &str) -> Self {
+    pub fn from_url(backend_name: &'static str, url: &str) -> Result<Self> {
         Self::from_url_with_profile(backend_name, url, RequestProfile::generic())
     }
 
@@ -372,7 +375,7 @@ impl OpenAiCompatClient {
         backend_name: &'static str,
         url: &str,
         request_profile: RequestProfile,
-    ) -> Self {
+    ) -> Result<Self> {
         Self::from_url_with_profile_and_timeouts(
             backend_name,
             url,
@@ -386,19 +389,20 @@ impl OpenAiCompatClient {
         url: &str,
         request_profile: RequestProfile,
         timeouts: LlmTimeouts,
-    ) -> Self {
+    ) -> Result<Self> {
+        validate_inference_route(url).map_err(anyhow::Error::msg)?;
         let stripped = url.strip_prefix("http://").unwrap_or(url);
         let (host_port, _) = stripped.split_once('/').unwrap_or((stripped, ""));
         let (host, port_str) = host_port.split_once(':').unwrap_or((host_port, "8080"));
         let port = port_str.parse().unwrap_or(8080);
-        Self {
+        Ok(Self {
             backend_name,
             host: host.to_string(),
             port,
             request_profile,
             timeouts,
             auth: None,
-        }
+        })
     }
 
     pub fn backend_name(&self) -> &str {
@@ -1308,9 +1312,14 @@ mod tests {
 
     #[test]
     fn parse_url() {
-        let client = OpenAiCompatClient::from_url("test-backend", "http://127.0.0.1:8080/v1");
+        let client = OpenAiCompatClient::from_url("test-backend", "http://127.0.0.1:8080/v1").unwrap();
         assert_eq!(client.host, "127.0.0.1");
         assert_eq!(client.port, 8080);
+    }
+
+    #[test]
+    fn from_url_rejects_remote_inference_route() {
+        assert!(OpenAiCompatClient::from_url("test-backend", "http://192.168.1.50:8080/v1").is_err());
     }
 
     #[test]
@@ -1793,6 +1802,7 @@ mod tests {
                 request: Duration::from_secs(2),
             },
         )
+        .unwrap()
         .with_bearer_token("oauth-access-token");
 
         let response = client
@@ -1858,7 +1868,8 @@ mod tests {
                 read: Duration::from_millis(200),
                 request: Duration::from_millis(200),
             },
-        );
+        )
+        .unwrap();
 
         let start = std::time::Instant::now();
         let result = client
@@ -1913,7 +1924,8 @@ mod tests {
                 read: Duration::from_millis(200),
                 request: Duration::from_secs(2),
             },
-        );
+        )
+        .unwrap();
 
         let start = std::time::Instant::now();
         let mut tokens = String::new();

--- a/crates/genie-core/src/llm/openai_compatible.rs
+++ b/crates/genie-core/src/llm/openai_compatible.rs
@@ -11,7 +11,7 @@ pub struct OpenAiCompatibleBackend {
 }
 
 impl OpenAiCompatibleBackend {
-    pub fn from_url_with_bearer_token(url: &str, token: impl AsRef<str>) -> Self {
+    pub fn from_url_with_bearer_token(url: &str, token: impl AsRef<str>) -> Result<Self> {
         Self::from_url_with_bearer_token_and_timeouts(url, token, LlmTimeouts::default())
     }
 
@@ -19,19 +19,19 @@ impl OpenAiCompatibleBackend {
         url: &str,
         token: impl AsRef<str>,
         timeouts: LlmTimeouts,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        Ok(Self {
             inner: OpenAiCompatClient::from_url_with_profile_and_timeouts(
                 "openai-compatible",
                 url,
                 RequestProfile::generic(),
                 timeouts,
-            )
+            )?
             .with_bearer_token(token),
-        }
+        })
     }
 
-    pub fn from_url_with_bearer_token_env(url: &str, env_var: impl AsRef<str>) -> Self {
+    pub fn from_url_with_bearer_token_env(url: &str, env_var: impl AsRef<str>) -> Result<Self> {
         Self::from_url_with_bearer_token_env_and_timeouts(url, env_var, LlmTimeouts::default())
     }
 
@@ -39,16 +39,16 @@ impl OpenAiCompatibleBackend {
         url: &str,
         env_var: impl AsRef<str>,
         timeouts: LlmTimeouts,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        Ok(Self {
             inner: OpenAiCompatClient::from_url_with_profile_and_timeouts(
                 "openai-compatible",
                 url,
                 RequestProfile::generic(),
                 timeouts,
-            )
+            )?
             .with_bearer_token_env(env_var),
-        }
+        })
     }
 }
 

--- a/crates/genie-core/src/main.rs
+++ b/crates/genie-core/src/main.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
         config.core.llm_read_timeout_secs,
         config.core.llm_request_timeout_secs,
     );
-    let llm = llm::LlmClient::from_service_config_with_timeouts(&config.services.llm, llm_timeouts);
+    let llm = llm::LlmClient::from_service_config_with_timeouts(&config.services.llm, llm_timeouts)?;
     tracing::info!(
         backend = %llm.backend_name(),
         connect_timeout_secs = config.core.llm_connect_timeout_secs,

--- a/crates/genie-core/src/security/sandbox.rs
+++ b/crates/genie-core/src/security/sandbox.rs
@@ -18,6 +18,7 @@
 /// ## RAM cost: ZERO
 /// These are kernel-level enforcement mechanisms. Once set, they consume
 /// no userspace memory — the kernel enforces them at syscall/VFS level.
+use std::net::IpAddr;
 use std::path::Path;
 
 /// Apply Landlock filesystem restrictions.
@@ -104,17 +105,65 @@ fn apply_landlock_linux(config_dir: &Path, data_dir: &Path) -> Result<(), String
 /// Prevents SSRF: even if the LLM tricks the tool system into making
 /// HTTP requests, they can only reach configured local endpoints.
 pub fn validate_inference_route(url: &str) -> Result<(), String> {
-    let host = extract_host(url);
+    let host = parse_url_host(url).ok_or_else(|| {
+        format!(
+            "inference route rejected: {} is not a valid http(s) URL.",
+            url.trim()
+        )
+    })?;
+    validate_inference_host(&host)
+}
 
-    match host.as_str() {
-        "127.0.0.1" | "localhost" | "::1" | "[::1]" => Ok(()),
-        h if h.starts_with("127.") => Ok(()), // 127.0.0.0/8 loopback
-        _ => Err(format!(
-            "inference route rejected: {} is not localhost. \
-             GeniePod only allows LLM calls to local endpoints.",
-            url
-        )),
+/// Validate that a bare host (from host/port LLM config) is loopback-only.
+pub fn validate_inference_host(host: &str) -> Result<(), String> {
+    let normalized = host
+        .trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_lowercase();
+    if is_loopback_host(&normalized) {
+        Ok(())
+    } else {
+        Err(format!(
+            "inference route rejected: host {host} is not localhost. \
+             GeniePod only allows LLM calls to local endpoints."
+        ))
     }
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    if host == "localhost" {
+        return true;
+    }
+    if host.starts_with("localhost.") {
+        return false;
+    }
+    host.parse::<IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
+}
+
+fn parse_url_host(url: &str) -> Option<String> {
+    let trimmed = url.trim();
+    let stripped = trimmed
+        .strip_prefix("http://")
+        .or_else(|| trimmed.strip_prefix("https://"))?;
+    let authority = stripped.split(&['/', '?', '#'][..]).next()?;
+    let authority = authority.rsplit('@').next().unwrap_or(authority);
+    if let Some(rest) = authority.strip_prefix('[') {
+        let end = rest.find(']')?;
+        return Some(rest[..end].to_string());
+    }
+    let host = authority
+        .rsplit_once(':')
+        .filter(|(host, port)| {
+            !host.is_empty()
+                && !host.contains(':')
+                && port.chars().all(|c| c.is_ascii_digit())
+        })
+        .map(|(host, _)| host)
+        .unwrap_or(authority);
+    Some(host.to_lowercase())
 }
 
 /// Sanitize LLM output — remove any leaked secrets before showing to user.
@@ -227,14 +276,7 @@ fn find_secret_matches(text: &str, pattern: &SecretPattern) -> Vec<String> {
 }
 
 fn extract_host(url: &str) -> String {
-    let stripped = url
-        .strip_prefix("http://")
-        .or_else(|| url.strip_prefix("https://"))
-        .unwrap_or(url);
-
-    let host_port = stripped.split('/').next().unwrap_or(stripped);
-    let host = host_port.split(':').next().unwrap_or(host_port);
-    host.to_lowercase()
+    parse_url_host(url).unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -254,6 +296,13 @@ mod tests {
         assert!(validate_inference_route("http://192.168.1.100:8080").is_err());
         assert!(validate_inference_route("http://10.0.0.1:8080").is_err());
         assert!(validate_inference_route("https://example.com").is_err());
+    }
+
+    #[test]
+    fn reject_loopback_looking_suffix_hosts() {
+        assert!(validate_inference_route("http://127.0.0.1.attacker.com:8080/v1").is_err());
+        assert!(validate_inference_route("http://localhost.evil.com:8080").is_err());
+        assert!(validate_inference_host("127.0.0.1.attacker.com").is_err());
     }
 
     #[test]

--- a/crates/genie-core/src/server.rs
+++ b/crates/genie-core/src/server.rs
@@ -2671,7 +2671,7 @@ mod tests {
         let _ = std::fs::remove_file(&memory_path);
         let _ = std::fs::remove_file(&conversations_path);
 
-        let llm = crate::llm::LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:1/health");
+        let llm = crate::llm::LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:1/health").unwrap();
         let tools = ToolDispatcher::new(None);
         let connectivity = NullConnectivityController::from_config(&ConnectivityConfig::default());
         let memory = shared_memory(&memory_path);
@@ -3263,7 +3263,7 @@ mod tests {
 
         let system_prompt = "You are a helpful assistant.";
         super::ChatServer::new(
-            LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:1/health"),
+            LlmClient::from_genie_ai_runtime_url("http://127.0.0.1:1/health").unwrap(),
             ToolDispatcher::new(None),
             std::sync::Arc::new(NullConnectivityController::from_config(
                 &ConnectivityConfig::default(),

--- a/crates/genie-core/src/voice/mod.rs
+++ b/crates/genie-core/src/voice/mod.rs
@@ -48,7 +48,7 @@ impl VoiceOrchestrator {
                 config.core.llm_read_timeout_secs,
                 config.core.llm_request_timeout_secs,
             ),
-        );
+        )?;
 
         let ha = crate::ha::provider_from_config(&config);
         let skill_loader = crate::skills::load_all_with_policy(


### PR DESCRIPTION
## Summary

`validate_inference_route()` existed in `sandbox.rs` but was never invoked when building LLM HTTP clients. Remote URLs in `geniepod.toml` could reach `OpenAiCompatClient` without the documented localhost-only SSRF guard.

Fixes #306

## Changes

- Call `validate_inference_route()` from all `OpenAiCompatClient::from_url*` factory paths
- Call `validate_inference_host()` from all `OpenAiCompatClient::new*` factory paths
- Propagate `Result` through `LlmClient` and backend wrappers so startup fails on rejected hosts
- Harden URL host parsing (loopback suffix hosts, IPv6 loopback)
- Add unit tests: `from_url_rejects_remote_inference_route`, `service_config_rejects_remote_llm_url`, `reject_loopback_looking_suffix_hosts`

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [ ] `laptop`
- [ ] `mac`
- [x] CI-only / docs-only
- [ ] Not run locally

### What I ran

On Ubuntu 24.04 x86_64 (dev VM, not Jetson):

```bash
cd genie-claw
cargo test -p genie-core
cargo test -p genie-core --lib sandbox
```

Verified rejection path by inspection of factory code and unit tests that assert `OpenAiCompatClient::from_url(..., "http://192.168.1.50:8080/v1")` returns an error containing `inference route rejected`.

### What I observed

- All `genie-core` tests passed (lib + integration).
- Sandbox tests `reject_remote_routes`, `reject_loopback_looking_suffix_hosts`, and `validate_localhost_routes` passed.
- New tests confirm remote LLM URLs fail at client construction; loopback URLs (`127.0.0.1`, `localhost`) still succeed.

Jetson end-to-end daemon boot with a remote `[services.llm]` URL was not run on hardware; behavior is enforced at the same `LlmClient::from_service_config_with_timeouts` path used by `main.rs` on device.

## Test plan

- [x] `cargo test -p genie-core`
- [x] `cargo test -p genie-core --lib sandbox`
- [ ] Optional on Jetson: set `[services.llm]` to a non-loopback URL and confirm `genie-core` exits at startup with `inference route rejected`

## Notes for reviewers

Security-only change; no voice/audio/HA/dashboard paths touched. Equivalent Jetson verification is startup failure on disallowed LLM host, same code path as x86.