### PR TITLE
[Bug]: API home control skips confirmation for Medium-risk actions

### DIFF
--- a/crates/genie-core/src/tools/home.rs
+++ b/crates/genie-core/src/tools/home.rs
@@ -74,7 +74,7 @@ pub async fn control(
 
     if !confirmed
         && matches!(request_origin, RequestOrigin::Api)
-        && matches!(policy.risk, crate::ha::ActionRisk::High)
+        && !matches!(policy.risk, crate::ha::ActionRisk::Low)
     {
         return Ok(ControlOutcome::ConfirmationRequired {
             reason: format!(


### PR DESCRIPTION
## Summary

Closes #353.

Require local confirmation for API home control when policy risk is not `Low`, matching voice and Telegram behavior.

## Changes

- `crates/genie-core/src/tools/home.rs`: API origin uses `!ActionRisk::Low` instead of `High` only.

## Real Behavior Proof

- [x] Medium-risk API call without `confirmed` returns `ConfirmationRequired` instead of executing.

### What I ran

```bash
cargo test -p genie-core --lib tools::home -- --nocapture
```

### What I observed

API origin now blocks non-Low risk until confirmed.

## Test plan

- [ ] `cargo test -p genie-core`
