### PR TITLE
[Bug]: Chat export misparses id when URL has extra query parameters

### DIFF
--- a/crates/genie-core/src/server.rs
+++ b/crates/genie-core/src/server.rs
@@ -312,6 +312,16 @@ impl RequestRoute<'_> {
     }
 }
 
+fn export_conv_id_from_path(path: &str) -> &str {
+    let query = path.split('?').nth(1).unwrap_or("");
+    for part in query.split('&') {
+        if let Some(value) = part.strip_prefix("id=") {
+            return value;
+        }
+    }
+    ""
+}
+
 fn classify_route<'a>(method: &str, path: &'a str) -> RequestRoute<'a> {
     match (method, path) {
         ("GET", "/" | "/index.html") => RequestRoute::Root,
@@ -337,7 +347,7 @@ fn classify_route<'a>(method: &str, path: &'a str) -> RequestRoute<'a> {
         ("GET", "/v1/models") => RequestRoute::Models,
         ("OPTIONS", _) => RequestRoute::Options,
         ("GET", path) if path.starts_with("/api/chat/export") => {
-            RequestRoute::Export(path.split("id=").nth(1).unwrap_or(""))
+            RequestRoute::Export(export_conv_id_from_path(path))
         }
         _ => RequestRoute::NotFound,
     }


### PR DESCRIPTION
## Summary

Closes #357.

Parse the `id` query parameter from `/api/chat/export` instead of splitting on the substring `id=`.

## Changes

- `crates/genie-core/src/server.rs`: `export_conv_id_from_path` helper.

## Real Behavior Proof

- [x] `GET /api/chat/export?id=conv-1&download=1` resolves `conv-1`.

## Test plan

- [ ] `cargo test -p genie-core`
