### PR TITLE
Add quick BFCL prediction generator

### DIFF
--- a/crates/genie-ctl/src/bfcl_import.rs
+++ b/crates/genie-ctl/src/bfcl_import.rs
@@ -148,14 +148,21 @@ pub fn import_ha_intents(args: &HaIntentsImportArgs) -> Result<HaIntentsImportRe
     let mut cases = Vec::new();
     let mut read_sentences = 0;
     let mut read_files = 0;
+    let mut next_case_index = 1usize;
     for (language, sentence_dir) in &sentence_dirs {
         let mut files = yaml_files(sentence_dir)?;
         files.sort();
 
         for path in &files {
             read_files += 1;
-            let file_cases = cases_from_file(&args.source, sentence_dir, path, language)
-                .with_context(|| format!("convert {}", path.display()))?;
+            let file_cases = cases_from_file(
+                &args.source,
+                sentence_dir,
+                path,
+                language,
+                &mut next_case_index,
+            )
+            .with_context(|| format!("convert {}", path.display()))?;
             read_sentences += file_cases.0;
             cases.extend(file_cases.1);
             if cases.len() >= args.limit {
@@ -189,6 +196,7 @@ fn cases_from_file(
     sentence_dir: &Path,
     path: &Path,
     language: &str,
+    next_case_index: &mut usize,
 ) -> Result<(usize, Vec<BfclCase>)> {
     let text = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     let parsed =
@@ -239,8 +247,9 @@ fn cases_from_file(
                 "ha-{}-{}-{:05}",
                 language,
                 slug(&intent_name),
-                cases.len() + 1
+                *next_case_index
             );
+            *next_case_index += 1;
             cases.push(BfclCase {
                 id,
                 category: Some(format!("ha_intents/{}", tool_call.name)),
@@ -1021,7 +1030,66 @@ intents:
         assert_eq!(report.generated_cases, 2);
         let cases = fs::read_to_string(out).unwrap();
         assert!(cases.contains("\"id\":\"ha-en-hassgetcurrenttime-00001\""));
-        assert!(cases.contains("\"id\":\"ha-es-hassgetcurrenttime-00001\""));
+        assert!(cases.contains("\"id\":\"ha-es-hassgetcurrenttime-00002\""));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn import_assigns_unique_case_ids_across_files() {
+        let root = unique_temp_dir("ha-intents-unique-ids");
+        fs::create_dir_all(root.join("sentences/en")).unwrap();
+        fs::write(
+            root.join("LICENSE.md"),
+            "Creative Commons Attribution 4.0 International Public License",
+        )
+        .unwrap();
+        let turn_on_yaml = |sentence: &str| {
+            format!(
+                r#"language: "en"
+intents:
+  HassTurnOn:
+    data:
+      - sentences:
+          - "{sentence}"
+        slots:
+          domain: "light"
+"#
+            )
+        };
+        fs::write(
+            root.join("sentences/en/light_HassTurnOn.yaml"),
+            turn_on_yaml("<turn> on [<the>] {name}"),
+        )
+        .unwrap();
+        fs::write(
+            root.join("sentences/en/switch_HassTurnOn.yaml"),
+            turn_on_yaml("<turn> on [<the>] {name} please"),
+        )
+        .unwrap();
+
+        let out = root.join("cases.jsonl");
+        let report = import_ha_intents(&HaIntentsImportArgs {
+            source: root.clone(),
+            out: out.clone(),
+            language: "en".to_string(),
+            limit: 10,
+        })
+        .unwrap();
+
+        assert_eq!(report.generated_cases, 2);
+        let cases = fs::read_to_string(out)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<BfclCase>(line).unwrap())
+            .collect::<Vec<_>>();
+        let ids = cases
+            .iter()
+            .map(|case| case.id.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(ids.len(), cases.len());
+        assert!(ids.contains("ha-en-hassturnon-00001"));
+        assert!(ids.contains("ha-en-hassturnon-00002"));
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -10,6 +10,8 @@
 //!   genie-ctl tools           List available tools
 //!   genie-ctl bfcl-score --cases CASES.jsonl --predictions PREDS.jsonl [--json]
 //!                              Score tool-call accuracy from JSONL fixtures
+//!   genie-ctl bfcl-predict-quick --cases CASES.jsonl --out PREDS.jsonl
+//!                              Generate deterministic quick-router predictions
 //!   genie-ctl bfcl-import-ha-intents --source INTENTS_DIR --out CASES.jsonl
 //!                              Convert Home Assistant Intents into BFCL cases
 //!   genie-ctl skill ...       Manage loadable skill modules
@@ -35,6 +37,7 @@ use genie_core::voice::identity::{
 use std::path::{Path, PathBuf};
 #[cfg(feature = "voice")]
 use std::process::Command;
+use std::{fs, io::Write};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 mod bfcl_import;
@@ -137,6 +140,16 @@ async fn main() -> Result<()> {
             let score_args = parse_bfcl_score_args(&args[2..])?;
             cmd_bfcl_score(&score_args)?;
         }
+        "bfcl-predict-quick" => {
+            let predict_args = parse_bfcl_predict_quick_args(&args[2..])?;
+            let generated = cmd_bfcl_predict_quick(&predict_args)?;
+            println!(
+                "generated {} quick-router BFCL predictions",
+                generated.total_cases
+            );
+            println!("tool calls: {}", generated.tool_calls);
+            println!("output: {}", predict_args.out.display());
+        }
         "bfcl-import-ha-intents" => {
             let import_args = bfcl_import::parse_ha_intents_import_args(&args[2..])?;
             let report = bfcl_import::import_ha_intents(&import_args)?;
@@ -221,6 +234,8 @@ COMMANDS:
     tools               List available tools
     bfcl-score --cases C --predictions P [--json]
                         Score tool-call accuracy from JSONL fixtures
+    bfcl-predict-quick --cases C --out P
+                        Generate deterministic quick-router predictions
     bfcl-import-ha-intents --source DIR --out CASES.jsonl [--language en] [--limit N]
                         Convert Home Assistant Intents into attributed BFCL cases
     connectivity        Inspect ESP32-C6 Thread/Matter sidecar status
@@ -945,6 +960,18 @@ struct BfclScoreArgs {
     json: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BfclPredictQuickArgs {
+    cases: PathBuf,
+    out: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BfclPredictQuickReport {
+    total_cases: usize,
+    tool_calls: usize,
+}
+
 fn parse_search_args(args: &[String]) -> Result<SearchArgs> {
     let mut fresh = false;
     let mut limit = 3;
@@ -1044,6 +1071,62 @@ fn parse_bfcl_score_args(args: &[String]) -> Result<BfclScoreArgs> {
     })
 }
 
+fn parse_bfcl_predict_quick_args(args: &[String]) -> Result<BfclPredictQuickArgs> {
+    let mut cases = None;
+    let mut out = None;
+    let mut idx = 0;
+
+    while idx < args.len() {
+        let arg = &args[idx];
+        match arg.as_str() {
+            "--cases" => {
+                let Some(value) = args.get(idx + 1) else {
+                    anyhow::bail!("--cases requires a JSONL path");
+                };
+                cases = Some(PathBuf::from(value));
+                idx += 2;
+            }
+            "--out" | "--predictions" | "--preds" => {
+                let Some(value) = args.get(idx + 1) else {
+                    anyhow::bail!("--out requires a JSONL output path");
+                };
+                out = Some(PathBuf::from(value));
+                idx += 2;
+            }
+            _ if arg.starts_with("--cases=") => {
+                cases = Some(PathBuf::from(arg.trim_start_matches("--cases=")));
+                idx += 1;
+            }
+            _ if arg.starts_with("--out=") => {
+                out = Some(PathBuf::from(arg.trim_start_matches("--out=")));
+                idx += 1;
+            }
+            _ if arg.starts_with("--predictions=") => {
+                out = Some(PathBuf::from(arg.trim_start_matches("--predictions=")));
+                idx += 1;
+            }
+            _ if arg.starts_with("--preds=") => {
+                out = Some(PathBuf::from(arg.trim_start_matches("--preds=")));
+                idx += 1;
+            }
+            other => anyhow::bail!("unknown bfcl-predict-quick option: {}", other),
+        }
+    }
+
+    let Some(cases) = cases else {
+        anyhow::bail!(
+            "Usage: genie-ctl bfcl-predict-quick --cases CASES.jsonl --out PREDICTIONS.jsonl"
+        );
+    };
+    let Some(out) = out else {
+        anyhow::bail!(
+            "Usage: genie-ctl bfcl-predict-quick --cases CASES.jsonl --out PREDICTIONS.jsonl"
+        );
+    };
+
+    Ok(BfclPredictQuickArgs { cases, out })
+}
+
 fn parse_search_limit(value: &str) -> Result<u64> {
     let limit = value
         .parse::<u64>()
@@ -1129,6 +1212,44 @@ fn cmd_bfcl_score(args: &BfclScoreArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn cmd_bfcl_predict_quick(args: &BfclPredictQuickArgs) -> Result<BfclPredictQuickReport> {
+    let cases = genie_core::eval::bfcl::load_cases_jsonl(&args.cases)?;
+    if let Some(parent) = args.out.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut writer = std::io::BufWriter::new(fs::File::create(&args.out)?);
+    let mut tool_calls = 0;
+    for case in &cases {
+        let response = if let Some(call) =
+            genie_core::tools::quick::route_for_available_tools(&case.prompt, true, true)
+        {
+            tool_calls += 1;
+            serde_json::json!({
+                "tool": call.name,
+                "arguments": call.arguments,
+            })
+            .to_string()
+        } else {
+            String::new()
+        };
+        let prediction = genie_core::eval::bfcl::BfclPrediction {
+            id: case.id.clone(),
+            response,
+        };
+        serde_json::to_writer(&mut writer, &prediction)?;
+        writer.write_all(b"\n")?;
+    }
+    writer.flush()?;
+
+    Ok(BfclPredictQuickReport {
+        total_cases: cases.len(),
+        tool_calls,
+    })
 }
 
 fn format_score_rate(rate: f64) -> String {
@@ -2301,6 +2422,67 @@ mod tests {
         ];
 
         assert!(parse_bfcl_score_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_bfcl_predict_quick_args_supports_output_aliases() {
+        let args = vec![
+            "--cases=tests/bfcl/local/ha_home_cases.jsonl".to_string(),
+            "--preds=tests/bfcl/local/ha_home_predictions.jsonl".to_string(),
+        ];
+
+        let parsed = parse_bfcl_predict_quick_args(&args).unwrap();
+
+        assert_eq!(
+            parsed.cases,
+            PathBuf::from("tests/bfcl/local/ha_home_cases.jsonl")
+        );
+        assert_eq!(
+            parsed.out,
+            PathBuf::from("tests/bfcl/local/ha_home_predictions.jsonl")
+        );
+    }
+
+    #[test]
+    fn bfcl_predict_quick_writes_prediction_jsonl() {
+        let dir = std::env::temp_dir().join(format!(
+            "genie-claw-bfcl-predict-test-{}-{}",
+            std::process::id(),
+            unix_time_ms()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let cases_path = dir.join("cases.jsonl");
+        let predictions_path = dir.join("predictions.jsonl");
+        std::fs::write(
+            &cases_path,
+            concat!(
+                "{\"id\":\"time-1\",\"prompt\":\"what time is it\",",
+                "\"expected_tool_calls\":[{\"name\":\"get_time\",\"arguments\":{}}]}\n"
+            ),
+        )
+        .unwrap();
+
+        let report = cmd_bfcl_predict_quick(&BfclPredictQuickArgs {
+            cases: cases_path.clone(),
+            out: predictions_path.clone(),
+        })
+        .unwrap();
+
+        assert_eq!(report.total_cases, 1);
+        assert_eq!(report.tool_calls, 1);
+
+        let predictions =
+            genie_core::eval::bfcl::load_predictions_jsonl(&predictions_path).unwrap();
+        assert_eq!(predictions.len(), 1);
+        assert_eq!(predictions[0].id, "time-1");
+
+        let cases = genie_core::eval::bfcl::load_cases_jsonl(&cases_path).unwrap();
+        let score = genie_core::eval::bfcl::score_cases(&cases, &predictions);
+        assert_eq!(score.strict_matches, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[cfg(feature = "voice")]

--- a/tests/bfcl/README.md
+++ b/tests/bfcl/README.md
@@ -27,6 +27,23 @@ cargo run -p genie-ctl -- bfcl-import-ha-intents \
 
 Use `--language all` for a larger multilingual suite.
 
+To create a deterministic baseline prediction file from GenieClaw's current
+quick router:
+
+```bash
+cargo run -p genie-ctl -- bfcl-predict-quick \
+  --cases tests/bfcl/local/ha_home_cases.jsonl \
+  --out tests/bfcl/local/ha_home_predictions.jsonl
+```
+
+Then score it:
+
+```bash
+cargo run -p genie-ctl -- bfcl-score \
+  --cases tests/bfcl/local/ha_home_cases.jsonl \
+  --predictions tests/bfcl/local/ha_home_predictions.jsonl
+```
+
 The fixture format is intentionally plain:
 
 - `home_tool_cases.jsonl`: one case per line with `id`, `prompt`,


### PR DESCRIPTION
## Summary
- add genie-ctl bfcl-predict-quick to generate deterministic quick-router prediction JSONL files
- document the HA Intents local import -> predict -> score flow
- make HA Intents imported case IDs unique across files and add regression coverage

## Real Behavior Proof
- [x] I ran the local verification listed below and recorded the observed BFCL output.

What I observed:
- English HA suite regenerated 208 cases with 0 duplicate IDs.
- quick-router baseline wrote 208 predictions with 0 missing rows and scored 5.77% strict accuracy.
- multilingual HA suite regenerated 1200 cases with 0 duplicate IDs.
- quick-router baseline wrote 1200 predictions with 0 missing rows and scored 1.92% strict accuracy.
- local host is x86_64, not Jetson Orin; local HA-derived JSONL outputs remain under gitignored tests/bfcl/local/.

## Tests
- cargo fmt --all -- --check
- git diff --check
- cargo test -p genie-ctl bfcl_import -- --nocapture
- cargo test -p genie-ctl bfcl_predict -- --nocapture
- cargo test -p genie-core -p genie-ctl
- cargo clippy -p genie-core -p genie-ctl --all-targets --locked -- -D warnings
- cargo test -p genie-core -p genie-ctl --no-default-features bfcl -- --nocapture
- cargo clippy -p genie-core -p genie-ctl --no-default-features --all-targets --locked -- -D warnings
- cargo run -p genie-ctl -- bfcl-import-ha-intents --source tests/bfcl/local/ha-intents --out tests/bfcl/local/ha_home_cases.jsonl --language en --limit 1000
- cargo run -p genie-ctl -- bfcl-predict-quick --cases tests/bfcl/local/ha_home_cases.jsonl --out tests/bfcl/local/ha_home_predictions.jsonl
- cargo run -p genie-ctl -- bfcl-score --cases tests/bfcl/local/ha_home_cases.jsonl --predictions tests/bfcl/local/ha_home_predictions.jsonl
- cargo run -p genie-ctl -- bfcl-import-ha-intents --source tests/bfcl/local/ha-intents --out tests/bfcl/local/ha_home_all_cases.jsonl --language all --limit 1200
- cargo run -p genie-ctl -- bfcl-predict-quick --cases tests/bfcl/local/ha_home_all_cases.jsonl --out tests/bfcl/local/ha_home_all_predictions.jsonl && cargo run -p genie-ctl -- bfcl-score --cases tests/bfcl/local/ha_home_all_cases.jsonl --predictions tests/bfcl/local/ha_home_all_predictions.jsonl