### PR TITLE
fix(tools): validate set_timer seconds at execution boundary

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -63,6 +63,27 @@ fn parse_home_status_args(args: &serde_json::Value) -> Result<&str> {
         .ok_or_else(|| anyhow::anyhow!("home_status requires non-empty string argument 'entity'"))
 }
 
+fn parse_set_timer_args(args: &serde_json::Value) -> Result<(u64, &str)> {
+    let seconds = match args.get("seconds") {
+        Some(value) => value
+            .as_u64()
+            .filter(|seconds| *seconds >= 1)
+            .ok_or_else(|| {
+                if value.as_u64() == Some(0) {
+                    anyhow::anyhow!("set_timer seconds must be at least 1")
+                } else {
+                    anyhow::anyhow!("set_timer requires integer argument 'seconds'")
+                }
+            })?,
+        None => anyhow::bail!("set_timer requires integer argument 'seconds'"),
+    };
+    let label = args
+        .get("label")
+        .and_then(|v| v.as_str())
+        .unwrap_or("timer");
+    Ok((seconds, label))
+}
+
 /// Tool definition for LLM function calling.
 ///
 /// These are sent to the configured LLM backend as part of the system prompt or
@@ -941,11 +962,7 @@ impl ToolDispatcher {
     }
 
     fn exec_set_timer(&self, args: &serde_json::Value) -> Result<String> {
-        let seconds = args.get("seconds").and_then(|v| v.as_u64()).unwrap_or(60);
-        let label = args
-            .get("label")
-            .and_then(|v| v.as_str())
-            .unwrap_or("timer");
+        let (seconds, label) = parse_set_timer_args(args)?;
         self.timers
             .set(seconds, label)
             .map_err(|e| anyhow::anyhow!(e))?;

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -602,3 +602,72 @@ async fn home_status_rejects_invalid_arguments_and_audits() {
         assert_eq!(event["success"], false);
     }
 }
+
+#[tokio::test]
+async fn set_timer_rejects_invalid_arguments_and_audits() {
+    let paths = TestAuditPaths::new();
+    let dispatcher = paths.dispatcher(
+        None,
+        ToolPolicyConfig::default(),
+        ActuationSafetyConfig::default(),
+    );
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Dashboard,
+        ..ToolExecutionContext::default()
+    };
+
+    let invalid_calls = [
+        (
+            serde_json::json!({}),
+            "set_timer requires integer argument 'seconds'",
+        ),
+        (
+            serde_json::json!({"seconds": 0}),
+            "set_timer seconds must be at least 1",
+        ),
+        (
+            serde_json::json!({"seconds": -1}),
+            "set_timer requires integer argument 'seconds'",
+        ),
+        (
+            serde_json::json!({"seconds": "five"}),
+            "set_timer requires integer argument 'seconds'",
+        ),
+    ];
+    let expected_audit_count = invalid_calls.len();
+
+    for (arguments, expected_snippet) in &invalid_calls {
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "set_timer".into(),
+                    arguments: arguments.clone(),
+                },
+                ctx,
+            )
+            .await;
+
+        assert!(
+            !result.success,
+            "expected schema rejection, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains(expected_snippet),
+            "expected output to contain {expected_snippet:?}, got: {}",
+            result.output
+        );
+    }
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(
+        events.len(),
+        expected_audit_count,
+        "each rejected call must be tool-audited"
+    );
+    for event in &events {
+        assert_eq!(event["tool"], "set_timer");
+        assert_eq!(event["origin"], "dashboard");
+        assert_eq!(event["success"], false);
+    }
+}


### PR DESCRIPTION
Fixes #359

## Summary

`set_timer` marked `seconds` as required in `ToolDef` but `exec_set_timer` silently defaulted missing values to 60. This PR adds `parse_set_timer_args()` and rejects missing, zero, negative, or wrong-type `seconds` before any timer is registered.

## Changes

- Add `parse_set_timer_args()` with positive integer `seconds` validation.
- Use parser in `exec_set_timer()`; optional `label` still defaults to `"timer"`.
- Add `set_timer_rejects_invalid_arguments_and_audits` integration test.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On x86_64 Linux dev host (`laptop` profile), branch `fix/issue-359-set-timer-schema-validation`:

```bash
cd genie-claw
cargo fmt -p genie-core
cargo test -p genie-core --test tool_gate_integration_test set_timer_rejects_invalid_arguments_and_audits
cargo test -p genie-core --test tool_gate_integration_test
cargo clippy -p genie-core -- -D warnings
```

### What I observed

- `set_timer_rejects_invalid_arguments_and_audits` passes for `{}`, `seconds: 0`, `-1`, and `"five"`.
- Full `tool_gate_integration_test` suite passes (8/8).
- Clippy clean on `genie-core`.

Jetson validation gap: schema enforcement verified via integration tests on dev host.

## Test plan

- [x] `cargo test -p genie-core --test tool_gate_integration_test set_timer_rejects_invalid_arguments_and_audits`
- [x] `cargo test -p genie-core --test tool_gate_integration_test`
- [x] `cargo clippy -p genie-core -- -D warnings`

## Notes for reviewers

M1 typed-tool reliability follow-up to closed #330 / #344.
