### PR TITLE
fix(audit): surface IO failures in AuditLogger and ToolAuditLogger (closes #131)

### DIFF
--- a/crates/genie-core/src/tools/actuation.rs
+++ b/crates/genie-core/src/tools/actuation.rs
@@ -304,6 +304,58 @@ pub struct AuditEvent {
     pub undo_of: Option<u64>,
 }
 
+/// A failure while appending one JSON line to an audit log, tagged by the step
+/// that failed. Kept narrow (one variant per IO step) so structured-log filters
+/// and future metric labels can tell a disk-full `Write` apart from a
+/// permission-denied `Open`.
+#[derive(Debug)]
+pub enum AuditError {
+    CreateDir(std::io::Error),
+    Open(std::io::Error),
+    Serialize(serde_json::Error),
+    Write(std::io::Error),
+}
+
+impl std::fmt::Display for AuditError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CreateDir(e) => write!(f, "audit log: create parent directory: {e}"),
+            Self::Open(e) => write!(f, "audit log: open file for append: {e}"),
+            Self::Serialize(e) => write!(f, "audit log: serialize event: {e}"),
+            Self::Write(e) => write!(f, "audit log: write line: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for AuditError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CreateDir(e) | Self::Open(e) | Self::Write(e) => Some(e),
+            Self::Serialize(e) => Some(e),
+        }
+    }
+}
+
+/// Append one `\n`-terminated JSON record to a JSONL file, creating the parent
+/// directory and the file if needed. Shared by both audit loggers so the IO
+/// path and its failure handling live in one tested place. Callers hold their
+/// own serialization lock across this call.
+pub(crate) fn append_json_line<T: Serialize>(path: &Path, payload: &T) -> Result<(), AuditError> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).map_err(AuditError::CreateDir)?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(AuditError::Open)?;
+    let line = serde_json::to_string(payload).map_err(AuditError::Serialize)?;
+    writeln!(file, "{line}").map_err(AuditError::Write)?;
+    Ok(())
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct AuditLogger {
     path: Option<PathBuf>,
@@ -322,21 +374,28 @@ impl AuditLogger {
         }
     }
 
-    pub fn append(&self, event: AuditEvent) {
+    /// Append an audit event. Returns `Ok(())` for a disabled logger (no path)
+    /// and surfaces the failing IO step otherwise, so a security-critical caller
+    /// can adopt a "no audit, no action" posture if it chooses.
+    pub fn append(&self, event: AuditEvent) -> Result<(), AuditError> {
         let Some(path) = &self.path else {
-            return;
+            return Ok(());
         };
         let _guard = self.lock.lock().expect("audit logger lock");
-        if let Some(parent) = path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+        append_json_line(path, &event)
+    }
+
+    /// Log-and-continue wrapper: append and, on failure, emit a `tracing::error!`
+    /// with the path and underlying error rather than silently dropping the
+    /// event. This is the default posture for the existing call sites.
+    pub fn append_or_log(&self, event: AuditEvent) {
+        if let Err(err) = self.append(event) {
+            tracing::error!(
+                path = ?self.path,
+                error = %err,
+                "audit event dropped due to IO failure"
+            );
         }
-        let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) else {
-            return;
-        };
-        let Ok(line) = serde_json::to_string(&event) else {
-            return;
-        };
-        let _ = writeln!(file, "{line}");
     }
 
     pub fn path(&self) -> Option<&Path> {
@@ -700,6 +759,73 @@ mod tests {
         assert_eq!(next.id, 12);
     }
 
+    fn sample_event(ts_ms: u64) -> AuditEvent {
+        AuditEvent {
+            ts_ms,
+            status: AuditStatus::Executed,
+            origin: RequestOrigin::Voice,
+            entity: "kitchen light".into(),
+            action: "turn_on".into(),
+            value: None,
+            reason: "home action executed".into(),
+            token: None,
+            confidence: Some(0.9),
+            action_id: Some(1),
+            undo_of: None,
+        }
+    }
+
+    #[test]
+    fn append_returns_ok_when_logger_is_disabled() {
+        let logger = AuditLogger::disabled();
+        assert!(logger.append(sample_event(1)).is_ok());
+    }
+
+    #[test]
+    fn append_writes_jsonl_line_with_event_fields() {
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-actuation-audit-write-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let logger = AuditLogger::new(&path);
+
+        logger
+            .append(sample_event(42))
+            .expect("append should succeed");
+
+        let line = std::fs::read_to_string(&path).unwrap();
+        let event: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(event["ts_ms"], 42);
+        assert_eq!(event["status"], "executed");
+        assert_eq!(event["entity"], "kitchen light");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn append_surfaces_io_error_when_parent_path_is_a_file() {
+        // Put a regular file where the audit log's parent directory should be.
+        // create_dir_all then fails deterministically on both Unix and Windows,
+        // so the append surfaces an AuditError instead of silently no-op'ing.
+        let blocker = std::env::temp_dir().join(format!(
+            "geniepod-actuation-audit-blocker-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&blocker);
+        std::fs::write(&blocker, b"not a directory").unwrap();
+        let path = blocker.join("actuation.jsonl");
+        let logger = AuditLogger::new(&path);
+
+        let err = logger
+            .append(sample_event(1))
+            .expect_err("append must fail");
+        assert!(matches!(
+            err,
+            AuditError::CreateDir(_) | AuditError::Open(_)
+        ));
+        let _ = std::fs::remove_file(&blocker);
+    }
+
     #[test]
     fn audit_logger_reads_recent_executed_actions_from_log_tail() {
         let path = std::env::temp_dir().join(format!(
@@ -710,23 +836,25 @@ mod tests {
         let logger = AuditLogger::new(&path);
 
         for idx in 0..500 {
-            logger.append(AuditEvent {
-                ts_ms: idx,
-                status: if idx % 2 == 0 {
-                    AuditStatus::Executed
-                } else {
-                    AuditStatus::ConfirmationIssued
-                },
-                origin: RequestOrigin::Voice,
-                entity: format!("entity-{idx}"),
-                action: "turn_on".into(),
-                value: None,
-                reason: "home action executed".into(),
-                token: None,
-                confidence: None,
-                action_id: if idx % 2 == 0 { Some(idx) } else { None },
-                undo_of: None,
-            });
+            logger
+                .append(AuditEvent {
+                    ts_ms: idx,
+                    status: if idx % 2 == 0 {
+                        AuditStatus::Executed
+                    } else {
+                        AuditStatus::ConfirmationIssued
+                    },
+                    origin: RequestOrigin::Voice,
+                    entity: format!("entity-{idx}"),
+                    action: "turn_on".into(),
+                    value: None,
+                    reason: "home action executed".into(),
+                    token: None,
+                    confidence: None,
+                    action_id: if idx % 2 == 0 { Some(idx) } else { None },
+                    undo_of: None,
+                })
+                .expect("append audit event");
         }
 
         let actions = logger.read_recent_executed_actions(3);
@@ -746,32 +874,36 @@ mod tests {
         let _ = std::fs::remove_file(&path);
         let logger = AuditLogger::new(&path);
 
-        logger.append(AuditEvent {
-            ts_ms: 100,
-            status: AuditStatus::Executed,
-            origin: RequestOrigin::Voice,
-            entity: "kitchen light".into(),
-            action: "turn_on".into(),
-            value: None,
-            reason: "home action executed".into(),
-            token: None,
-            confidence: Some(0.9),
-            action_id: Some(1),
-            undo_of: None,
-        });
-        logger.append(AuditEvent {
-            ts_ms: 200,
-            status: AuditStatus::ConfirmationIssued,
-            origin: RequestOrigin::Voice,
-            entity: "front door".into(),
-            action: "unlock".into(),
-            value: None,
-            reason: "needs confirmation".into(),
-            token: Some("act-test".into()),
-            confidence: None,
-            action_id: None,
-            undo_of: None,
-        });
+        logger
+            .append(AuditEvent {
+                ts_ms: 100,
+                status: AuditStatus::Executed,
+                origin: RequestOrigin::Voice,
+                entity: "kitchen light".into(),
+                action: "turn_on".into(),
+                value: None,
+                reason: "home action executed".into(),
+                token: None,
+                confidence: Some(0.9),
+                action_id: Some(1),
+                undo_of: None,
+            })
+            .expect("append executed event");
+        logger
+            .append(AuditEvent {
+                ts_ms: 200,
+                status: AuditStatus::ConfirmationIssued,
+                origin: RequestOrigin::Voice,
+                entity: "front door".into(),
+                action: "unlock".into(),
+                value: None,
+                reason: "needs confirmation".into(),
+                token: Some("act-test".into()),
+                confidence: None,
+                action_id: None,
+                undo_of: None,
+            })
+            .expect("append confirmation event");
 
         let actions = logger.read_recent_executed_actions(10);
         assert_eq!(actions.len(), 1);

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -4,15 +4,13 @@ use genie_common::config::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use super::actuation::{
-    ActionLedger, AuditEvent, AuditLogger, AuditStatus, ConfirmationManager, PendingConfirmation,
-    RecordedAction, RequestOrigin, now_ms,
+    ActionLedger, AuditError, AuditEvent, AuditLogger, AuditStatus, ConfirmationManager,
+    PendingConfirmation, RecordedAction, RequestOrigin, append_json_line, now_ms,
 };
 use super::home;
 use super::timer;
@@ -135,21 +133,22 @@ impl ToolAuditLogger {
         }
     }
 
-    fn append(&self, event: ToolAuditEvent) {
+    fn append(&self, event: ToolAuditEvent) -> Result<(), AuditError> {
         let Some(path) = &self.path else {
-            return;
+            return Ok(());
         };
         let _guard = self.lock.lock().expect("tool audit logger lock");
-        if let Some(parent) = path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+        append_json_line(path, &event)
+    }
+
+    fn append_or_log(&self, event: ToolAuditEvent) {
+        if let Err(err) = self.append(event) {
+            tracing::error!(
+                path = ?self.path,
+                error = %err,
+                "tool audit event dropped due to IO failure"
+            );
         }
-        let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) else {
-            return;
-        };
-        let Ok(line) = serde_json::to_string(&event) else {
-            return;
-        };
-        let _ = writeln!(file, "{line}");
     }
 
     fn path(&self) -> Option<&std::path::Path> {
@@ -587,7 +586,7 @@ impl ToolDispatcher {
         started: Instant,
         result: &ToolResult,
     ) {
-        self.tool_audit_logger.append(ToolAuditEvent {
+        self.tool_audit_logger.append_or_log(ToolAuditEvent {
             ts_ms: now_ms(),
             tool: call.name.clone(),
             action_class: result.action_class,
@@ -629,7 +628,7 @@ impl ToolDispatcher {
                 "actuation from '{}' is not allowed by channel policy",
                 exec_ctx.request_origin.as_policy_key()
             );
-            self.audit_logger.append(AuditEvent {
+            self.audit_logger.append_or_log(AuditEvent {
                 ts_ms: now_ms(),
                 status: AuditStatus::BlockedPolicy,
                 origin: exec_ctx.request_origin,
@@ -654,7 +653,7 @@ impl ToolDispatcher {
                 .check_and_record(&self.actuation_safety, exec_ctx.request_origin)
         {
             let reason = err.to_string();
-            self.audit_logger.append(AuditEvent {
+            self.audit_logger.append_or_log(AuditEvent {
                 ts_ms: now_ms(),
                 status: AuditStatus::BlockedRuntime,
                 origin: exec_ctx.request_origin,
@@ -701,7 +700,7 @@ impl ToolDispatcher {
                         confidence,
                     )
                 };
-                self.audit_logger.append(AuditEvent {
+                self.audit_logger.append_or_log(AuditEvent {
                     ts_ms: now_ms(),
                     status: AuditStatus::Executed,
                     origin: exec_ctx.request_origin,
@@ -728,7 +727,7 @@ impl ToolDispatcher {
                         "Too many pending home confirmations; confirm or wait for existing ones to expire before requesting another.".into(),
                     );
                 };
-                self.audit_logger.append(AuditEvent {
+                self.audit_logger.append_or_log(AuditEvent {
                     ts_ms: now_ms(),
                     status: AuditStatus::ConfirmationIssued,
                     origin: exec_ctx.request_origin,
@@ -761,7 +760,7 @@ impl ToolDispatcher {
                 } else {
                     AuditStatus::Failed
                 };
-                self.audit_logger.append(AuditEvent {
+                self.audit_logger.append_or_log(AuditEvent {
                     ts_ms: now_ms(),
                     status,
                     origin: exec_ctx.request_origin,
@@ -2094,6 +2093,50 @@ mod tests {
         assert!(!line.contains("secret-token-value"));
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn tool_audit_logger_disabled_appends_ok() {
+        let logger = ToolAuditLogger::default();
+        let event = ToolAuditEvent {
+            ts_ms: now_ms(),
+            tool: "calculate".into(),
+            action_class: ToolActionClass::ReadOnly,
+            origin: RequestOrigin::Api,
+            success: true,
+            duration_ms: 1,
+            argument_keys: vec!["expression".into()],
+            output_chars: 3,
+        };
+        assert!(logger.append(event).is_ok());
+    }
+
+    #[test]
+    fn tool_audit_logger_surfaces_blocked_parent_error() {
+        let blocker = std::env::temp_dir().join(format!(
+            "geniepod-tool-audit-blocker-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&blocker);
+        std::fs::write(&blocker, b"not a directory").unwrap();
+        let logger = ToolAuditLogger::new(blocker.join("tool-audit.jsonl"));
+
+        let event = ToolAuditEvent {
+            ts_ms: now_ms(),
+            tool: "calculate".into(),
+            action_class: ToolActionClass::ReadOnly,
+            origin: RequestOrigin::Api,
+            success: true,
+            duration_ms: 1,
+            argument_keys: vec!["expression".into()],
+            output_chars: 3,
+        };
+        let err = logger.append(event).expect_err("append must fail");
+        assert!(matches!(
+            err,
+            AuditError::CreateDir(_) | AuditError::Open(_)
+        ));
+        let _ = std::fs::remove_file(&blocker);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #131. `AuditLogger::append` (`crates/genie-core/src/tools/actuation.rs`) and `ToolAuditLogger::append` (`crates/genie-core/src/tools/dispatch.rs`) returned `()` and silently swallowed four IO failure modes each — `create_dir_all`, `open`, `serde_json::to_string`, and `writeln!`. A disk-full or permission-denied condition left both audit files permanently empty with no log line, no metric, and no return signal. Replay/undo logic that reads the audit tail (`read_recent_executed_actions`) then silently degraded to "no recent actions", defeating the log's forensic purpose.

Both methods now return `Result<(), AuditError>`. The existing call sites use a new `append_or_log` wrapper that preserves today's log-and-continue behaviour while emitting a `tracing::error!` on failure, so the bare `append` stays available for a future "no audit, no action" caller (#24).

## Changes

- **`crates/genie-core/src/tools/actuation.rs`**
  - Add `pub enum AuditError { CreateDir(io::Error), Open(io::Error), Serialize(serde_json::Error), Write(io::Error) }` with `Display` + `std::error::Error` impls. Variants are deliberately one-per-step so structured-log filters can tell a disk-full `Write` apart from a permission-denied `Open`.
  - Extract `pub(crate) fn append_json_line<T: Serialize>(path, payload) -> Result<(), AuditError>` so both loggers share one tested IO path.
  - `AuditLogger::append` now returns `Result<(), AuditError>` (a disabled logger still returns `Ok(())` without doing IO). Add `append_or_log`, which logs the path + underlying error on failure and continues.
- **`crates/genie-core/src/tools/dispatch.rs`**
  - `ToolAuditLogger::append` uses the shared helper and returns `Result<(), AuditError>`; add a matching `append_or_log`.
  - Convert the six fire-and-forget call sites (one tool-audit, five actuation-audit) to `append_or_log`, preserving the prior happy-path behaviour while making failures visible in `journalctl -u genie-core`.
  - Drop the now-unused `std::fs::OpenOptions` / `std::io::Write` imports.
- **Tests** — actuation: disabled-logger `Ok` path, JSONL round-trip with field assertions, and a cross-platform IO-failure test (a regular file at the parent path forces `CreateDir`/`Open` on both Unix and Windows). dispatch: disabled tool-logger `Ok` path and the same blocked-parent surfacing test.

No new dependencies. A metrics counter (`audit_writes_failed_total`) is a natural follow-up once the workspace has metrics infrastructure — deliberately out of scope here.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

No Jetson available. `genie-core` pulls in Unix-only APIs (`tokio::net::UnixStream`, `tokio::signal::unix`), so I built and tested inside WSL2 Ubuntu (x86_64, Rust/cargo 1.95.0 matching the repo toolchain) against the same on-disk worktree. The changed paths are pure file-IO/error-handling — no ALSA, Home Assistant, or voice hardware involved — and are covered by the unit tests below; the aarch64 cross-compile CI job confirms they build for the Jetson target.

```
$ cargo fmt --all -- --check
# clean, no diff

$ cargo clippy -p genie-core --all-targets --locked -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 05s
# 0 warnings

$ cargo clippy -p genie-core -p genie-ctl --no-default-features --all-targets --locked -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 40.09s
# 0 warnings

$ cargo test -p genie-core --locked --lib tools::actuation::tests
running 15 tests
test tools::actuation::tests::append_returns_ok_when_logger_is_disabled ... ok
test tools::actuation::tests::append_writes_jsonl_line_with_event_fields ... ok
test tools::actuation::tests::append_surfaces_io_error_when_parent_path_is_a_file ... ok
test tools::actuation::tests::audit_logger_reads_recent_executed_actions ... ok
test tools::actuation::tests::audit_logger_reads_recent_executed_actions_from_log_tail ... ok
... (15 total)
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 653 filtered out

$ cargo test -p genie-core --locked --lib tools::dispatch::tests::tool_audit
running 3 tests
test tools::dispatch::tests::tool_audit_logger_disabled_appends_ok ... ok
test tools::dispatch::tests::tool_audit_logger_surfaces_blocked_parent_error ... ok
test tools::dispatch::tests::tool_audit_records_origin_and_argument_keys_without_values ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 665 filtered out

$ cargo test -p genie-core --locked --lib
test result: ok. 668 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### What I observed

- `append_surfaces_io_error_when_parent_path_is_a_file` and `tool_audit_logger_surfaces_blocked_parent_error`: with a regular file occupying the parent path, both loggers now return `Err(AuditError::CreateDir | AuditError::Open)` instead of silently no-op'ing — the exact silent-discard the issue describes is now observable.
- `append_writes_jsonl_line_with_event_fields`: a successful append writes one JSONL line whose `ts_ms` / `status` / `entity` fields round-trip, confirming the happy path is unchanged.
- `append_returns_ok_when_logger_is_disabled` / `tool_audit_logger_disabled_appends_ok`: a disabled logger still returns `Ok(())` and does no IO.
- All 668 `genie-core` lib tests pass, so converting the six dispatch call sites to `append_or_log` didn't regress any existing behaviour. Clippy is clean under `-D warnings` for both the full and `--no-default-features` builds.

## Test plan

- [ ] CI green: `cargo fmt`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked --all-targets`, the `--no-default-features` job, and the aarch64 cross-compile.
- [ ] Re-verify locally: `cargo test -p genie-core --locked --lib tools::actuation::tests` and `... tools::dispatch::tests::tool_audit`.
- [ ] Optional Jetson check: point `[actuation].audit_path` at a read-only directory (`sudo install -d -m 0555 /var/lib/geniepod/audit-ro`, set `audit_path = "/var/lib/geniepod/audit-ro/actuation.jsonl"`), issue any actuation, and confirm `journalctl -u genie-core` now shows `audit event dropped due to IO failure` while the actuation itself still completes (log-and-continue preserved).

## Notes for reviewers

- `pub enum AuditError` is the only new public API surface; `append_json_line` is `pub(crate)` (a dedup helper between the two loggers in the same crate).
- I left the failure posture as log-and-continue at every existing call site — none of them currently depend on the audit write succeeding. The bare `append` returning `Result` is what lets a future evidence-trail caller (#24) adopt "no audit, no action"; easy to flip any specific site to that posture if you'd prefer.