### PR TITLE
ci: limit contributors to two open PRs

### DIFF
--- a/.github/workflows/pr-limit.yml
+++ b/.github/workflows/pr-limit.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     env:
-      MAX_OPEN_PRS: "3"
+      MAX_OPEN_PRS: "2"
     steps:
       - name: Close PR when author has too many open PRs
         env:


### PR DESCRIPTION
## Summary

Lower the per-author open PR limit from 3 to 2.

This keeps review load bounded and forces contributors to keep only their highest-signal work open.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Workflow-only change. It does not affect Jetson runtime behavior.

Tested profile / hardware:

- [ ] jetson
- [ ] raspberry_pi
- [ ] portable_sbc
- [ ] laptop
- [ ] mac
- [x] CI-only / docs-only
- [ ] Not run locally

### What I ran

Reviewed the workflow diff locally.

### What I observed

The PR limit workflow will now close when an author has more than 2 open PRs.