### PR TITLE
docs: clarify active M1 contribution gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ Everything else is noise until the local home agent is fast, accurate, and
 measurable under the Jetson 4096-token constraint. Routing, memory retrieval,
 typed tools, BFCL score, and Jetson behavior are the work.
 
+## Active Contribution Gate
+
+GenieClaw is not optimizing for broad user deployment yet. The current work is
+to make the agent materially faster, more accurate, and more reliable inside
+the Jetson 4096-token home-agent harness.
+
+Generic bug-fix PRs, cleanup PRs, broad refactors, dashboard polish, provider
+churn, and speculative feature work are not welcome unless they directly move
+the M1 scorecard: BFCL tool-call accuracy, deterministic family/home memory,
+typed-tool reliability, compact prompt assembly, or Jetson-native runtime
+behavior. A fix that is technically correct but outside that path is still
+noise for this phase.
+
+Valuable contributions are the ones that help this repository become what it is
+intended to be: a private, local, deterministic household agent that can run
+well on NVIDIA Jetson Orin 8GB hardware. Spam-like PRs, AI-generated issue
+churn, duplicate reports, unplanned bug-fix batches, or changes without real
+behavior proof will be closed immediately to protect review quality.
+
 ## Product Quality Bar
 
 PRs must improve the product behavior or make it easier to measure product


### PR DESCRIPTION
## Summary

Clarifies that GenieClaw is currently optimizing the M1 Jetson 4096-token home-agent harness, not broad user deployment or generic bug-fix intake.

## Changes

- Add an Active Contribution Gate section to the main README.
- State that accepted contributions must directly move BFCL/tool-call accuracy, deterministic home memory/device state, compact prompt assembly, or Jetson-native reliability.
- Make clear that spam-like, duplicate, unplanned, or unproven PRs will be closed to protect review quality.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [ ] `laptop`
- [ ] `mac`
- [x] CI-only / docs-only
- [ ] Not run locally

### What I ran

- `cargo fmt --check`

### What I observed

- Formatting check passed. This is a docs-only README policy change; Jetson runtime validation is not applicable.

## Test plan

- Review README wording for M1 contribution scope and closure policy.

## Notes for reviewers

- This codifies current maintainer policy for issue and PR triage.