### PR TITLE
fix(tools): reject invalid home_control arguments at dispatch

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -21,6 +21,42 @@ use crate::skills::SkillLoader;
 
 const ACTUATION_RATE_WINDOW_MS: u64 = 60_000;
 
+const HOME_CONTROL_ACTIONS: &[&str] = &[
+    "turn_on",
+    "turn_off",
+    "toggle",
+    "set_brightness",
+    "set_temperature",
+    "open",
+    "close",
+    "lock",
+    "unlock",
+    "activate",
+];
+
+fn parse_home_control_args(args: &serde_json::Value) -> Result<(&str, &str, Option<f64>)> {
+    let entity = args
+        .get("entity")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!("home_control requires non-empty string argument 'entity'")
+        })?;
+    let action = args
+        .get("action")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("home_control requires string argument 'action'"))?;
+    if !HOME_CONTROL_ACTIONS.contains(&action) {
+        anyhow::bail!(
+            "home_control action '{}' is invalid; expected one of: {}",
+            action,
+            HOME_CONTROL_ACTIONS.join(", ")
+        );
+    }
+    Ok((entity, action, args.get("value").and_then(|v| v.as_f64())))
+}
+
 /// Tool definition for LLM function calling.
 ///
 /// These are sent to the configured LLM backend as part of the system prompt or
@@ -617,13 +653,8 @@ impl ToolDispatcher {
             .ha
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Home Assistant not connected"))?;
-        let entity_name = args.get("entity").and_then(|v| v.as_str()).unwrap_or("");
+        let (entity_name, action, value) = parse_home_control_args(args)?;
         let resolved_entity = self.resolve_device_alias(entity_name);
-        let action = args
-            .get("action")
-            .and_then(|v| v.as_str())
-            .unwrap_or("toggle");
-        let value = args.get("value").and_then(|v| v.as_f64());
         if !actuation_origin_allowed(&self.actuation_safety, exec_ctx.request_origin) {
             let reason = format!(
                 "actuation from '{}' is not allowed by channel policy",

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -460,3 +460,78 @@ async fn tool_gate_audit_logs_are_append_only_and_record_all_dispatches() {
         "one executed plus one blocked_runtime home_control event"
     );
 }
+
+#[tokio::test]
+async fn home_control_rejects_invalid_arguments_and_audits() {
+    let paths = TestAuditPaths::new();
+    let executed = Arc::new(Mutex::new(Vec::new()));
+    let dispatcher = paths.dispatcher(
+        Some(Arc::new(FakeHomeProvider::light(executed.clone()))),
+        ToolPolicyConfig::default(),
+        ActuationSafetyConfig::default(),
+    );
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Dashboard,
+        ..ToolExecutionContext::default()
+    };
+
+    let invalid_calls = [
+        (
+            serde_json::json!({}),
+            "home_control requires non-empty string argument 'entity'",
+        ),
+        (
+            serde_json::json!({"entity": "", "action": "turn_on"}),
+            "home_control requires non-empty string argument 'entity'",
+        ),
+        (
+            serde_json::json!({"entity": "kitchen light", "action": "turnn_on"}),
+            "home_control action 'turnn_on' is invalid",
+        ),
+        (
+            serde_json::json!({"entity": "kitchen light"}),
+            "home_control requires string argument 'action'",
+        ),
+    ];
+    let expected_audit_count = invalid_calls.len();
+
+    for (arguments, expected_snippet) in &invalid_calls {
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "home_control".into(),
+                    arguments: arguments.clone(),
+                },
+                ctx,
+            )
+            .await;
+
+        assert!(
+            !result.success,
+            "expected schema rejection, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains(expected_snippet),
+            "expected output to contain {expected_snippet:?}, got: {}",
+            result.output
+        );
+    }
+
+    assert!(
+        executed.lock().unwrap().is_empty(),
+        "invalid home_control calls must not reach the home provider"
+    );
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(
+        events.len(),
+        expected_audit_count,
+        "each rejected call must be tool-audited"
+    );
+    for event in &events {
+        assert_eq!(event["tool"], "home_control");
+        assert_eq!(event["origin"], "dashboard");
+        assert_eq!(event["success"], false);
+    }
+}


### PR DESCRIPTION
Fixes #330

## Summary

`home_control` advertised required `entity`/`action` fields and an action enum in `ToolDef`, but execution silently defaulted missing values to `""` and `"toggle"`. This PR validates arguments at the dispatch boundary before any Home Assistant call, returning a clear tool error and audit entry instead of mis-actuating.

## Changes

- Add `parse_home_control_args()` in `dispatch.rs` to require a non-empty `entity`, a present `action`, and membership in the runtime action enum.
- Call the validator from `exec_home_control_inner` before alias resolution and actuation.
- Add `home_control_rejects_invalid_arguments_and_audits` integration test covering `{}`, empty entity, typo action, and missing action — asserts no fake-home side effects and tool audit entries with `success: false`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On x86_64 Linux dev host (`laptop` profile), branch `fix/issue-330-home-control-schema-validation`:

```bash
cd genie-claw
cargo fmt -p genie-core
cargo test -p genie-core home_control_rejects_invalid_arguments --test tool_gate_integration_test
cargo test -p genie-core --test tool_gate_integration_test
cargo clippy -p genie-core -- -D warnings
```

### What I observed

- `home_control_rejects_invalid_arguments_and_audits` passed — invalid payloads return `success: false` with schema error messages; `FakeHomeProvider` executed list stays empty; four tool audit lines recorded with `tool: home_control`, `origin: dashboard`, `success: false`.
- Full `cargo test -p genie-core --test tool_gate_integration_test`: 6 passed, 0 failed.
- `cargo clippy -p genie-core -- -D warnings`: clean.

Jetson validation gap: repro uses fake-home integration tests only; no Orin Nano hardware run for this dispatch-path change. Behavior is schema validation before HA — equivalent to existing `tool_gate_integration_test` coverage.

## Test plan

- [x] `cargo test -p genie-core home_control_rejects_invalid_arguments --test tool_gate_integration_test`
- [x] `cargo test -p genie-core --test tool_gate_integration_test`
- [x] `cargo clippy -p genie-core -- -D warnings`

## Notes for reviewers

M1 typed-tool reliability fix for #330. Scope is `home_control` only; `home_status` empty-entity default and `set_timer` defaults are unchanged. No prompt or BFCL fixture changes.
