### PR TITLE
fix(tools): validate home_status entity at execution boundary

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -57,6 +57,14 @@ fn parse_home_control_args(args: &serde_json::Value) -> Result<(&str, &str, Opti
     Ok((entity, action, args.get("value").and_then(|v| v.as_f64())))
 }
 
+fn parse_home_status_args(args: &serde_json::Value) -> Result<&str> {
+    args.get("entity")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("home_status requires non-empty string argument 'entity'"))
+}
+
 /// Tool definition for LLM function calling.
 ///
 /// These are sent to the configured LLM backend as part of the system prompt or
@@ -912,7 +920,7 @@ impl ToolDispatcher {
             .ha
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Home Assistant not connected"))?;
-        let entity_name = args.get("entity").and_then(|v| v.as_str()).unwrap_or("");
+        let entity_name = parse_home_status_args(args)?;
         let entity_name = self.resolve_device_alias(entity_name);
 
         home::status(ha.as_ref(), &entity_name).await

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -535,3 +535,70 @@ async fn home_control_rejects_invalid_arguments_and_audits() {
         assert_eq!(event["success"], false);
     }
 }
+
+#[tokio::test]
+async fn home_status_rejects_invalid_arguments_and_audits() {
+    let paths = TestAuditPaths::new();
+    let dispatcher = paths.dispatcher(
+        Some(Arc::new(FakeHomeProvider::light(Arc::new(Mutex::new(
+            Vec::new(),
+        ))))),
+        ToolPolicyConfig::default(),
+        ActuationSafetyConfig::default(),
+    );
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Dashboard,
+        ..ToolExecutionContext::default()
+    };
+
+    let invalid_calls = [
+        (
+            serde_json::json!({}),
+            "home_status requires non-empty string argument 'entity'",
+        ),
+        (
+            serde_json::json!({"entity": ""}),
+            "home_status requires non-empty string argument 'entity'",
+        ),
+        (
+            serde_json::json!({"entity": 123}),
+            "home_status requires non-empty string argument 'entity'",
+        ),
+    ];
+    let expected_audit_count = invalid_calls.len();
+
+    for (arguments, expected_snippet) in &invalid_calls {
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "home_status".into(),
+                    arguments: arguments.clone(),
+                },
+                ctx,
+            )
+            .await;
+
+        assert!(
+            !result.success,
+            "expected schema rejection, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains(expected_snippet),
+            "expected output to contain {expected_snippet:?}, got: {}",
+            result.output
+        );
+    }
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(
+        events.len(),
+        expected_audit_count,
+        "each rejected call must be tool-audited"
+    );
+    for event in &events {
+        assert_eq!(event["tool"], "home_status");
+        assert_eq!(event["origin"], "dashboard");
+        assert_eq!(event["success"], false);
+    }
+}


### PR DESCRIPTION
Fixes #344

## Summary

`home_status` marked `entity` as required in `ToolDef` but `exec_home_status` silently defaulted missing/invalid values to `""`. This PR adds `parse_home_status_args()` (matching the #330 `home_control` pattern) and rejects invalid calls with tool audit entries before any Home Assistant lookup.

## Changes

- Add `parse_home_status_args()` with non-empty string `entity` validation.
- Use parser in `exec_home_status()`.
- Add `home_status_rejects_invalid_arguments_and_audits` integration test.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On x86_64 Linux dev host (`laptop` profile), branch `fix/issue-344-home-status-schema-validation`:

```bash
cd genie-claw
cargo fmt -p genie-core
cargo test -p genie-core --test tool_gate_integration_test home_status_rejects_invalid_arguments_and_audits
cargo test -p genie-core --test tool_gate_integration_test
cargo clippy -p genie-core -- -D warnings
```

### What I observed

- `home_status_rejects_invalid_arguments_and_audits` passes for `{}`, empty entity, and non-string entity.
- Full `tool_gate_integration_test` suite passes.
- Clippy clean on `genie-core`.

Jetson validation gap: schema enforcement verified via integration tests on dev host; no on-device HA run in this PR.

## Test plan

- [x] `cargo test -p genie-core --test tool_gate_integration_test home_status_rejects_invalid_arguments_and_audits`
- [x] `cargo test -p genie-core --test tool_gate_integration_test`
- [x] `cargo clippy -p genie-core -- -D warnings`

## Notes for reviewers

M1 typed-tool reliability follow-up to closed #330. `set_timer` silent defaults remain out of scope.
