### PR TITLE
docs(eval): require license metadata for public BFCL data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 /ROADMAP.md
 /VISION.md
 
+# Local/generated BFCL stress datasets. These can be large and intentionally
+# imperfect, so keep them out of git.
+/tests/bfcl/local/
+
 # macOS metadata
 .DS_Store
 **/.DS_Store

--- a/crates/genie-core/src/eval/bfcl.rs
+++ b/crates/genie-core/src/eval/bfcl.rs
@@ -19,11 +19,28 @@ pub struct BfclCase {
     pub id: String,
     #[serde(default)]
     pub category: Option<String>,
+    #[serde(default)]
+    pub source: Option<BfclCaseSource>,
     pub prompt: String,
     #[serde(default, alias = "expected_calls")]
     pub expected_tool_calls: Vec<ExpectedToolCall>,
     #[serde(default)]
     pub allow_extra_arguments: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BfclCaseSource {
+    pub dataset: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub license: Option<String>,
+    #[serde(default)]
+    pub citation: Option<String>,
+    #[serde(default)]
+    pub derived_from: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -45,6 +62,7 @@ pub struct BfclPrediction {
 pub struct BfclCaseScore {
     pub id: String,
     pub category: Option<String>,
+    pub source: Option<BfclCaseSource>,
     pub missing_prediction: bool,
     pub parse_success: bool,
     pub tool_name_match: bool,
@@ -171,6 +189,7 @@ fn score_parsed_calls(
         return BfclCaseScore {
             id: case.id.clone(),
             category: case.category.clone(),
+            source: case.source.clone(),
             missing_prediction,
             parse_success: pass,
             tool_name_match: pass,
@@ -236,6 +255,7 @@ fn score_parsed_calls(
     BfclCaseScore {
         id: case.id.clone(),
         category: case.category.clone(),
+        source: case.source.clone(),
         missing_prediction,
         parse_success,
         tool_name_match,
@@ -401,6 +421,7 @@ mod tests {
         BfclCase {
             id: "case-1".to_string(),
             category: Some("unit".to_string()),
+            source: None,
             prompt: "test prompt".to_string(),
             expected_tool_calls,
             allow_extra_arguments: false,
@@ -533,6 +554,42 @@ mod tests {
         assert_eq!(report.strict_matches, 21);
         assert_eq!(report.failure_count, 0);
         assert!((report.strict_accuracy - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn loads_optional_source_metadata_for_license_audit() {
+        let record = r#"{
+            "id": "ha-turn-on-kitchen",
+            "category": "home_control",
+            "source": {
+                "dataset": "Home Assistant Intents",
+                "url": "https://github.com/OHF-Voice/intents",
+                "license": "CC BY 4.0",
+                "citation": "OHF-Voice/intents",
+                "derived_from": "sentences/en/light_HassTurnOn.yaml",
+                "notes": "Converted template sentence with local fixture slots."
+            },
+            "prompt": "turn on the kitchen light",
+            "expected_tool_calls": [
+                {
+                    "name": "home_control",
+                    "arguments": {
+                        "action": "turn_on",
+                        "entity": "kitchen light"
+                    }
+                }
+            ]
+        }"#;
+
+        let case = serde_json::from_str::<BfclCase>(record).unwrap();
+        let source = case.source.expect("source metadata");
+
+        assert_eq!(source.dataset, "Home Assistant Intents");
+        assert_eq!(source.license.as_deref(), Some("CC BY 4.0"));
+        assert_eq!(
+            source.derived_from.as_deref(),
+            Some("sentences/en/light_HassTurnOn.yaml")
+        );
     }
 
     #[test]

--- a/doc/README.md
+++ b/doc/README.md
@@ -26,6 +26,7 @@ Where current code is transitional, the docs call that out explicitly.
 - [household-security.md](household-security.md): family/shared-memory trust model and redacted config policy
 - [core-subsystems.md](core-subsystems.md): LLM, prompt, tools, memory, voice, Telegram, security, and skills
 - [memory-system.md](memory-system.md): implemented memory architecture, storage model, recall layers, policy, and extension guidance
+- [evaluation-data.md](evaluation-data.md): public dataset fit, license policy, and BFCL source metadata rules
 - [deployment-and-ops.md](deployment-and-ops.md): local dev, Docker, Jetson deploy, systemd, and operations
 - [milestone-1-portable-home-agent.md](milestone-1-portable-home-agent.md): M1 architecture movement for portable validation without weakening the limited-context home-agent goal
 - [repo-map.md](repo-map.md): top-level files, directories, and module map

--- a/doc/evaluation-data.md
+++ b/doc/evaluation-data.md
@@ -1,0 +1,84 @@
+# Evaluation Data And License Policy
+
+GenieClaw can use public data to improve BFCL tool-call accuracy and home
+context retrieval, but every imported or converted dataset must keep a clear
+license trail. If the license is unknown, noncommercial-only, or incompatible
+with product use, keep it out of committed fixtures and product CI.
+
+This is the engineering rule for this repo:
+
+- verify the license before import
+- keep source URL, license, citation, version/date, and conversion notes
+- commit only small fixtures or adapters, not raw public datasets
+- keep large generated data under ignored local paths such as `tests/bfcl/local/`
+- do not commit private household facts, real secrets, credentials, or raw user
+  logs
+- treat noncommercial data as research-only unless a separate license is
+  obtained
+
+When in doubt, do not import the data.
+
+## Dataset Fit
+
+| Dataset | License posture | GenieClaw use |
+|---------|-----------------|---------------|
+| [Home Assistant Intents](https://github.com/OHF-Voice/intents) | Source repo is CC BY 4.0. Preserve attribution. | Best first source for BFCL `home_control`, `home_status`, timer, media, weather, and slot cases. Convert templates into Genie typed-tool expectations. |
+| [CASAS Smart Home Data Sets](https://casas.wsu.edu/datasets/) | Current Zenodo CASAS records are CC BY 4.0; verify each record before use. | Best public real-home source for sensor timelines, presence, activity, action-history, and device-state context replay. |
+| [REFIT Electrical Load Measurements](https://pureportal.strath.ac.uk/en/datasets/refit-electrical-load-measurements-cleaned/) | CC BY 4.0. | Use for deterministic energy/device-state tests such as "what is using the most power" and appliance activity checks. |
+| [UK-DALE](https://jack-kelly.com/data/) | CC BY 4.0. | Use for longer appliance electricity traces, power summaries, and anomaly-style home status tests. |
+| [SLURP](https://github.com/pswietojanski/slurp) | Text annotations are CC BY 4.0. Audio is CC BY-NC 4.0 unless a separate license is obtained. | Use text only for assistant-style utterance variants and STT-like wording. Keep audio out of product CI. |
+| [MASSIVE](https://github.com/alexa/massive) | Dataset is CC BY 4.0; repo code is Apache 2.0. | Use text for multilingual utterance and slot-routing tests after mapping intents to Genie typed tools. |
+| [Google Speech Commands](https://www.tensorflow.org/datasets/catalog/speech_commands) | CC BY 4.0 for dataset content. | Primarily belongs in `genie-voice-runtime` for wake/keyword audio tests. Only use tiny derived text smoke cases in GenieClaw if needed. |
+
+No public dataset above is a complete GenieClaw benchmark. The correct target is
+a layered eval suite: BFCL cases for typed tools, replayed home state for
+context, and separate voice-runtime audio tests in `genie-voice-runtime`.
+
+## BFCL Source Metadata
+
+BFCL cases may include optional `source` metadata. Any committed case derived
+from a public dataset should include it:
+
+```json
+{
+  "id": "ha-turn-on-kitchen",
+  "category": "home_control",
+  "source": {
+    "dataset": "Home Assistant Intents",
+    "url": "https://github.com/OHF-Voice/intents",
+    "license": "CC BY 4.0",
+    "citation": "OHF-Voice/intents",
+    "derived_from": "sentences/en/light_HassTurnOn.yaml",
+    "notes": "Converted template sentence with local fixture slots."
+  },
+  "prompt": "turn on the kitchen light",
+  "expected_tool_calls": [
+    {
+      "name": "home_control",
+      "arguments": {
+        "action": "turn_on",
+        "entity": "kitchen light"
+      }
+    }
+  ]
+}
+```
+
+Synthetic hand-written fixtures do not need source metadata, but they should
+not pretend to be public benchmark data.
+
+## Conversion Rules
+
+1. Convert Home Assistant Intents into typed Genie tool calls, not natural
+   language answer checks.
+2. Convert CASAS timelines into small home-context snapshots before a prompt:
+   room activity, presence, door/motion events, and current sensor state.
+3. Convert REFIT and UK-DALE into aggregate device-state facts and expected
+   `home_status`, `system_info`, or memory/tool calls.
+4. Convert MASSIVE and SLURP text into robustness variants only after mapping
+   intent and slots to Genie tools.
+5. Keep generated stress suites local unless they are small, attributed,
+   reviewed, and product-license compatible.
+
+The score target remains Jetson Orin 8GB product behavior: fast, typed,
+deterministic tool calls inside the 4096-token home-agent harness.

--- a/tests/bfcl/README.md
+++ b/tests/bfcl/README.md
@@ -25,3 +25,12 @@ including home/device calls, memory read/write/diagnostic tools, timers,
 weather/search, calculations, media, no-tool responses, multi-tool responses,
 and OpenAI-compatible `tool_calls` output. Dynamic native skill tools are loaded
 at runtime, so each installed skill should add its own BFCL fixture.
+
+For local stress testing, put large generated suites under `tests/bfcl/local/`.
+That directory is gitignored on purpose. A useful local run shape is:
+
+```bash
+cargo run -p genie-ctl -- bfcl-score \
+  --cases tests/bfcl/local/long_home_tool_cases.jsonl \
+  --predictions tests/bfcl/local/long_home_tool_predictions.jsonl
+```

--- a/tests/bfcl/README.md
+++ b/tests/bfcl/README.md
@@ -19,6 +19,8 @@ The fixture format is intentionally plain:
   `expected_tool_calls`, and optional `allow_extra_arguments`.
 - `home_tool_predictions.jsonl`: one model response per line with matching
   `id` and `response`.
+- Public-dataset-derived cases may also include `source` metadata with
+  `dataset`, `url`, `license`, `citation`, `derived_from`, and `notes`.
 
 The first suite covers every static built-in tool name from `ToolDispatcher`,
 including home/device calls, memory read/write/diagnostic tools, timers,
@@ -34,3 +36,8 @@ cargo run -p genie-ctl -- bfcl-score \
   --cases tests/bfcl/local/long_home_tool_cases.jsonl \
   --predictions tests/bfcl/local/long_home_tool_predictions.jsonl
 ```
+
+Public data imports must follow [doc/evaluation-data.md](../../doc/evaluation-data.md).
+Do not commit raw public datasets, noncommercial-only audio, private household
+facts, secrets, or large generated suites. Committed public-derived fixtures
+need license and attribution metadata.


### PR DESCRIPTION
## Summary
- keep generated local BFCL stress datasets ignored under tests/bfcl/local
- add an evaluation-data policy for public dataset use, license compatibility, attribution, and local-only data
- add optional BFCL case source metadata so public-derived fixtures can carry dataset URL, license, citation, and conversion notes into reports
- document source metadata in the BFCL fixture README

## Real Behavior Proof
- [x] I ran the verification below and included the observed result.

Commands and observed results:
- cargo fmt --all -- --check: passed
- cargo test -p genie-core eval::bfcl -- --nocapture: passed, 9 BFCL tests
- cargo run -p genie-ctl -- bfcl-score --cases tests/bfcl/home_tool_cases.jsonl --predictions tests/bfcl/home_tool_predictions.jsonl: passed, 21 cases, 100% strict accuracy
- cargo clippy -p genie-core -p genie-ctl --all-targets --locked -- -D warnings: passed
- cargo test -p genie-core -p genie-ctl --no-default-features bfcl -- --nocapture: passed, 9 core BFCL tests and 3 ctl BFCL arg tests
- cargo clippy -p genie-core -p genie-ctl --no-default-features --all-targets --locked -- -D warnings: passed
- git diff --check: passed
- grep -R "GeniePod Home" -n README.md Cargo.toml crates doc tests .github --exclude-dir=target 2>/dev/null | head -100: no matches

## Jetson Validation
- Not run on physical Jetson. This is docs plus BFCL JSON metadata plumbing only; no runtime device behavior changed.