### PR TITLE
fix(security): parse loopback host in validate_inference_route

### DIFF
--- a/crates/genie-core/src/security/sandbox.rs
+++ b/crates/genie-core/src/security/sandbox.rs
@@ -106,14 +106,14 @@ fn apply_landlock_linux(config_dir: &Path, data_dir: &Path) -> Result<(), String
 pub fn validate_inference_route(url: &str) -> Result<(), String> {
     let host = extract_host(url);
 
-    match host.as_str() {
-        "127.0.0.1" | "localhost" | "::1" | "[::1]" => Ok(()),
-        h if h.starts_with("127.") => Ok(()), // 127.0.0.0/8 loopback
-        _ => Err(format!(
+    if is_loopback_host(&host) {
+        Ok(())
+    } else {
+        Err(format!(
             "inference route rejected: {} is not localhost. \
              GeniePod only allows LLM calls to local endpoints.",
             url
-        )),
+        ))
     }
 }
 
@@ -227,14 +227,43 @@ fn find_secret_matches(text: &str, pattern: &SecretPattern) -> Vec<String> {
 }
 
 fn extract_host(url: &str) -> String {
+    let url = url.trim();
     let stripped = url
         .strip_prefix("http://")
         .or_else(|| url.strip_prefix("https://"))
         .unwrap_or(url);
 
-    let host_port = stripped.split('/').next().unwrap_or(stripped);
-    let host = host_port.split(':').next().unwrap_or(host_port);
-    host.to_lowercase()
+    let authority = stripped.split('/').next().unwrap_or(stripped);
+    let host_port = authority.rsplit('@').next().unwrap_or(authority);
+    let host = if let Some(rest) = host_port.strip_prefix('[') {
+        rest.find(']')
+            .map(|idx| host_port[..=idx + 1].to_string())
+            .unwrap_or_else(|| host_port.to_string())
+    } else {
+        host_port.split(':').next().unwrap_or(host_port).to_string()
+    };
+    host.to_ascii_lowercase()
+}
+
+/// True when `host` is a literal loopback target (not a hostname that merely
+/// starts with a loopback-looking prefix).
+fn is_loopback_host(host: &str) -> bool {
+    let host = host.trim();
+    if host.is_empty() {
+        return false;
+    }
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    let ip_str = host
+        .strip_prefix('[')
+        .and_then(|inner| inner.strip_suffix(']'))
+        .unwrap_or(host);
+    ip_str
+        .parse::<std::net::IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -246,6 +275,14 @@ mod tests {
         assert!(validate_inference_route("http://127.0.0.1:8080/v1").is_ok());
         assert!(validate_inference_route("http://localhost:8080").is_ok());
         assert!(validate_inference_route("http://127.0.0.2:8080").is_ok());
+        assert!(validate_inference_route("http://[::1]:8080/v1").is_ok());
+    }
+
+    #[test]
+    fn reject_loopback_looking_hostnames() {
+        assert!(validate_inference_route("http://127.evil.com:8080/v1").is_err());
+        assert!(validate_inference_route("http://127.0.0.1.attacker.com:8080/v1").is_err());
+        assert!(validate_inference_route("http://localhost.evil.com:8080/v1").is_err());
     }
 
     #[test]
@@ -325,6 +362,8 @@ mod tests {
         assert_eq!(extract_host("http://127.0.0.1:8080/v1"), "127.0.0.1");
         assert_eq!(extract_host("http://localhost:3000"), "localhost");
         assert_eq!(extract_host("https://api.openai.com/v1"), "api.openai.com");
+        assert_eq!(extract_host("http://[::1]:8080/v1"), "[::1]");
+        assert_eq!(extract_host("http://user@127.0.0.1:8080/v1"), "127.0.0.1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #320. `validate_inference_route()` used `host.starts_with("127.")`, so hostnames like `127.evil.com` and `127.0.0.1.attacker.com` passed as loopback. This PR parses the authority host and uses `IpAddr::is_loopback()` instead, and hardens `extract_host()` for IPv6 brackets and userinfo.

## Changes

- `crates/genie-core/src/security/sandbox.rs`: add `is_loopback_host()`; improve `extract_host()`; reject suffix-trick hostnames in tests.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] `CI-only / docs-only`
- [ ] `Not run locally`

### What I ran

Ubuntu x86_64 dev host, Rust stable from rustup. On branch `fix/validate-inference-route-host-prefix` at commit `35a3a2d`:

```bash
cd genie-claw
cargo test -p genie-core --lib sandbox
cargo fmt --check -p genie-core
cargo clippy -p genie-core -- -D warnings
```

### What I observed

12 sandbox tests passed, including new `reject_loopback_looking_hostnames` (`127.evil.com`, `127.0.0.1.attacker.com`, `localhost.evil.com` rejected) and `validate_localhost_routes` (`127.0.0.1`, `127.0.0.2`, `[::1]` still accepted). fmt and clippy clean.

## Test plan

1. `cargo test -p genie-core --lib sandbox`
2. `cargo fmt --check -p genie-core`
3. `cargo clippy -p genie-core -- -D warnings`

## Notes for reviewers

Complements #306 (wiring `validate_inference_route` at LLM client build). Orthogonal to #301 (SearXNG `is_local_base_url`).
