### PR TITLE
fix(tools): validate memory_recall query at execution boundary

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -63,6 +63,31 @@ fn parse_home_status_args(args: &serde_json::Value) -> Result<&str> {
         .ok_or_else(|| anyhow::anyhow!("home_status requires non-empty string argument 'entity'"))
 }
 
+fn parse_memory_recall_query(args: &serde_json::Value) -> Result<String> {
+    let raw = args
+        .get("query")
+        .or_else(|| args.get("topic"))
+        .or_else(|| args.get("what"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!("memory_recall requires non-empty string argument 'query'")
+        })?;
+    Ok(normalize_memory_recall_query(raw))
+}
+
+fn normalize_memory_recall_query(raw: &str) -> String {
+    let lower = raw.to_lowercase();
+    if lower.contains("my name") || lower == "name" || lower.contains("who am i") {
+        "name".into()
+    } else if lower.contains("about me") || lower == "me" || lower == "user" {
+        "user".into()
+    } else {
+        raw.to_string()
+    }
+}
+
 /// Tool definition for LLM function calling.
 ///
 /// These are sent to the configured LLM backend as part of the system prompt or
@@ -957,6 +982,10 @@ impl ToolDispatcher {
         args: &serde_json::Value,
         exec_ctx: ToolExecutionContext,
     ) -> Result<String> {
+        let query = parse_memory_recall_query(args)?;
+        let read_context = exec_ctx
+            .memory_read_context
+            .unwrap_or_else(|| memory_read_context(args));
         let mem = self
             .memory
             .as_ref()
@@ -964,32 +993,30 @@ impl ToolDispatcher {
         let mem = mem
             .lock()
             .map_err(|e| anyhow::anyhow!("memory lock: {}", e))?;
-        let query = memory_query(args);
-        let read_context = exec_ctx
-            .memory_read_context
-            .unwrap_or_else(|| memory_read_context(args));
+        let query_ref = query.as_str();
 
-        if let Some(answer) = mem.structured_household_answer(query)? {
+        if let Some(answer) = mem.structured_household_answer(query_ref)? {
             return Ok(answer);
         }
 
-        if let Some(role) = household_role_query(query) {
+        if let Some(role) = household_role_query(query_ref) {
             let profiles = mem.household_profiles_by_role(role)?;
             if !profiles.is_empty() {
                 return Ok(format_household_role_answer(role, &profiles));
             }
         }
 
-        let results = crate::memory::recall::recall_with_context(&mem, query, 10, read_context)?;
+        let results =
+            crate::memory::recall::recall_with_context(&mem, query_ref, 10, read_context)?;
         if results.is_empty() {
-            return Ok(match query {
+            return Ok(match query_ref {
                 "name" => "I don't remember your name yet.".to_string(),
                 "user" => "I don't remember anything about you yet.".to_string(),
                 other => format!("I don't remember anything about {} yet.", other),
             });
         }
 
-        if query == "name"
+        if query_ref == "name"
             && let Some(entry) = results
                 .iter()
                 .find(|entry| entry.entry.content.to_lowercase().contains("name is "))
@@ -1000,7 +1027,7 @@ impl ToolDispatcher {
                 .replace("User's name is ", "Your name is "));
         }
 
-        if query == "user" || query == "me" {
+        if query_ref == "user" || query_ref == "me" {
             let items = results
                 .iter()
                 .take(3)
@@ -1404,24 +1431,6 @@ fn actuation_rate_limit(config: &ActuationSafetyConfig, origin: RequestOrigin) -
         .find(|(key, _)| key.trim().eq_ignore_ascii_case(origin.as_policy_key()))
         .map(|(_, limit)| *limit)
         .unwrap_or(config.max_actions_per_minute)
-}
-
-fn memory_query(args: &serde_json::Value) -> &str {
-    let raw = args
-        .get("query")
-        .or_else(|| args.get("topic"))
-        .or_else(|| args.get("what"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("user");
-
-    let lower = raw.to_lowercase();
-    if lower.contains("my name") || lower == "name" || lower.contains("who am i") {
-        "name"
-    } else if lower.contains("about me") || lower == "me" || lower == "user" {
-        "user"
-    } else {
-        raw
-    }
 }
 
 fn household_role_query(query: &str) -> Option<&'static str> {
@@ -2653,6 +2662,28 @@ mod tests {
             .unwrap();
 
         assert_eq!(output, "Your name is Jared");
+    }
+
+    #[test]
+    fn memory_recall_accepts_topic_alias_after_schema_validation() {
+        let db = std::env::temp_dir().join(format!(
+            "memory-recall-topic-alias-test-{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db);
+        let memory = crate::memory::Memory::open(&db).unwrap();
+        memory.store("preference", "User likes jazz music").unwrap();
+        let dispatcher =
+            ToolDispatcher::new(None).with_memory(Arc::new(std::sync::Mutex::new(memory)));
+
+        let output = dispatcher
+            .exec_memory_recall(
+                &serde_json::json!({"topic": "jazz"}),
+                ToolExecutionContext::default(),
+            )
+            .unwrap();
+
+        assert!(output.contains("jazz"));
     }
 
     #[test]

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -602,3 +602,73 @@ async fn home_status_rejects_invalid_arguments_and_audits() {
         assert_eq!(event["success"], false);
     }
 }
+
+#[tokio::test]
+async fn memory_recall_rejects_invalid_arguments_and_audits() {
+    let paths = TestAuditPaths::new();
+    let memory_path = paths.data_dir.join("memory.db");
+    let memory = genie_core::memory::Memory::open(&memory_path).unwrap();
+    memory.store("identity", "User's name is Jared").unwrap();
+    let dispatcher = paths
+        .dispatcher(
+            None,
+            ToolPolicyConfig::default(),
+            ActuationSafetyConfig::default(),
+        )
+        .with_memory(Arc::new(Mutex::new(memory)));
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Dashboard,
+        ..ToolExecutionContext::default()
+    };
+
+    let invalid_calls = [
+        (
+            serde_json::json!({}),
+            "memory_recall requires non-empty string argument 'query'",
+        ),
+        (
+            serde_json::json!({"query": ""}),
+            "memory_recall requires non-empty string argument 'query'",
+        ),
+        (
+            serde_json::json!({"query": 123}),
+            "memory_recall requires non-empty string argument 'query'",
+        ),
+    ];
+    let expected_audit_count = invalid_calls.len();
+
+    for (arguments, expected_snippet) in &invalid_calls {
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "memory_recall".into(),
+                    arguments: arguments.clone(),
+                },
+                ctx,
+            )
+            .await;
+
+        assert!(
+            !result.success,
+            "expected schema rejection, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains(expected_snippet),
+            "expected output to contain {expected_snippet:?}, got: {}",
+            result.output
+        );
+    }
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(
+        events.len(),
+        expected_audit_count,
+        "each rejected call must be tool-audited"
+    );
+    for event in &events {
+        assert_eq!(event["tool"], "memory_recall");
+        assert_eq!(event["origin"], "dashboard");
+        assert_eq!(event["success"], false);
+    }
+}


### PR DESCRIPTION
Fixes #361

## Summary

`memory_recall` marked `query` as required in `ToolDef`, but missing arguments silently defaulted to broad `"user"` recall via `memory_query()`. This PR adds `parse_memory_recall_query()` with non-empty string validation (including legacy `topic`/`what` aliases) and rejects invalid calls before memory lookup.

## Changes

- Add `parse_memory_recall_query()` and `normalize_memory_recall_query()`.
- Validate query before locking memory in `exec_memory_recall()`.
- Remove silent `unwrap_or("user")` default.
- Add `memory_recall_rejects_invalid_arguments_and_audits` integration test.
- Add `memory_recall_accepts_topic_alias_after_schema_validation` unit test.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On x86_64 Linux dev host (`laptop` profile), branch `fix/issue-361-memory-recall-query-validation`:

```bash
cd genie-claw
cargo fmt -p genie-core
cargo test -p genie-core memory_recall
cargo test -p genie-core --test tool_gate_integration_test memory_recall_rejects_invalid_arguments_and_audits
cargo test -p genie-core --test tool_gate_integration_test
cargo clippy -p genie-core -- -D warnings
```

### What I observed

- `memory_recall_rejects_invalid_arguments_and_audits` passes for `{}`, empty query, and non-string query.
- Existing `memory_recall_*` unit tests pass; `topic` alias still works after validation.
- Full `tool_gate_integration_test` suite passes; clippy clean.

Jetson validation gap: schema enforcement verified via unit/integration tests on dev host.

## Test plan

- [x] `cargo test -p genie-core memory_recall`
- [x] `cargo test -p genie-core --test tool_gate_integration_test memory_recall_rejects_invalid_arguments_and_audits`
- [x] `cargo test -p genie-core --test tool_gate_integration_test`
- [x] `cargo clippy -p genie-core -- -D warnings`

## Notes for reviewers

M1 typed-tool + memory retrieval fix for #361. Explicit `"user"` / `"about me"` queries still normalize to broad recall; only missing/invalid args are rejected.
