### PR TITLE
fix(memory): fuse lexical + semantic recall (RRF) and decay from last access

### DIFF
--- a/crates/genie-core/src/memory/mod.rs
+++ b/crates/genie-core/src/memory/mod.rs
@@ -799,7 +799,10 @@ impl Memory {
                 let decay_mult = if evergreen {
                     1.0
                 } else {
-                    let age_days = (now as f64 - entry.created_ms as f64) / (86_400_000.0);
+                    // Recency-of-use: decay from last access, not creation, so a
+                    // frequently-recalled memory stays fresh. `accessed_ms` is
+                    // refreshed by update_recall_tracking on every recall.
+                    let age_days = (now as f64 - entry.accessed_ms as f64) / (86_400_000.0);
                     decay::exponential_decay(age_days, self.half_life_days)
                 };
                 let final_score = bm25_score * decay_mult;
@@ -1044,7 +1047,7 @@ impl Memory {
         let now = now_ms();
         let mut stmt = self
             .conn
-            .prepare("SELECT id, created_ms FROM memories WHERE evergreen = 0 AND promoted = 0")?;
+            .prepare("SELECT id, accessed_ms FROM memories WHERE evergreen = 0 AND promoted = 0")?;
 
         let candidates: Vec<(i64, i64)> = stmt
             .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
@@ -1052,8 +1055,11 @@ impl Memory {
             .collect();
 
         let mut deleted = 0;
-        for (id, created_ms) in candidates {
-            let age_days = (now as f64 - created_ms as f64) / 86_400_000.0;
+        for (id, accessed_ms) in candidates {
+            // Decay from last access (recency-of-use), consistent with search
+            // ranking — a long-unused memory decays and is pruned; a recently
+            // recalled one survives regardless of how long ago it was created.
+            let age_days = (now as f64 - accessed_ms as f64) / 86_400_000.0;
             let multiplier = decay::exponential_decay(age_days, self.half_life_days);
 
             if multiplier < min_decay_threshold {
@@ -10979,6 +10985,39 @@ mod tests {
         let deleted = mem.prune_decayed(0.5).unwrap();
         assert!(deleted <= 1); // temporary might be deleted
         assert!(mem.count().unwrap() >= 1); // evergreen survives
+    }
+
+    /// Decay (and the destructive prune it drives) must be measured from last
+    /// access, not creation — so a year-old but recently-recalled memory is
+    /// kept, while a long-unused one is pruned. Pre-fix this used `created_ms`
+    /// and deleted the actively-used memory.
+    #[test]
+    fn prune_decayed_uses_last_access_not_creation_time() {
+        let mem = Memory::open_with_half_life(&temp_memory_path("prune-recency"), 30.0).unwrap();
+        let id = mem.store("fact", "frequently used fact").unwrap();
+        let now = now_ms();
+        let a_year_ago = now - 365 * 86_400_000;
+
+        // Created a year ago, but accessed just now (a daily-used fact).
+        mem.conn
+            .execute(
+                "UPDATE memories SET created_ms = ?1, accessed_ms = ?2 WHERE id = ?3",
+                rusqlite::params![a_year_ago, now, id],
+            )
+            .unwrap();
+        let deleted = mem.prune_decayed(0.5).unwrap();
+        assert_eq!(deleted, 0, "a recently-accessed memory must survive prune");
+        assert_eq!(mem.count().unwrap(), 1);
+
+        // Now make it stale by last-access as well — it should be pruned.
+        mem.conn
+            .execute(
+                "UPDATE memories SET accessed_ms = ?1 WHERE id = ?2",
+                rusqlite::params![a_year_ago, id],
+            )
+            .unwrap();
+        let deleted = mem.prune_decayed(0.5).unwrap();
+        assert_eq!(deleted, 1, "a long-unused memory must be pruned");
     }
 
     #[test]

--- a/crates/genie-core/src/memory/recall.rs
+++ b/crates/genie-core/src/memory/recall.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use super::decay;
 use super::policy;
-use super::{Memory, MemoryEntry};
+use super::{Memory, MemoryEntry, SemanticMemoryHit};
 
 /// Dreaming-inspired memory consolidation.
 ///
@@ -160,14 +160,9 @@ pub fn recall_with_context(
     limit: usize,
     context: policy::MemoryReadContext,
 ) -> Result<Vec<RecallableMemory>> {
-    let mut results = memory.search(query, limit)?;
-    let semantic_hits = memory.semantic_search(query, limit)?;
-    for hit in semantic_hits {
-        if !results.iter().any(|entry| entry.id == hit.entry.id) {
-            results.push(hit.entry);
-        }
-    }
-    results.truncate(limit.max(1));
+    let lexical = memory.search(query, limit)?;
+    let semantic = memory.semantic_search(query, limit)?;
+    let results = fuse_recall_candidates(lexical, semantic, limit);
     let raw_hits = results.len();
     let recalled = filter_recall_results(results, context);
 
@@ -195,6 +190,73 @@ pub fn recall_with_context(
     }
 
     Ok(recalled)
+}
+
+/// Reciprocal-Rank-Fusion constant. The standard value from the original RRF
+/// paper (Cormack et al.); larger `k` flattens the contribution of top ranks,
+/// smaller `k` sharpens it. 60 is the widely-used default.
+const RRF_K: f64 = 60.0;
+
+/// Fuse the lexical (BM25/LIKE) and semantic (cosine) recall rankings into a
+/// single relevance-ordered list using Reciprocal Rank Fusion.
+///
+/// Previously the two result sets were concatenated (lexical first, semantic
+/// appended) and then truncated to `limit`, which silently discarded every
+/// semantic hit whenever lexical search already filled the limit, and never
+/// ranked the combined set by relevance. RRF fixes both: each list contributes
+/// `1 / (RRF_K + rank)` per item (rank is 1-based), contributions for an id
+/// present in both lists are summed (agreement boosts it), and the merged set
+/// is sorted by the fused score before truncation.
+///
+/// RRF is rank-based, so it sidesteps the fact that BM25-derived scores and
+/// cosine similarities live on different, non-comparable scales. Ties are
+/// broken by first-seen order (lexical before semantic, then original rank),
+/// giving a deterministic result.
+fn fuse_recall_candidates(
+    lexical: Vec<MemoryEntry>,
+    semantic: Vec<SemanticMemoryHit>,
+    limit: usize,
+) -> Vec<MemoryEntry> {
+    use std::collections::HashMap;
+    use std::collections::hash_map::Entry as MapEntry;
+
+    let mut score_by_id: HashMap<i64, f64> = HashMap::new();
+    let mut entry_by_id: HashMap<i64, MemoryEntry> = HashMap::new();
+    // First-seen order, used as a stable tie-breaker.
+    let mut seen_order: Vec<i64> = Vec::new();
+
+    let mut accumulate = |id: i64, rank: usize, entry: MemoryEntry| {
+        // `rank` is 0-based here; RRF uses 1-based ranks.
+        let contribution = 1.0 / (RRF_K + (rank as f64) + 1.0);
+        *score_by_id.entry(id).or_insert(0.0) += contribution;
+        if let MapEntry::Vacant(slot) = entry_by_id.entry(id) {
+            slot.insert(entry);
+            seen_order.push(id);
+        }
+    };
+
+    // Lexical hits arrive already ordered best-first (decayed BM25).
+    for (rank, entry) in lexical.into_iter().enumerate() {
+        accumulate(entry.id, rank, entry);
+    }
+    // Semantic hits arrive already ordered best-first (cosine similarity).
+    for (rank, hit) in semantic.into_iter().enumerate() {
+        accumulate(hit.entry.id, rank, hit.entry);
+    }
+
+    // Stable sort by fused score (desc); equal scores keep first-seen order.
+    let mut ranked = seen_order;
+    ranked.sort_by(|a, b| {
+        let sa = score_by_id.get(a).copied().unwrap_or(0.0);
+        let sb = score_by_id.get(b).copied().unwrap_or(0.0);
+        sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    ranked
+        .into_iter()
+        .take(limit.max(1))
+        .filter_map(|id| entry_by_id.remove(&id))
+        .collect()
 }
 
 pub fn filter_recall_results(
@@ -241,6 +303,82 @@ fn diversity_from_unique_queries(unique_queries: usize) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_entry(id: i64, content: &str) -> MemoryEntry {
+        MemoryEntry {
+            id,
+            kind: "fact".to_string(),
+            content: content.to_string(),
+            created_ms: 0,
+            accessed_ms: 0,
+            recall_count: 0,
+            max_score: 0.0,
+            promoted: false,
+            metadata: policy::MemoryPolicyMetadata {
+                scope: policy::MemoryScope::Household,
+                sensitivity: policy::MemorySensitivity::Normal,
+                spoken_policy: policy::SpokenMemoryPolicy::Allow,
+            },
+        }
+    }
+
+    fn test_hit(id: i64, content: &str, score: f64) -> SemanticMemoryHit {
+        SemanticMemoryHit {
+            entry: test_entry(id, content),
+            score,
+            embedding_model: "test".to_string(),
+        }
+    }
+
+    /// The regression for the core bug: when lexical search already fills the
+    /// limit, the top semantic hit must still survive (RRF), not be truncated.
+    #[test]
+    fn fusion_keeps_semantic_hit_when_lexical_fills_the_limit() {
+        let lexical: Vec<MemoryEntry> = (1..=10).map(|i| test_entry(i, "common token")).collect();
+        let semantic = vec![test_hit(100, "semantically relevant", 0.95)];
+
+        let fused = fuse_recall_candidates(lexical, semantic, 10);
+
+        assert_eq!(fused.len(), 10);
+        assert!(
+            fused.iter().any(|e| e.id == 100),
+            "the top semantic hit must survive fusion, got ids {:?}",
+            fused.iter().map(|e| e.id).collect::<Vec<_>>()
+        );
+        assert!(
+            !fused.iter().any(|e| e.id == 10),
+            "the weakest lexical hit should be displaced by the semantic hit"
+        );
+    }
+
+    /// An id present in BOTH rankings has its contributions summed, so it
+    /// outranks items that appear in only one list.
+    #[test]
+    fn fusion_boosts_ids_present_in_both_rankings() {
+        let lexical = vec![test_entry(1, "a"), test_entry(2, "b"), test_entry(3, "c")];
+        let semantic = vec![test_hit(3, "c", 0.9)];
+
+        let fused = fuse_recall_candidates(lexical, semantic, 10);
+        let ids: Vec<i64> = fused.iter().map(|e| e.id).collect();
+
+        // id 3: lexical rank 3 (1/63) + semantic rank 1 (1/61) — highest fused.
+        // id 1: 1/61; id 2: 1/62.
+        assert_eq!(ids, vec![3, 1, 2]);
+    }
+
+    /// The same memory appearing in both lists must be de-duplicated.
+    #[test]
+    fn fusion_deduplicates_ids() {
+        let lexical = vec![test_entry(1, "a"), test_entry(2, "b")];
+        let semantic = vec![test_hit(1, "a", 0.9), test_hit(2, "b", 0.8)];
+
+        let fused = fuse_recall_candidates(lexical, semantic, 10);
+
+        assert_eq!(fused.len(), 2);
+        let mut ids: Vec<i64> = fused.iter().map(|e| e.id).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![1, 2]);
+    }
 
     #[test]
     fn default_weights_sum_to_one() {


### PR DESCRIPTION
## Summary

Fixes two correctness defects in the memory recall scoring pipeline. (1) `recall_with_context` concatenated the lexical and semantic result sets and truncated to `limit`, so semantic hits were silently dropped whenever lexical search already filled the limit, and the combined set was never relevance-ranked. (2) Temporal decay — used both for search ranking and for the destructive `prune_decayed` — was computed from `created_ms` instead of `accessed_ms`, so a frequently-recalled but old memory decayed to near-zero and could be pruned despite daily use.

Closes #311 

## Changes

- `memory/recall.rs`: add `fuse_recall_candidates`, which merges the lexical (BM25/LIKE) and semantic (cosine) rankings with Reciprocal Rank Fusion (`RRF_K = 60`): each list contributes `1 / (RRF_K + rank)`, contributions for an id present in both lists are summed, and the merged set is sorted by fused score before truncation. Rewire `recall_with_context` to use it (the `raw_hits` count and the `memory.recall.miss` diagnostic are preserved).
- `memory/mod.rs`: compute decay from `accessed_ms` (recency-of-use) in `search` ranking and in `prune_decayed` (which now also selects `accessed_ms`). Evergreen/promoted exemption is unchanged.
- Tests: `fusion_keeps_semantic_hit_when_lexical_fills_the_limit`, `fusion_boosts_ids_present_in_both_rankings`, `fusion_deduplicates_ids`, and `prune_decayed_uses_last_access_not_creation_time`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

x86_64 Linux dev host (Ubuntu, `laptop` profile), Rust stable 1.96.0. This change is pure SQLite scoring/ranking logic with no audio/voice/HA/dashboard path, so it is exercised end-to-end by the crate's unit and integration tests rather than on Jetson — the validation gap relative to Jetson is the hardware I/O paths, which this PR does not touch.

```
cargo test -p genie-core --lib
cargo test -p genie-core --lib memory::recall::tests::fusion
cargo test -p genie-core --lib memory::tests::prune_decayed_uses_last_access_not_creation_time
cargo fmt -p genie-core -- --check
cargo clippy -p genie-core
```

### What I observed

```
test result: ok. 649 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.83s

test memory::recall::tests::fusion_keeps_semantic_hit_when_lexical_fills_the_limit ... ok
test memory::recall::tests::fusion_boosts_ids_present_in_both_rankings ... ok
test memory::recall::tests::fusion_deduplicates_ids ... ok
test memory::tests::prune_decayed_uses_last_access_not_creation_time ... ok

# existing recall/semantic/decay coverage still green, e.g.
test memory::tests::semantic_search_links_cold_to_thermostat_preference ... ok
test memory::tests::evergreen_memories_dont_decay ... ok
```

`cargo fmt -- --check` reported no diffs; `cargo clippy` finished with no warnings.

## Test plan

- `cargo test -p genie-core --lib memory::` — confirms the fusion + decay tests and all existing memory tests pass.
- Behavioral check on any profile: store ≥10 memories sharing a common token plus one semantically-related memory; recall a query that lexically matches the fillers; confirm the semantically-related memory now appears in the recall set instead of being truncated away.
- Decay check: set a memory's `created_ms` far in the past but `accessed_ms` to now; confirm `prune_decayed` keeps it; then age `accessed_ms` and confirm it is pruned.

## Notes for reviewers

- RRF is rank-based by design, which avoids trying to normalize the non-comparable BM25-derived and cosine score scales. `RRF_K = 60` is the standard default; happy to expose it as a tunable if preferred.
- Ties are broken by first-seen order (lexical before semantic, then original rank) for deterministic output.
- The decay-field change shifts ranking/pruning from creation-age to last-access; on insert `accessed_ms == created_ms`, so freshly-stored memories are unaffected. No public signatures change.
