### PR TITLE
Release v1.0.0-alpha.10

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -74,7 +74,7 @@ body:
     id: version
     attributes:
       label: GenieClaw version / commit
-      placeholder: "v1.0.0-alpha.9 or commit SHA"
+      placeholder: "v1.0.0-alpha.10 or commit SHA"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/jetson_audio.yml
+++ b/.github/ISSUE_TEMPLATE/jetson_audio.yml
@@ -112,7 +112,7 @@ body:
     id: version
     attributes:
       label: GenieClaw version / commit
-      placeholder: "v1.0.0-alpha.9 or commit SHA"
+      placeholder: "v1.0.0-alpha.10 or commit SHA"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/voice_pipeline.yml
+++ b/.github/ISSUE_TEMPLATE/voice_pipeline.yml
@@ -115,7 +115,7 @@ body:
     id: version
     attributes:
       label: GenieClaw version / commit
-      placeholder: "v1.0.0-alpha.9 or commit SHA"
+      placeholder: "v1.0.0-alpha.10 or commit SHA"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- Nothing yet.
+
+## 1.0.0-alpha.10 - 2026-05-29
+
+Alpha 10 is the **Jetson-context harness + BFCL measurement** release. It
+keeps GenieClaw focused on the 4096-token NVIDIA Jetson Orin 8GB contract,
+records the current Home Assistant Intents BFCL quick-router baseline, and
+continues hardening local memory, tool routing, HTTP safety, and voice-facing
+runtime behavior.
+
+Current measured BFCL baseline for the Home Assistant Intents English import:
+208 cases, 208 generated quick-router predictions, 0 missing predictions, and
+5.77% strict tool-call accuracy. This is intentionally tracked as a baseline,
+not as a product-quality target; the next accuracy work is deterministic
+intent routing, entity/slot normalization, and typed-tool argument accuracy
+for high-signal home commands.
+
 - **CORS lockdown + local API token** (#228): the hand-rolled HTTP servers in
   both `genie-core` (`:3000`) and `genie-api` (`:3080`) previously answered
   every request with a wildcard `Access-Control-Allow-Origin: *` and did no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "genie-api"
-version = "1.0.0-alpha.9"
+version = "1.0.0-alpha.10"
 dependencies = [
  "anyhow",
  "genie-common",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "genie-common"
-version = "1.0.0-alpha.9"
+version = "1.0.0-alpha.10"
 dependencies = [
  "anyhow",
  "rustls",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "genie-core"
-version = "1.0.0-alpha.9"
+version = "1.0.0-alpha.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "genie-ctl"
-version = "1.0.0-alpha.9"
+version = "1.0.0-alpha.10"
 dependencies = [
  "anyhow",
  "genie-common",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "genie-governor"
-version = "1.0.0-alpha.9"
+version = "1.0.0-alpha.10"
 dependencies = [
  "anyhow",
  "genie-common",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "genie-health"
-version = "1.0.0-alpha.9"
+version = "1.0.0-alpha.10"
 dependencies = [
  "anyhow",
  "genie-common",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "genie-skill-sdk"
-version = "1.0.0-alpha.9"
+version = "1.0.0-alpha.10"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-alpha.9"
+version = "1.0.0-alpha.10"
 edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/GeniePod/genie-claw"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ first.
 - BFCL-style local tool-call scoring through `genie-ctl bfcl-score`
 - Jetson aarch64 cross-compile CI
 
-Current workspace version: `v1.0.0-alpha.9`.
+Current workspace version: `v1.0.0-alpha.10`.
 
 ## Current Focus
 

--- a/doc/implementation-status.md
+++ b/doc/implementation-status.md
@@ -24,7 +24,7 @@ Status labels:
 | Household memory | Implemented | `crates/genie-core/src/memory/*` | SQLite + FTS memory, local semantic recall, typed indexes for profiles, profile attributes such as shoe sizes, device aliases, rules, notes, media profiles, calendar events including lessons/medical/vet appointments, shopping-list items, pantry inventory, access permissions, chore/task logs including hygiene and pet-care checks, household schedules including school transport/sunset/community/business/channel-guide/subscription/TV/community-meeting hours, appliance/environment/location/presence/waste/access/finance/market/fitness/health/security/payment event logs, delivery/package, laundry, device-audit, device-health, school-task, guest-mode, safety-route, room-comfort, project-note, electrical-panel, trash-day, pest-history, homework-connectivity, plant-care, alarm-failure, gate-away, guest-device, end-of-day-summary, after-dinner cleanup, school/project form, filter, camera/privacy, guest-network, air-quality, garage-change, and final-safety-sweep recall, app-only sensitive references, contextual comfort/routine/safety/report semantic recall, extraction, recall, injection, decay, policy metadata, canonical markdown artifacts, namespace projection, dashboard edit/delete/reorder endpoints. |
 | Prompt and reasoning policy | Implemented | `crates/genie-core/src/prompt.rs`, `crates/genie-core/src/reasoning.rs` | Model-family prompt selection and no-think/think-mode application by interaction kind. |
 | Built-in tool dispatcher | Implemented | `crates/genie-core/src/tools/*` | Time, calculator, weather, system info, timers, memory tools, media hook, optional home tools, optional web search, quick router, policy checks, and audit logging. |
-| Tool-call evaluation | Implemented | `crates/genie-core/src/eval/bfcl.rs`, `tests/bfcl/*` | BFCL-style JSONL scoring for parsed tool names and JSON arguments. It is side-effect free and does not execute tools or require a live home backend. |
+| Tool-call evaluation | Implemented | `crates/genie-core/src/eval/bfcl.rs`, `crates/genie-ctl/src/bfcl_import.rs`, `tests/bfcl/*` | BFCL-style JSONL scoring for parsed tool names and JSON arguments, plus local Home Assistant Intents import and quick-router prediction generation. It is side-effect free and does not execute tools or require a live home backend. Current 2026-05-29 HA English quick-router baseline: 208 cases, 0 missing predictions, 5.77% strict accuracy. |
 | Web search tool | Implemented | `crates/genie-core/src/tools/web_search.rs` | No-key DuckDuckGo provider and optional SearXNG provider with cache and sensitive-query blocking. It is a lightweight search tool, not a full browser/research crawler. |
 | Home action safety in agent layer | Implemented | `crates/genie-core/src/tools/actuation.rs`, `crates/genie-core/src/ha/policy.rs` | Origin allowlist, target confidence thresholds, sensitive-action confirmation tokens, rate limits, action ledger, bounded undo, and append-only audit log. |
 | Runtime contract | Implemented | `crates/genie-core/src/runtime_contract.rs`, `crates/genie-core/src/server.rs` | Prompt/tool/policy/hydration fingerprints, optional drift detection, and boot contract log. |
@@ -68,7 +68,7 @@ Status labels:
 
 ## Current Alpha Truth
 
-The workspace version is currently `1.0.0-alpha.9`.
+The workspace version is currently `1.0.0-alpha.10`.
 
 The current alpha line defaults Jetson deployments to `genie-ai-runtime`,
 preserves the 4096-token agent harness, and treats optional remote/API providers

--- a/tests/bfcl/README.md
+++ b/tests/bfcl/README.md
@@ -44,6 +44,31 @@ cargo run -p genie-ctl -- bfcl-score \
   --predictions tests/bfcl/local/ha_home_predictions.jsonl
 ```
 
+## Current Progress Baseline
+
+Latest operator-reported local run on 2026-05-29:
+
+```text
+generated 208 BFCL cases from 475 Home Assistant Intents sentence templates
+generated 208 quick-router BFCL predictions
+tool calls: 35
+
+BFCL tool-call score
+cases:               208
+parse_accuracy:      16.83%
+tool_name_accuracy:  16.35%
+argument_accuracy:   5.77%
+strict_accuracy:     5.77%
+missing_predictions: 0
+failures:            196
+```
+
+Interpretation: the scorer/importer path is working, prediction coverage is
+complete, and the current deterministic quick-router baseline is intentionally
+low on the broader Home Assistant Intents suite. The next progress target is
+not larger prompts; it is improving deterministic intent routing, entity/slot
+normalization, and typed-tool argument accuracy for high-signal home commands.
+
 The fixture format is intentionally plain:
 
 - `home_tool_cases.jsonl`: one case per line with `id`, `prompt`,


### PR DESCRIPTION
## Summary

Release v1.0.0-alpha.10 for the Jetson-context harness and BFCL measurement baseline.

## Changes

- Bump workspace package version and lockfile packages to 1.0.0-alpha.10.
- Update README, implementation status, issue-template placeholders, and changelog for alpha.10.
- Record the current Home Assistant Intents BFCL quick-router baseline from the operator run.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Host profile: x86_64 Linux workspace host, not Jetson Orin.

- `cargo check -p genie-ctl`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p genie-core -p genie-ctl`
- `cargo clippy -p genie-core -p genie-ctl --all-targets --locked -- -D warnings`
- `cargo test -p genie-core -p genie-ctl --no-default-features bfcl -- --nocapture`
- `cargo clippy -p genie-core -p genie-ctl --no-default-features --all-targets --locked -- -D warnings`
- `cargo run -p genie-ctl -- version`
- `cargo audit`
- `cargo deny check`

### What I observed

- `cargo test -p genie-core -p genie-ctl` passed, including 652 genie-core unit tests, memory/tool/voice integration tests, and 35 genie-ctl tests.
- clippy passed for default and no-default feature paths.
- `genie-ctl version` printed `genie-ctl v1.0.0-alpha.10`.
- `cargo audit` and `cargo deny` are not installed on this host; GitHub CI audit/deny workflow must cover those checks.
- Jetson hardware was not available locally; required aarch64 CI should validate the cross-build before merge.
- Operator BFCL baseline recorded in docs: 208 HA English cases, 208 generated predictions, 0 missing predictions, 5.77% strict accuracy.

## Test plan

- Confirm CI passes, especially cargo test, no-default features, audit, and aarch64 release build.
- After merge, tag `v1.0.0-alpha.10` and publish the prerelease.

## Notes for reviewers

This release does not claim the HA BFCL score is product quality. It records the baseline so deterministic routing/entity normalization work has a measurable starting point.