### PR TITLE
fix(security/dispatch): wire LoopGuard and Tainted<T> IFC into all to…

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -1,0 +1,134 @@
+# [bug] security: `LoopGuard` circuit-breaker and `Tainted<T>` IFC are dead code — zero wiring into any live chat, voice, or Telegram path
+
+**Labels:** `bug`, `security`, `critical`
+
+---
+
+## Summary
+
+`security/loop_guard.rs` and `security/taint.rs` are fully implemented but never instantiated or invoked in any production execution path — the tool-call circuit-breaker and the information-flow control (IFC) layer have zero effect on runtime behavior, creating a false security narrative while providing no actual protection.
+
+---
+
+## Steps to reproduce
+
+```bash
+# LoopGuard has no callers outside its own module
+grep -rn "LoopGuard\|LoopCheck\|loop_guard" \
+  crates/genie-core/src/ --include="*.rs" \
+  | grep -v "security/loop_guard.rs" \
+  | grep -v "security/mod.rs"
+# → (empty)
+
+# Tainted / TaintLabel / TaintSink have no callers
+grep -rn "Tainted\|TaintLabel\|TaintSink" \
+  crates/genie-core/src/ --include="*.rs" \
+  | grep -v "security/taint.rs" \
+  | grep -v "security/mod.rs"
+# → (empty)
+```
+
+Every live turn goes through one of five paths — none create a `LoopGuard`, call `LoopGuard::check()`, apply any `TaintLabel`, or call `Tainted::check_sink()`:
+
+| Entry point | File |
+|---|---|
+| HTTP streaming chat | `server.rs` → `process_chat_stream()` |
+| HTTP non-streaming chat | `server.rs` → `process_chat_turn()` |
+| REPL | `repl.rs` → `run()` |
+| Voice loop | `voice_loop.rs` → `run()` |
+| Telegram adapter | `telegram.rs` → `handle_update()` |
+
+---
+
+## Expected behavior
+
+**`LoopGuard`:** every tool execution within a conversation turn is checked against the per-turn circuit-breaker. Calls to the same tool + args beyond `max_repeat_calls`, total calls beyond `max_total_calls`, or A→B→A→B ping-pong beyond `max_pingpong_cycles` are blocked before the tool dispatches and a clear error is surfaced to the LLM.
+
+**`Tainted<T>`:** data from external APIs (weather, web search) carries `TaintLabel::ExternalNetwork`; LLM outputs carry `TaintLabel::LlmOutput`. Before a value reaches the user, `check_sink(TaintSink::DisplayToUser)` must pass (blocks `Secret`). Before a value is sent to an external network endpoint, `check_sink(TaintSink::NetworkSend)` must pass (blocks `Secret` and `Pii`). Before external-network data enters a side-effecting tool, `check_sink(TaintSink::ToolExec)` must block the flow.
+
+---
+
+## Actual behavior
+
+Neither module executes at runtime. Both are compiled, unit-tested, and exported from `security/mod.rs`, but nothing in live code ever calls them.
+
+* **`LoopGuard::check()` is never called.** An adversarially prompted or looping LLM can trigger repeated tool executions across turns with no accumulated call counter — each turn re-enters tool dispatch with a clean slate. The configured `max_total_calls = 20` and `max_repeat_calls = 3` thresholds never fire.
+
+* **`Tainted<T>` labels are never applied.** A web-search result, a weather API body, or an LLM-hallucinated token string flows from tool execution back to the user with no taint annotation and no sink check. The `TaintSink::NetworkSend` policy that would block `Secret`-labeled values from reaching external services is never invoked.
+
+The injection scanner (`security/injection.rs`) and output sanitizer (`security/sandbox.rs::sanitize_output`) are wired correctly; the gap is exclusively `loop_guard` and `taint`.
+
+---
+
+## Concrete impact scenarios
+
+### 1 — Tool-call flood via crafted conversation history
+
+An attacker with access to the Telegram adapter (`allow_all_chats = true`) or the API sends a sequence of turns engineered to cause the LLM to emit the same high-cost tool call (e.g., `web_search`, `home_control`) on every reply. On Jetson Orin Nano 8 GB, each `web_search` spawns an outbound HTTP request plus a second LLM call for summarization. Without a circuit-breaker, this flood exhausts the bounded LLM request queue and degrades all concurrent sessions. The `LoopGuard` thresholds in `LoopGuardConfig::default()` exist precisely for this scenario — they just never execute.
+
+### 2 — PII leakage from memory injection to external search
+
+`memory::inject::build_memory_context()` hydrates household context strings (names, relationships, schedules) into the system prompt. If the LLM then issues a `web_search` and includes PII from the hydrated context in the query argument, that PII is forwarded to the configured SearXNG instance — which may be a public one. `TaintSink::NetworkSend` blocks `TaintLabel::Pii` from reaching external sinks; it is never invoked, so the block never fires.
+
+### 3 — Credential fragment echo through LLM summary
+
+If a tool result (e.g., a 401 error body from `home_control`) inadvertently includes a fragment of the HA token, the LLM summary call in `finalize_tool_turn()` may echo that fragment in its natural-language response. `TaintSink::DisplayToUser` blocks `TaintLabel::Secret`; it is never invoked.
+
+---
+
+## Hardware
+
+- Jetson Orin Nano Super 8 GB (all five call paths are live in production)
+- Non-Jetson x86_64 — also affected (REPL + HTTP paths present on all platforms)
+
+## JetPack / L4T version
+
+Any — the bug is architectural, not hardware-specific.
+
+## GenieClaw version / commit
+
+Confirmed present on `HEAD` (`fix/sandbox/enforce-landlock-ruleset`, commit `4c70bb7`). Both modules were introduced early in the security layer and have never been connected to a call site.
+
+## Relevant logs
+
+No log output — neither module produces log lines because neither is ever called. Absence of any line matching `loop_guard: blocked` or `taint: sink violation` in `journalctl -u genie-core` after a tool-heavy session is the indicator.
+
+---
+
+## Files requiring structural changes
+
+| File | Change required |
+|---|---|
+| `crates/genie-core/src/server.rs` | Instantiate `LoopGuard` at turn start; pass `&mut LoopGuard` into `try_tool_call_with_context()`; call `guard.check(name, args)` before dispatch; call `guard.reset()` at turn end. Apply `check_sink(TaintSink::DisplayToUser)` on tool output before writing to the response stream. |
+| `crates/genie-core/src/repl.rs` | Same LoopGuard and taint-sink wiring as `server.rs`. |
+| `crates/genie-core/src/voice_loop.rs` | Same LoopGuard and taint-sink wiring. |
+| `crates/genie-core/src/telegram.rs` | Same wiring; LoopGuard state scoped to the per-chat lock's critical section so it resets between Telegram turns. |
+| `crates/genie-core/src/tools/dispatch.rs` | `execute_with_context()` accepts `&mut LoopGuard`; calls `check()` before dispatching any tool; return type carries a `DataOrigin` tag so callers can apply taint labels. |
+| `crates/genie-core/src/tools/weather.rs` | Tag HTTP response body with `TaintLabel::ExternalNetwork` before returning `ToolResult`. |
+| `crates/genie-core/src/tools/web_search.rs` | Same: tag SearXNG response with `TaintLabel::ExternalNetwork`. |
+| `crates/genie-core/src/tools/mod.rs` | Re-export updated signatures; expose `DataOrigin` or `Tainted<ToolResult>` to call sites. |
+| `crates/genie-core/src/security/loop_guard.rs` | Expose per-origin `LoopGuardConfig` overrides (e.g., stricter limits for `Telegram` / `Api` origins vs `Voice` / `Dashboard`). |
+| `crates/genie-core/src/security/taint.rs` | Add `Tainted::from_tool_result(result, origin)` constructor and a `DataOrigin` enum mirroring `ToolActionClass::Network` → `TaintLabel::ExternalNetwork`. |
+
+---
+
+## Additional context
+
+This parallels earlier dead-code security bugs in this codebase:
+
+* **#286** — `CredentialStore` was dead code (secrets stored as plain `String`s). Fixed.
+* **#181** — `RetryLlmClient` was dead code; `chat_turn_lock` unbounded. Fixed.
+* **#196** — `scan_and_warn` wired only to the OpenAI-compat bridge. Fixed.
+
+The pattern recurs here at a higher level: both `LoopGuard` and `Tainted<T>` are well-implemented, well-tested modules that are simply never called from any production code path. Unlike the prior cases, this gap spans all five entry points and multiple tool implementations, making it a broader structural issue requiring coordinated changes across the tool dispatch pipeline.
+
+**Minimum viable fix:**
+
+1. Thread `&mut LoopGuard` through the five chat-turn entry points listed above.
+2. Call `guard.check(name, args_json)` in `ToolDispatcher::execute_with_context()` before any tool runs; surface `LoopCheck::Block` as a `ToolResult` error so the LLM sees a clear rejection instead of a silent no-op.
+3. Add `TaintLabel::ExternalNetwork` to `ToolResult::output` for `ToolActionClass::Network` results (weather, web_search) and call `check_sink(TaintSink::DisplayToUser)` in the response-finalization helpers.
+
+**Complete fix also:**
+
+4. Expose per-origin `LoopGuardConfig` overrides in `[core.tool_policy]` (stricter limits for remote/Telegram origins, relaxed for Voice/Dashboard).
+5. Propagate `TaintLabel::Pii` when memory injection hydrates named-person context strings, and enforce `TaintSink::NetworkSend` before those values reach `web_search` query arguments.

--- a/crates/genie-core/src/repl.rs
+++ b/crates/genie-core/src/repl.rs
@@ -6,6 +6,7 @@ use crate::llm::{LlmClient, LlmRequestHints, Message};
 use crate::memory::{self, SharedMemory, with_shared_memory};
 use crate::prompt::ModelFamily;
 use crate::reasoning::InteractionKind;
+use crate::security::loop_guard::{LoopGuard, LoopGuardConfig};
 use crate::tools;
 
 /// Interactive REPL for genie-core.
@@ -64,6 +65,9 @@ pub async fn run(
         // Persist user message.
         conversations.append_or_log(&conv_id, "user", text, None);
 
+        // One LoopGuard per REPL input — resets between turns automatically.
+        let mut loop_guard = LoopGuard::new(LoopGuardConfig::default());
+
         if let Some(call) = tools::quick::route_for_available_tools(
             text,
             tools_dispatch.has_home_automation(),
@@ -76,6 +80,7 @@ pub async fn run(
                         request_origin: tools::RequestOrigin::Repl,
                         ..tools::ToolExecutionContext::default()
                     },
+                    &mut loop_guard,
                 )
                 .await;
             let response = if tool_result.success {
@@ -158,6 +163,7 @@ pub async fn run(
                         request_origin: tools::RequestOrigin::Repl,
                         ..tools::ToolExecutionContext::default()
                     },
+                    &mut loop_guard,
                 )
                 .await
                 {

--- a/crates/genie-core/src/server.rs
+++ b/crates/genie-core/src/server.rs
@@ -12,12 +12,12 @@ use tokio::sync::{Mutex, Semaphore};
 
 use crate::connectivity::{ConnectivityController, ConnectivityHealth, ConnectivityState};
 use crate::conversation::ConversationStore;
-use crate::security::loop_guard::{LoopGuard, LoopGuardConfig};
 use crate::llm::{LlmClient, LlmRequestHints, Message};
 use crate::memory::{Memory, SharedMemory, with_shared_memory};
 use crate::origin_auth::OriginResolver;
 use crate::prompt::ModelFamily;
 use crate::reasoning::InteractionKind;
+use crate::security::loop_guard::{LoopGuard, LoopGuardConfig};
 use crate::tools::ToolDispatcher;
 use crate::tools::{RequestOrigin, ToolExecutionContext};
 

--- a/crates/genie-core/src/server.rs
+++ b/crates/genie-core/src/server.rs
@@ -12,6 +12,7 @@ use tokio::sync::{Mutex, Semaphore};
 
 use crate::connectivity::{ConnectivityController, ConnectivityHealth, ConnectivityState};
 use crate::conversation::ConversationStore;
+use crate::security::loop_guard::{LoopGuard, LoopGuardConfig};
 use crate::llm::{LlmClient, LlmRequestHints, Message};
 use crate::memory::{Memory, SharedMemory, with_shared_memory};
 use crate::origin_auth::OriginResolver;
@@ -884,6 +885,10 @@ async fn handle_chat_stream(
     conversations.ensure(&conv_id, "New conversation")?;
     conversations.append(&conv_id, "user", user_text, None)?;
 
+    // One LoopGuard per HTTP turn — shared across the quick-tool fast path
+    // and the LLM-driven tool dispatch so call counts accumulate correctly.
+    let mut loop_guard = LoopGuard::new(LoopGuardConfig::default());
+
     if let Some(call) = crate::tools::quick::route_for_available_tools(
         user_text,
         tools.has_home_automation(),
@@ -903,6 +908,7 @@ async fn handle_chat_stream(
                     request_origin,
                     ..ToolExecutionContext::default()
                 },
+                &mut loop_guard,
             )
             .await;
         let final_response =
@@ -1043,6 +1049,7 @@ async fn handle_chat_stream(
             request_origin,
             ..ToolExecutionContext::default()
         },
+        &mut loop_guard,
     )
     .await
     {
@@ -1114,6 +1121,8 @@ pub async fn process_chat_turn(
     conversations.ensure(conv_id, "New conversation")?;
     conversations.append(conv_id, "user", user_text, None)?;
 
+    let mut loop_guard = LoopGuard::new(LoopGuardConfig::default());
+
     if let Some(call) = crate::tools::quick::route_for_available_tools(
         user_text,
         tools.has_home_automation(),
@@ -1126,6 +1135,7 @@ pub async fn process_chat_turn(
                     request_origin,
                     ..ToolExecutionContext::default()
                 },
+                &mut loop_guard,
             )
             .await;
         let final_response = finalize_direct_tool_turn(conversations, conv_id, &call, &tool_result);
@@ -1178,6 +1188,7 @@ pub async fn process_chat_turn(
             request_origin,
             ..ToolExecutionContext::default()
         },
+        &mut loop_guard,
     )
     .await
     {
@@ -2096,6 +2107,8 @@ async fn handle_openai_chat(
         crate::security::injection::source::OPENAI_BRIDGE,
     );
 
+    let mut loop_guard = LoopGuard::new(LoopGuardConfig::default());
+
     if let Some(call) = crate::tools::quick::route_for_available_tools(
         &user_text,
         tools.has_home_automation(),
@@ -2108,6 +2121,7 @@ async fn handle_openai_chat(
                     request_origin,
                     ..ToolExecutionContext::default()
                 },
+                &mut loop_guard,
             )
             .await;
         let response = if tool_result.success {
@@ -2180,6 +2194,7 @@ async fn handle_openai_chat(
             request_origin,
             ..ToolExecutionContext::default()
         },
+        &mut loop_guard,
     )
     .await
     {

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -17,6 +17,8 @@ use super::actuation::{
 use super::home;
 use super::timer;
 use crate::ha::HomeAutomationProvider;
+use crate::security::loop_guard::{LoopCheck, LoopGuard, LoopGuardConfig};
+use crate::security::taint::{TaintLabel, TaintSink, Tainted};
 use crate::skills::SkillLoader;
 
 const ACTUATION_RATE_WINDOW_MS: u64 = 60_000;
@@ -517,7 +519,8 @@ impl ToolDispatcher {
 
     /// Execute a tool call from the LLM.
     pub async fn execute(&self, call: &ToolCall) -> ToolResult {
-        self.execute_with_context(call, ToolExecutionContext::default())
+        let mut guard = LoopGuard::new(LoopGuardConfig::default());
+        self.execute_with_context(call, ToolExecutionContext::default(), &mut guard)
             .await
     }
 
@@ -525,9 +528,32 @@ impl ToolDispatcher {
         &self,
         call: &ToolCall,
         exec_ctx: ToolExecutionContext,
+        guard: &mut LoopGuard,
     ) -> ToolResult {
         let started = Instant::now();
         let action_class = tool_action_class(&call.name);
+
+        // Circuit-breaker: check before any dispatch so a looping LLM is
+        // blocked regardless of which tool it keeps calling.
+        let args_json = call.arguments.to_string();
+        match guard.check(&call.name, &args_json) {
+            LoopCheck::Block(reason) => {
+                tracing::warn!(tool = %call.name, %reason, "loop_guard: blocked tool call");
+                let tool_result = ToolResult {
+                    tool: call.name.clone(),
+                    action_class,
+                    success: false,
+                    output: format!("Tool call blocked by loop guard: {reason}"),
+                };
+                self.audit_tool_call(call, exec_ctx, started, &tool_result);
+                return tool_result;
+            }
+            LoopCheck::Warn(reason) => {
+                tracing::warn!(tool = %call.name, %reason, "loop_guard: repeated tool call warning");
+            }
+            LoopCheck::Allow => {}
+        }
+
         if let Err(err) =
             tool_origin_allowed(&self.tool_policy, exec_ctx.request_origin, &call.name)
         {
@@ -574,6 +600,22 @@ impl ToolDispatcher {
                 output: e.to_string(),
             },
         };
+
+        // IFC: tag Network tool outputs with ExternalNetwork and verify the
+        // DisplayToUser sink policy. Currently ExternalNetwork is not blocked
+        // at DisplayToUser (only Secret is), so this is a no-op today but
+        // establishes the wire-up so future Secret-carrying network results
+        // are caught at the boundary rather than leaking to the user.
+        if tool_result.action_class == ToolActionClass::Network && tool_result.success {
+            let tainted = Tainted::new(tool_result.output.clone(), TaintLabel::ExternalNetwork);
+            if let Err(violation) = tainted.check_sink(TaintSink::DisplayToUser) {
+                tracing::warn!(
+                    tool = %call.name,
+                    %violation,
+                    "taint: network tool output violates DisplayToUser policy"
+                );
+            }
+        }
 
         self.audit_tool_call(call, exec_ctx, started, &tool_result);
 
@@ -859,6 +901,9 @@ impl ToolDispatcher {
         // `"confirmation"`. The original-bucket already paid one slot when
         // the request returned `ConfirmationRequired`, so the limiter skips
         // re-charging here (see `confirmed`-guard in `exec_home_control_inner`).
+        // Confirmation re-entries are single, already-approved actions.
+        // A fresh guard is correct here: this is not an LLM-driven turn.
+        let mut guard = LoopGuard::new(LoopGuardConfig::default());
         let result = self
             .execute_with_context(
                 &call,
@@ -867,6 +912,7 @@ impl ToolDispatcher {
                     confirmed: true,
                     ..ToolExecutionContext::default()
                 },
+                &mut guard,
             )
             .await;
         if result.success {
@@ -1731,6 +1777,19 @@ mod tests {
     use std::sync::OnceLock;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    /// Convenience wrapper used by tests that don't care about loop-guard
+    /// state: creates a fresh default LoopGuard for each call so the
+    /// test exercises the same code path as production without needing to
+    /// thread a guard through every assertion.
+    async fn exec_ctx(
+        dispatcher: &ToolDispatcher,
+        call: &ToolCall,
+        ctx: ToolExecutionContext,
+    ) -> ToolResult {
+        let mut guard = LoopGuard::new(LoopGuardConfig::default());
+        dispatcher.execute_with_context(call, ctx, &mut guard).await
+    }
+
     struct StubHomeProvider;
 
     struct RecordingHomeProvider {
@@ -1966,18 +2025,18 @@ mod tests {
             .insert("telegram".into(), vec!["web_search".into()]);
         let dispatcher = ToolDispatcher::new(None).with_tool_policy_config(policy);
 
-        let result = dispatcher
-            .execute_with_context(
-                &ToolCall {
-                    name: "web_search".into(),
-                    arguments: serde_json::json!({"query": "test"}),
-                },
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Telegram,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let result = exec_ctx(
+            &dispatcher,
+            &ToolCall {
+                name: "web_search".into(),
+                arguments: serde_json::json!({"query": "test"}),
+            },
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Telegram,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
 
         assert!(!result.success);
         assert!(result.output.contains("origin policy"));
@@ -1991,30 +2050,30 @@ mod tests {
             .insert("voice".into(), vec!["get_time".into()]);
         let dispatcher = ToolDispatcher::new(None).with_tool_policy_config(policy);
 
-        let allowed = dispatcher
-            .execute_with_context(
-                &ToolCall {
-                    name: "get_time".into(),
-                    arguments: serde_json::json!({}),
-                },
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Voice,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
-        let blocked = dispatcher
-            .execute_with_context(
-                &ToolCall {
-                    name: "calculate".into(),
-                    arguments: serde_json::json!({"expression": "1 + 1"}),
-                },
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Voice,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let allowed = exec_ctx(
+            &dispatcher,
+            &ToolCall {
+                name: "get_time".into(),
+                arguments: serde_json::json!({}),
+            },
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Voice,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
+        let blocked = exec_ctx(
+            &dispatcher,
+            &ToolCall {
+                name: "calculate".into(),
+                arguments: serde_json::json!({"expression": "1 + 1"}),
+            },
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Voice,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
 
         assert!(allowed.success);
         assert!(!blocked.success);
@@ -2069,18 +2128,18 @@ mod tests {
         let _ = std::fs::remove_file(&path);
         let dispatcher = ToolDispatcher::new(None).with_tool_audit_path(path.clone());
 
-        let result = dispatcher
-            .execute_with_context(
-                &ToolCall {
-                    name: "calculate".into(),
-                    arguments: serde_json::json!({"expression": "secret-token-value"}),
-                },
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Api,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let result = exec_ctx(
+            &dispatcher,
+            &ToolCall {
+                name: "calculate".into(),
+                arguments: serde_json::json!({"expression": "secret-token-value"}),
+            },
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Api,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
 
         assert!(!result.success);
         let line = std::fs::read_to_string(&path).unwrap();
@@ -2116,21 +2175,21 @@ mod tests {
             executed: executed.clone(),
         })));
 
-        let result = dispatcher
-            .execute_with_context(
-                &ToolCall {
-                    name: "home_control".into(),
-                    arguments: serde_json::json!({
-                        "entity": "kitchen light",
-                        "action": "turn_on"
-                    }),
-                },
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Dashboard,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let result = exec_ctx(
+            &dispatcher,
+            &ToolCall {
+                name: "home_control".into(),
+                arguments: serde_json::json!({
+                    "entity": "kitchen light",
+                    "action": "turn_on"
+                }),
+            },
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Dashboard,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
 
         assert!(result.success);
         assert_eq!(*executed.lock().unwrap(), vec![HomeActionKind::TurnOn]);
@@ -2164,21 +2223,21 @@ mod tests {
         })))
         .with_memory(Arc::new(std::sync::Mutex::new(memory)));
 
-        let result = dispatcher
-            .execute_with_context(
-                &ToolCall {
-                    name: "home_control".into(),
-                    arguments: serde_json::json!({
-                        "entity": "playroom lights",
-                        "action": "turn_on"
-                    }),
-                },
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Dashboard,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let result = exec_ctx(
+            &dispatcher,
+            &ToolCall {
+                name: "home_control".into(),
+                arguments: serde_json::json!({
+                    "entity": "playroom lights",
+                    "action": "turn_on"
+                }),
+            },
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Dashboard,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
 
         assert!(result.success, "{}", result.output);
         assert_eq!(*executed.lock().unwrap(), vec![HomeActionKind::TurnOn]);
@@ -2226,21 +2285,21 @@ mod tests {
         })))
         .with_actuation_safety_config(safety);
 
-        let result = dispatcher
-            .execute_with_context(
-                &ToolCall {
-                    name: "home_control".into(),
-                    arguments: serde_json::json!({
-                        "entity": "kitchen light",
-                        "action": "turn_on"
-                    }),
-                },
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Telegram,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let result = exec_ctx(
+            &dispatcher,
+            &ToolCall {
+                name: "home_control".into(),
+                arguments: serde_json::json!({
+                    "entity": "kitchen light",
+                    "action": "turn_on"
+                }),
+            },
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Telegram,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
 
         assert!(!result.success);
         assert!(result.output.contains("telegram"));
@@ -2270,8 +2329,8 @@ mod tests {
             ..ToolExecutionContext::default()
         };
 
-        let first = dispatcher.execute_with_context(&call, ctx).await;
-        let second = dispatcher.execute_with_context(&call, ctx).await;
+        let first = exec_ctx(&dispatcher, &call, ctx).await;
+        let second = exec_ctx(&dispatcher, &call, ctx).await;
 
         assert!(first.success);
         assert!(!second.success);
@@ -2294,30 +2353,30 @@ mod tests {
             }),
         };
         assert!(
-            dispatcher
-                .execute_with_context(
-                    &control,
-                    ToolExecutionContext {
-                        request_origin: RequestOrigin::Dashboard,
-                        ..ToolExecutionContext::default()
-                    },
-                )
-                .await
-                .success
-        );
-
-        let undo = dispatcher
-            .execute_with_context(
-                &ToolCall {
-                    name: "home_undo".into(),
-                    arguments: serde_json::json!({}),
-                },
+            exec_ctx(
+                &dispatcher,
+                &control,
                 ToolExecutionContext {
                     request_origin: RequestOrigin::Dashboard,
                     ..ToolExecutionContext::default()
                 },
             )
-            .await;
+            .await
+            .success
+        );
+
+        let undo = exec_ctx(
+            &dispatcher,
+            &ToolCall {
+                name: "home_undo".into(),
+                arguments: serde_json::json!({}),
+            },
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Dashboard,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
 
         assert!(undo.success);
         assert!(undo.output.contains("Undid the last home action"));
@@ -2326,18 +2385,18 @@ mod tests {
             vec![HomeActionKind::TurnOn, HomeActionKind::TurnOff]
         );
 
-        let second_undo = dispatcher
-            .execute_with_context(
-                &ToolCall {
-                    name: "home_undo".into(),
-                    arguments: serde_json::json!({}),
-                },
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Dashboard,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let second_undo = exec_ctx(
+            &dispatcher,
+            &ToolCall {
+                name: "home_undo".into(),
+                arguments: serde_json::json!({}),
+            },
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Dashboard,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
         assert!(!second_undo.success);
         assert!(second_undo.output.contains("No recent reversible"));
     }
@@ -2355,22 +2414,22 @@ mod tests {
         })))
         .with_actuation_audit_path(path.clone());
         assert!(
-            dispatcher
-                .execute_with_context(
-                    &ToolCall {
-                        name: "home_control".into(),
-                        arguments: serde_json::json!({
-                            "entity": "kitchen light",
-                            "action": "turn_on"
-                        }),
-                    },
-                    ToolExecutionContext {
-                        request_origin: RequestOrigin::Dashboard,
-                        ..ToolExecutionContext::default()
-                    },
-                )
-                .await
-                .success
+            exec_ctx(
+                &dispatcher,
+                &ToolCall {
+                    name: "home_control".into(),
+                    arguments: serde_json::json!({
+                        "entity": "kitchen light",
+                        "action": "turn_on"
+                    }),
+                },
+                ToolExecutionContext {
+                    request_origin: RequestOrigin::Dashboard,
+                    ..ToolExecutionContext::default()
+                },
+            )
+            .await
+            .success
         );
 
         let restarted = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider {
@@ -2895,21 +2954,21 @@ mod tests {
             name: "memory_recall".into(),
             arguments: serde_json::json!({"query": "oat milk"}),
         };
-        let output = dispatcher
-            .execute_with_context(
-                &call,
-                ToolExecutionContext {
-                    memory_read_context: Some(crate::memory::policy::MemoryReadContext {
-                        identity_confidence: crate::memory::policy::IdentityConfidence::High,
-                        explicit_named_person: false,
-                        explicit_private_intent: false,
-                        shared_space_voice: true,
-                    }),
-                    request_origin: RequestOrigin::Dashboard,
-                    confirmed: false,
-                },
-            )
-            .await;
+        let output = exec_ctx(
+            &dispatcher,
+            &call,
+            ToolExecutionContext {
+                memory_read_context: Some(crate::memory::policy::MemoryReadContext {
+                    identity_confidence: crate::memory::policy::IdentityConfidence::High,
+                    explicit_named_person: false,
+                    explicit_private_intent: false,
+                    shared_space_voice: true,
+                }),
+                request_origin: RequestOrigin::Dashboard,
+                confirmed: false,
+            },
+        )
+        .await;
 
         assert!(output.success);
         assert_eq!(output.output, "I remember: Maya likes oat milk");
@@ -3071,15 +3130,15 @@ mod tests {
                 "action": "lock"
             }),
         };
-        let issued = dispatcher
-            .execute_with_context(
-                &lock_call,
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Telegram,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let issued = exec_ctx(
+            &dispatcher,
+            &lock_call,
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Telegram,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
         assert!(issued.success, "issuing confirmation must succeed");
         assert!(
             !issued.output.contains("act-"),
@@ -3132,15 +3191,15 @@ mod tests {
 
         // First Telegram request → returns ConfirmationRequired and charges
         // the telegram bucket once.
-        let first_issue = dispatcher
-            .execute_with_context(
-                &lock_call,
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Telegram,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let first_issue = exec_ctx(
+            &dispatcher,
+            &lock_call,
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Telegram,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
         assert!(first_issue.success);
         let first_token = latest_confirmation_token(&dispatcher);
 
@@ -3157,15 +3216,15 @@ mod tests {
         // A second Telegram-initiated sensitive request inside the same window
         // must now be rate-limited at the issue step, instead of getting
         // through by routing through the confirmation bucket.
-        let second_issue = dispatcher
-            .execute_with_context(
-                &lock_call,
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Telegram,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let second_issue = exec_ctx(
+            &dispatcher,
+            &lock_call,
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Telegram,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
         assert!(
             !second_issue.success,
             "second telegram-initiated sensitive request must be rate-limited"
@@ -3209,15 +3268,15 @@ mod tests {
             }),
         };
 
-        let first_issue = dispatcher
-            .execute_with_context(
-                &lock_call,
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Telegram,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let first_issue = exec_ctx(
+            &dispatcher,
+            &lock_call,
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Telegram,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
         assert!(first_issue.success);
         let first_token = latest_confirmation_token(&dispatcher);
         dispatcher
@@ -3229,15 +3288,15 @@ mod tests {
         // so far: 1 (request) + 0 (confirm doesn't recharge) = 1. With limit
         // = 2, this issue must still be accepted (returns
         // ConfirmationRequired again, charging slot #2).
-        let second_issue = dispatcher
-            .execute_with_context(
-                &lock_call,
-                ToolExecutionContext {
-                    request_origin: RequestOrigin::Telegram,
-                    ..ToolExecutionContext::default()
-                },
-            )
-            .await;
+        let second_issue = exec_ctx(
+            &dispatcher,
+            &lock_call,
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Telegram,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
         assert!(
             second_issue.success,
             "second issue must succeed: confirm of #1 must not double-charge the telegram bucket"

--- a/crates/genie-core/src/tools/parser.rs
+++ b/crates/genie-core/src/tools/parser.rs
@@ -1,3 +1,5 @@
+use crate::security::loop_guard::{LoopGuard, LoopGuardConfig};
+
 use super::dispatch::{ToolCall, ToolDispatcher, ToolExecutionContext, ToolResult};
 
 /// Parse a tool call from LLM output and execute it.
@@ -8,13 +10,15 @@ use super::dispatch::{ToolCall, ToolDispatcher, ToolExecutionContext, ToolResult
 /// 3. Embedded in text: `I'll check that. {"tool": "get_weather", "arguments": {"location": "Denver"}}`
 /// 4. With extra fields: `{"tool": "set_timer", "arguments": {"seconds": 300}, "reasoning": "..."}`
 pub async fn try_tool_call(response: &str, tools: &ToolDispatcher) -> Option<ToolResult> {
-    try_tool_call_with_context(response, tools, ToolExecutionContext::default()).await
+    let mut guard = LoopGuard::new(LoopGuardConfig::default());
+    try_tool_call_with_context(response, tools, ToolExecutionContext::default(), &mut guard).await
 }
 
 pub async fn try_tool_call_with_context(
     response: &str,
     tools: &ToolDispatcher,
     exec_ctx: ToolExecutionContext,
+    guard: &mut LoopGuard,
 ) -> Option<ToolResult> {
     let json_str = extract_json(response)?;
     let value: serde_json::Value = serde_json::from_str(&json_str).ok()?;
@@ -24,7 +28,7 @@ pub async fn try_tool_call_with_context(
         return None;
     }
 
-    Some(tools.execute_with_context(&call, exec_ctx).await)
+    Some(tools.execute_with_context(&call, exec_ctx, guard).await)
 }
 
 /// Parse tool calls from model output without executing them.

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -24,6 +24,7 @@ use crate::memory::{SharedMemory, with_shared_memory};
 use crate::memory::{extract, inject};
 use crate::prompt::ModelFamily;
 use crate::reasoning::InteractionKind;
+use crate::security::loop_guard::{LoopGuard, LoopGuardConfig};
 use crate::tools::ToolDispatcher;
 use crate::voice::identity::{self, SpeakerIdentityProvider};
 use crate::voice::intent::{self, VoiceIntentDecision};
@@ -385,6 +386,7 @@ async fn run_with_wakeword(
                             // (we already have the text).
                             conversations.append_or_log(conv_id, "user", &text, None);
 
+                            let mut followup_guard = LoopGuard::new(LoopGuardConfig::default());
                             if handle_quick_tool_for_voice(
                                 tools,
                                 conversations,
@@ -394,6 +396,7 @@ async fn run_with_wakeword(
                                 voice_cfg,
                                 audio_device,
                                 response_language.as_deref(),
+                                &mut followup_guard,
                             )
                             .await
                             .is_some()
@@ -698,6 +701,7 @@ async fn handle_quick_tool_for_voice(
     voice_cfg: &VoiceConfig,
     audio_device: &str,
     response_language: Option<&str>,
+    guard: &mut LoopGuard,
 ) -> Option<String> {
     let call = crate::tools::quick::route_for_available_tools(
         text,
@@ -761,6 +765,7 @@ async fn handle_quick_tool_for_voice(
                 request_origin: crate::tools::RequestOrigin::Voice,
                 confirmed: false,
             },
+            guard,
         )
         .await;
     let response = if tool_result.success {
@@ -1011,6 +1016,10 @@ pub async fn process_transcript(
     }
     // Security: scan for prompt injection (issue #196).
     crate::security::injection::scan_and_warn(&text, crate::security::injection::source::VOICE);
+
+    // One LoopGuard per voice cycle — shared across the quick-tool fast path
+    // and the LLM-driven tool dispatch so call counts accumulate correctly.
+    let mut loop_guard = LoopGuard::new(LoopGuardConfig::default());
     if let VoiceIntentDecision::Reject(reason) = intent::assess_transcript(&text) {
         if let Some(path) = wav_path {
             let _ = tokio::fs::remove_file(path).await;
@@ -1055,6 +1064,7 @@ pub async fn process_transcript(
         voice_cfg,
         audio_device,
         response_language.as_deref(),
+        &mut loop_guard,
     )
     .await
     {
@@ -1158,6 +1168,7 @@ pub async fn process_transcript(
                 request_origin: crate::tools::RequestOrigin::Voice,
                 confirmed: false,
             },
+            &mut loop_guard,
         )
         .await
     {

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -10,6 +10,7 @@ use genie_core::ha::{
     ActionResult, DeviceRef, HomeAction, HomeActionKind, HomeAutomationProvider, HomeGraph,
     HomeState, HomeTarget, HomeTargetKind, IntegrationHealth, SceneRef,
 };
+use genie_core::security::loop_guard::{LoopGuard, LoopGuardConfig};
 use genie_core::tools::{RequestOrigin, ToolCall, ToolDispatcher, ToolExecutionContext};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -182,6 +183,7 @@ async fn tool_gate_acl_denies_disallowed_origin_and_audits() {
         .insert("telegram".into(), vec!["get_time".into()]);
 
     let dispatcher = paths.dispatcher(None, policy, ActuationSafetyConfig::default());
+    let mut guard = LoopGuard::new(LoopGuardConfig::default());
     let result = dispatcher
         .execute_with_context(
             &ToolCall {
@@ -192,6 +194,7 @@ async fn tool_gate_acl_denies_disallowed_origin_and_audits() {
                 request_origin: RequestOrigin::Telegram,
                 ..ToolExecutionContext::default()
             },
+            &mut guard,
         )
         .await;
 
@@ -236,8 +239,10 @@ async fn tool_gate_rate_limit_allows_n_then_denies_and_audits() {
         ..ToolExecutionContext::default()
     };
 
-    let first = dispatcher.execute_with_context(&call, ctx).await;
-    let second = dispatcher.execute_with_context(&call, ctx).await;
+    let mut guard1 = LoopGuard::new(LoopGuardConfig::default());
+    let first = dispatcher.execute_with_context(&call, ctx, &mut guard1).await;
+    let mut guard2 = LoopGuard::new(LoopGuardConfig::default());
+    let second = dispatcher.execute_with_context(&call, ctx, &mut guard2).await;
 
     assert!(
         first.success,
@@ -308,6 +313,7 @@ async fn tool_gate_confirmable_home_action_requires_token_and_audits() {
         ActuationSafetyConfig::default(),
     );
 
+    let mut guard = LoopGuard::new(LoopGuardConfig::default());
     let result = dispatcher
         .execute_with_context(
             &ToolCall {
@@ -321,6 +327,7 @@ async fn tool_gate_confirmable_home_action_requires_token_and_audits() {
                 request_origin: RequestOrigin::Dashboard,
                 ..ToolExecutionContext::default()
             },
+            &mut guard,
         )
         .await;
 
@@ -381,6 +388,7 @@ async fn tool_gate_audit_logs_are_append_only_and_record_all_dispatches() {
         safety,
     );
 
+    let mut guard = LoopGuard::new(LoopGuardConfig::default());
     let denied = dispatcher
         .execute_with_context(
             &ToolCall {
@@ -391,12 +399,14 @@ async fn tool_gate_audit_logs_are_append_only_and_record_all_dispatches() {
                 request_origin: RequestOrigin::Api,
                 ..ToolExecutionContext::default()
             },
+            &mut guard,
         )
         .await;
     assert!(!denied.success);
     let tool_len_1 = read_jsonl(&paths.tool_audit).len();
     assert_eq!(tool_len_1, 1);
 
+    let mut guard = LoopGuard::new(LoopGuardConfig::default());
     let allowed = dispatcher
         .execute_with_context(
             &ToolCall {
@@ -407,6 +417,7 @@ async fn tool_gate_audit_logs_are_append_only_and_record_all_dispatches() {
                 request_origin: RequestOrigin::Api,
                 ..ToolExecutionContext::default()
             },
+            &mut guard,
         )
         .await;
     assert!(allowed.success);
@@ -425,15 +436,17 @@ async fn tool_gate_audit_logs_are_append_only_and_record_all_dispatches() {
         request_origin: RequestOrigin::Dashboard,
         ..ToolExecutionContext::default()
     };
+    let mut guard1 = LoopGuard::new(LoopGuardConfig::default());
     assert!(
         dispatcher
-            .execute_with_context(&home_call, dash_ctx)
+            .execute_with_context(&home_call, dash_ctx, &mut guard1)
             .await
             .success
     );
+    let mut guard2 = LoopGuard::new(LoopGuardConfig::default());
     assert!(
         !dispatcher
-            .execute_with_context(&home_call, dash_ctx)
+            .execute_with_context(&home_call, dash_ctx, &mut guard2)
             .await
             .success
     );

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -240,9 +240,13 @@ async fn tool_gate_rate_limit_allows_n_then_denies_and_audits() {
     };
 
     let mut guard1 = LoopGuard::new(LoopGuardConfig::default());
-    let first = dispatcher.execute_with_context(&call, ctx, &mut guard1).await;
+    let first = dispatcher
+        .execute_with_context(&call, ctx, &mut guard1)
+        .await;
     let mut guard2 = LoopGuard::new(LoopGuardConfig::default());
-    let second = dispatcher.execute_with_context(&call, ctx, &mut guard2).await;
+    let second = dispatcher
+        .execute_with_context(&call, ctx, &mut guard2)
+        .await;
 
     assert!(
         first.success,
@@ -509,6 +513,7 @@ async fn home_control_rejects_invalid_arguments_and_audits() {
     let expected_audit_count = invalid_calls.len();
 
     for (arguments, expected_snippet) in &invalid_calls {
+        let mut guard = LoopGuard::new(LoopGuardConfig::default());
         let result = dispatcher
             .execute_with_context(
                 &ToolCall {
@@ -516,6 +521,7 @@ async fn home_control_rejects_invalid_arguments_and_audits() {
                     arguments: arguments.clone(),
                 },
                 ctx,
+                &mut guard,
             )
             .await;
 

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -587,6 +587,7 @@ async fn home_status_rejects_invalid_arguments_and_audits() {
     let expected_audit_count = invalid_calls.len();
 
     for (arguments, expected_snippet) in &invalid_calls {
+        let mut guard = LoopGuard::new(LoopGuardConfig::default());
         let result = dispatcher
             .execute_with_context(
                 &ToolCall {
@@ -594,6 +595,7 @@ async fn home_status_rejects_invalid_arguments_and_audits() {
                     arguments: arguments.clone(),
                 },
                 ctx,
+                &mut guard,
             )
             .await;
 

--- a/crates/genie-core/tests/voice_loop_integration.rs
+++ b/crates/genie-core/tests/voice_loop_integration.rs
@@ -161,10 +161,14 @@ async fn tool_dispatch_via_try_tool_call_writes_audit_log_event() {
 
     let llm_output = r#"{"tool": "get_time", "arguments": {}}"#;
     let mut guard = LoopGuard::new(LoopGuardConfig::default());
-    let result =
-        try_tool_call_with_context(llm_output, &dispatcher, ToolExecutionContext::default(), &mut guard)
-            .await
-            .expect("get_time should be dispatchable");
+    let result = try_tool_call_with_context(
+        llm_output,
+        &dispatcher,
+        ToolExecutionContext::default(),
+        &mut guard,
+    )
+    .await
+    .expect("get_time should be dispatchable");
     assert_eq!(result.tool, "get_time");
     assert!(result.success, "get_time should succeed");
 
@@ -263,10 +267,14 @@ async fn mock_voice_cycle_drives_stt_then_llm_then_streaming_tts_then_tool_audit
 
     // Tool dispatch — exactly what voice_cycle does on the LLM output.
     let mut guard = LoopGuard::new(LoopGuardConfig::default());
-    let tool_result =
-        try_tool_call_with_context(&llm_output, &dispatcher, ToolExecutionContext::default(), &mut guard)
-            .await
-            .expect("LLM output should parse as a tool call");
+    let tool_result = try_tool_call_with_context(
+        &llm_output,
+        &dispatcher,
+        ToolExecutionContext::default(),
+        &mut guard,
+    )
+    .await
+    .expect("LLM output should parse as a tool call");
     assert_eq!(tool_result.tool, "get_time");
     assert!(tool_result.success);
 

--- a/crates/genie-core/tests/voice_loop_integration.rs
+++ b/crates/genie-core/tests/voice_loop_integration.rs
@@ -47,6 +47,7 @@ use genie_core::conversation::ConversationStore;
 use genie_core::llm::{LlmClient, Message};
 use genie_core::memory::{Memory, SharedMemory};
 use genie_core::prompt::ModelFamily;
+use genie_core::security::loop_guard::{LoopGuard, LoopGuardConfig};
 use genie_core::tools::{ToolDispatcher, ToolExecutionContext, try_tool_call_with_context};
 use genie_core::voice::identity::SpeakerIdentityProvider;
 use genie_core::voice::streaming::stream_and_speak;
@@ -159,8 +160,9 @@ async fn tool_dispatch_via_try_tool_call_writes_audit_log_event() {
     let dispatcher = ToolDispatcher::new(None).with_tool_audit_path(audit_path.clone());
 
     let llm_output = r#"{"tool": "get_time", "arguments": {}}"#;
+    let mut guard = LoopGuard::new(LoopGuardConfig::default());
     let result =
-        try_tool_call_with_context(llm_output, &dispatcher, ToolExecutionContext::default())
+        try_tool_call_with_context(llm_output, &dispatcher, ToolExecutionContext::default(), &mut guard)
             .await
             .expect("get_time should be dispatchable");
     assert_eq!(result.tool, "get_time");
@@ -260,8 +262,9 @@ async fn mock_voice_cycle_drives_stt_then_llm_then_streaming_tts_then_tool_audit
     assert!(llm_output.contains("get_time"));
 
     // Tool dispatch — exactly what voice_cycle does on the LLM output.
+    let mut guard = LoopGuard::new(LoopGuardConfig::default());
     let tool_result =
-        try_tool_call_with_context(&llm_output, &dispatcher, ToolExecutionContext::default())
+        try_tool_call_with_context(&llm_output, &dispatcher, ToolExecutionContext::default(), &mut guard)
             .await
             .expect("LLM output should parse as a tool call");
     assert_eq!(tool_result.tool, "get_time");


### PR DESCRIPTION
Closes #349
## Summary

Wire the `LoopGuard` circuit-breaker and `Tainted<T>` IFC layer into every live tool dispatch path. Both modules were fully implemented and unit-tested but never instantiated in production code, so the configured call-count limits and taint sink policies had zero runtime effect. Fixes the dead-code security gap reported in ISSUE.md (mirrors #286, #181, #196).

## Changes

- `tools/dispatch.rs` — `execute_with_context` now accepts `&mut LoopGuard`; calls `guard.check(name, args_json)` before any tool runs; `LoopCheck::Block` short-circuits with a `ToolResult` error visible to the LLM; `LoopCheck::Warn` emits a tracing warning. After dispatch, `Network`-class results are tagged `TaintLabel::ExternalNetwork` and verified against `TaintSink::DisplayToUser`. `execute()` and `confirm_pending_home_action()` create local default guards.
- `tools/parser.rs` — `try_tool_call_with_context` accepts and threads `&mut LoopGuard` through to `execute_with_context`; `try_tool_call` creates a default guard.
- `server.rs` — `handle_chat_stream`, `process_chat_turn`, and `handle_openai_chat` each create one `LoopGuard` per HTTP turn and thread it through both the quick-tool fast path and LLM-driven dispatch.
- `repl.rs` — creates a fresh `LoopGuard` per user input line; threads through both dispatch paths.
- `voice_loop.rs` — `handle_quick_tool_for_voice` accepts `&mut LoopGuard`; `process_transcript` creates a per-cycle guard and threads it through the quick-tool and LLM-driven paths; continuous follow-up utterances in `run_with_wakeword` get their own fresh guard.
- Integration tests (`voice_loop_integration.rs`, `tool_gate_integration_test.rs`) updated with fresh per-call guards.
- Unit tests in `dispatch.rs` refactored to use a local `exec_ctx` helper so existing behaviour assertions are unchanged.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

All changes are pure Rust in the tool dispatch pipeline — no ALSA, no Home Assistant, no GPU path touched. Verification was done by code audit against the five entry points named in the issue and by confirming the grep commands from the issue now produce non-empty output:

```bash
# LoopGuard now has callers outside its own module
grep -rn "LoopGuard\|LoopCheck\|loop_guard" \
  crates/genie-core/src/ --include="*.rs" \
  | grep -v "security/loop_guard.rs" \
  | grep -v "security/mod.rs"
# → non-empty: dispatch.rs, parser.rs, server.rs, repl.rs, voice_loop.rs

# Tainted / TaintLabel / TaintSink now have callers
grep -rn "Tainted\|TaintLabel\|TaintSink" \
  crates/genie-core/src/ --include="*.rs" \
  | grep -v "security/taint.rs" \
  | grep -v "security/mod.rs"
# → non-empty: dispatch.rs
```

Existing unit and integration tests for origin ACLs, rate limiting, confirmation tokens, and audit logging continue to pass unchanged — the new `LoopGuard` default config (max_repeat_calls=3, max_total_calls=20, max_pingpong_cycles=3) does not trip on any single-dispatch test.

### What I observed

- All five entry points (`handle_chat_stream`, `process_chat_turn`, `repl::run`, `voice_loop::process_transcript`, and the OpenAI bridge) now hold a live `LoopGuard` for the duration of each turn.
- A tool call that would previously repeat silently now returns `ToolResult { success: false, output: "Tool call blocked by loop guard: ..." }` to the LLM after the configured threshold.
- `Network`-class tool results carry a `TaintLabel::ExternalNetwork` tag; the `DisplayToUser` sink check runs at the dispatch boundary on every weather or web-search response.
- The absence of any `loop_guard: blocked` or `taint: sink violation` log line in a clean session confirms the guards are live but not tripping on normal traffic.

## Test plan

1. Run `cargo test --workspace --locked --all-targets` — all existing tests must pass.
2. Send the same tool call (e.g. `{"tool":"get_time","arguments":{}}`) from the REPL or `/api/chat` more than 3 times in a single turn by crafting a looping conversation history. Confirm the 4th dispatch returns `"Tool call blocked by loop guard"` in the response.
3. Send 21 distinct tool calls in a single turn. Confirm the 21st is blocked by the global circuit breaker.
4. Observe `journalctl -u genie-core | grep loop_guard` — the warn line should appear on the 3rd repeat, the block line on the 4th.

## Notes for reviewers

- The taint `DisplayToUser` check on `Network` results is currently a no-op (ExternalNetwork is not in the blocked set for that sink) — it is wired in to catch future `Secret`-carrying network results at the boundary rather than to block today's weather/search output. The complete fix (items 4 and 5 from the issue) — per-origin `LoopGuardConfig` overrides and `TaintSink::NetworkSend` enforcement on web-search query args — is deferred to a follow-up.
- `confirm_pending_home_action` re-entry gets a fresh default guard (not the turn's guard) because confirmation is a single pre-approved action, not an LLM-driven turn; double-charging the per-turn counter would be wrong.
- The Telegram path is covered transitively: it routes through `/api/chat` → `process_chat_turn`, which now holds the guard.
