### PR TITLE
fix(calc): parse unary minus as a grammar rule, not in the lexer

### DIFF
--- a/crates/genie-core/src/tools/calc.rs
+++ b/crates/genie-core/src/tools/calc.rs
@@ -16,11 +16,11 @@ pub fn evaluate(expr: &str) -> Result<f64, String> {
 
 /// Maximum nested parenthesis depth the parser will accept.
 ///
-/// The parser is recursive-descent: each `(` adds three stack frames
-/// (`parse_expr` → `parse_term` → `parse_factor`) before the recursion
-/// deepens again. Tokio's default worker thread has a 2 MiB stack, which
-/// empirically aborts somewhere around ~1500-3000 nested parens. 64 levels
-/// leaves a roughly 30x safety margin for the worst-case frame size while
+/// The parser is recursive-descent: each `(` adds four stack frames
+/// (`parse_expr` → `parse_term` → `parse_unary` → `parse_factor`) before the
+/// recursion deepens again. Tokio's default worker thread has a 2 MiB stack,
+/// which empirically aborts somewhere around ~1500-3000 nested parens. 64
+/// levels leaves a large safety margin for the worst-case frame size while
 /// still admitting any realistic arithmetic expression. The check exists so
 /// a hostile chat message (or LLM-forwarded prompt-injected expression) can
 /// never abort the daemon via stack overflow.
@@ -66,37 +66,11 @@ fn tokenize(input: &str) -> Result<Vec<Token>, String> {
                 chars.next();
             }
             '-' => {
-                // Handle unary minus.
-                if tokens.is_empty()
-                    || matches!(
-                        tokens.last(),
-                        Some(
-                            Token::Plus | Token::Minus | Token::Star | Token::Slash | Token::LParen
-                        )
-                    )
-                {
-                    chars.next();
-                    let mut num_str = String::from("-");
-                    while let Some(&c) = chars.peek() {
-                        if c.is_ascii_digit() || c == '.' {
-                            num_str.push(c);
-                            chars.next();
-                        } else {
-                            break;
-                        }
-                    }
-                    if num_str == "-" {
-                        tokens.push(Token::Minus);
-                    } else {
-                        let num: f64 = num_str
-                            .parse()
-                            .map_err(|_| format!("invalid number: {}", num_str))?;
-                        tokens.push(Token::Number(num));
-                    }
-                } else {
-                    tokens.push(Token::Minus);
-                    chars.next();
-                }
+                // Unary vs. binary `-` is decided by the grammar (`parse_unary`),
+                // not the lexer. The tokenizer stays context-free: it always
+                // emits a `Minus` and never glues the sign onto a number literal.
+                tokens.push(Token::Minus);
+                chars.next();
             }
             '*' => {
                 tokens.push(Token::Star);
@@ -142,19 +116,19 @@ fn parse_expr(tokens: &[Token], pos: &mut usize, depth: usize) -> Result<f64, St
     Ok(result)
 }
 
-// term → factor ((*|/) factor)*
+// term → unary ((*|/) unary)*
 fn parse_term(tokens: &[Token], pos: &mut usize, depth: usize) -> Result<f64, String> {
-    let mut result = parse_factor(tokens, pos, depth)?;
+    let mut result = parse_unary(tokens, pos, depth)?;
 
     while *pos < tokens.len() {
         match tokens[*pos] {
             Token::Star => {
                 *pos += 1;
-                result *= parse_factor(tokens, pos, depth)?;
+                result *= parse_unary(tokens, pos, depth)?;
             }
             Token::Slash => {
                 *pos += 1;
-                let divisor = parse_factor(tokens, pos, depth)?;
+                let divisor = parse_unary(tokens, pos, depth)?;
                 if divisor == 0.0 {
                     return Err("division by zero".to_string());
                 }
@@ -167,12 +141,39 @@ fn parse_term(tokens: &[Token], pos: &mut usize, depth: usize) -> Result<f64, St
     Ok(result)
 }
 
+// unary → ('+' | '-')* factor
+//
+// Prefix sign binds tighter than `*`/`/` and applies to any factor — a literal
+// OR a parenthesized expression — so `-(2 + 3)`, `3 * -(2)` and `--3` all parse.
+// The run of leading signs is consumed ITERATIVELY (folding parity into a single
+// `negate` bool), so a hostile chain like `-----…-1` cannot grow the call stack:
+// the only recursion is through `(` ... `)`, which `MAX_PAREN_DEPTH` already caps.
+fn parse_unary(tokens: &[Token], pos: &mut usize, depth: usize) -> Result<f64, String> {
+    let mut negate = false;
+    while *pos < tokens.len() {
+        match tokens[*pos] {
+            Token::Minus => {
+                negate = !negate;
+                *pos += 1;
+            }
+            Token::Plus => {
+                // Unary plus is a no-op (sign-preserving).
+                *pos += 1;
+            }
+            _ => break,
+        }
+    }
+
+    let value = parse_factor(tokens, pos, depth)?;
+    Ok(if negate { -value } else { value })
+}
+
 // factor → NUMBER | '(' expr ')'
 //
 // `depth` counts the number of unbalanced `(` already on the stack above
 // this call. Only `parse_factor` deepens the recursion (the `LParen` arm
-// below), so the cap is enforced here. `parse_expr` and `parse_term` pass
-// the same `depth` through unchanged.
+// below), so the cap is enforced here. `parse_expr`, `parse_term` and
+// `parse_unary` pass the same `depth` through unchanged.
 fn parse_factor(tokens: &[Token], pos: &mut usize, depth: usize) -> Result<f64, String> {
     if *pos >= tokens.len() {
         return Err("unexpected end of expression".to_string());
@@ -231,6 +232,58 @@ mod tests {
     fn negative_numbers() {
         assert_eq!(evaluate("-5 + 3").unwrap(), -2.0);
         assert_eq!(evaluate("10 + -3").unwrap(), 7.0);
+    }
+
+    /// Unary minus must negate a parenthesized group, not just a literal.
+    /// Pre-fix these all returned `Err("unexpected token: Minus")`.
+    #[test]
+    fn unary_minus_negates_parenthesized_group() {
+        assert_eq!(evaluate("-(2 + 3)").unwrap(), -5.0);
+        assert_eq!(evaluate("-(5)").unwrap(), -5.0);
+        assert_eq!(evaluate("-(2 + 3) * 2").unwrap(), -10.0);
+    }
+
+    /// Unary sign in a term position (after `*` / `/` / binary `-`).
+    #[test]
+    fn unary_minus_in_term_position() {
+        assert_eq!(evaluate("3 * -(2)").unwrap(), -6.0);
+        assert_eq!(evaluate("-2 * -3").unwrap(), 6.0);
+        assert_eq!(evaluate("2 - -3").unwrap(), 5.0);
+        assert_eq!(evaluate("2--3").unwrap(), 5.0);
+    }
+
+    /// Chained signs fold by parity: an even count is positive, odd is negative.
+    #[test]
+    fn chained_unary_signs() {
+        assert_eq!(evaluate("--3").unwrap(), 3.0);
+        assert_eq!(evaluate("---3").unwrap(), -3.0);
+        assert_eq!(evaluate("-+-3").unwrap(), 3.0);
+    }
+
+    /// The previously-working "signed literal" path must be unchanged.
+    #[test]
+    fn existing_negative_number_cases_unchanged() {
+        assert_eq!(evaluate("-5 + 3").unwrap(), -2.0);
+        assert_eq!(evaluate("10 + -3").unwrap(), 7.0);
+        assert_eq!(evaluate("2 * -3").unwrap(), -6.0);
+        assert_eq!(evaluate("3 * (-2)").unwrap(), -6.0);
+    }
+
+    /// A long run of leading signs must fold iteratively, NOT recurse — so it
+    /// cannot overflow the stack. 5000 minuses is even, so the result is +1.
+    /// Runs in a 2 MiB-stack thread to match Tokio's default worker.
+    #[test]
+    fn long_unary_run_does_not_overflow() {
+        let result = std::thread::Builder::new()
+            .stack_size(2 * 1024 * 1024)
+            .spawn(|| {
+                let expr = format!("{}1", "-".repeat(5000));
+                evaluate(&expr)
+            })
+            .expect("spawning a fixed-stack-size thread must succeed")
+            .join()
+            .expect("a long unary run must NOT abort the process");
+        assert_eq!(result.unwrap(), 1.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix unary minus so it negates any factor (including parenthesized groups), not
just bare literals. `-(2 + 3)` and friends previously returned
`Err("unexpected token: Minus")`. Split out of #312 to keep that PR focused on
memory recall.

## Changes

- Move unary `+`/`-` handling out of the tokenizer and into a new `parse_unary`
  grammar rule sitting between `parse_term` and `parse_factor`.
- The lexer is now context-free: `-` always emits a `Token::Minus` and never
  glues a sign onto a number literal.
- `parse_unary` folds a run of leading signs by parity *iteratively*, so a
  hostile `-----…-1` chain can't grow the call stack — only `(` recurses, which
  `MAX_PAREN_DEPTH` already caps. Updated the depth-cap doc comment to reflect
  the extra frame per `(`.
- Added regression tests for parenthesized negation, term-position signs,
  chained signs, unchanged signed-literal cases, and a 5000-sign no-overflow
  test on a 2 MiB stack.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Ubuntu 22.04, x86_64 (laptop profile):

cargo test -p genie-core --lib tools::calc



### What I observed

running 17 tests
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 628 filtered out



Including the new cases: `unary_minus_negates_parenthesized_group`,
`unary_minus_in_term_position`, `chained_unary_signs`,
`existing_negative_number_cases_unchanged`, and `long_unary_run_does_not_overflow`.

This change is pure arithmetic-parser logic with no voice/audio/Home Assistant/
dashboard surface, so the Jetson gap carries no runtime-specific risk — behavior
is identical across profiles. The stack-overflow safety test pins a 2 MiB stack
to match Tokio's default worker thread.

## Test plan

- `cargo test -p genie-core --lib tools::calc`
- Manually: evaluate `-(2 + 3)`, `3 * -(2)`, `--3`, `-+-3` — all should succeed.

## Notes for reviewers

- Split out of #312 (memory recall) per the request to keep PRs to one behavior
  surface.
- No behavior change to the existing signed-literal path; only previously-failing
  `-(...)` expressions now evaluate.