### PR TITLE
fix(genie-ctl): surface agent_harness in status output

### DIFF
--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -925,6 +925,11 @@ async fn cmd_status() -> Result<()> {
             if let Some(sha) = data.get("system_prompt_sha").and_then(|v| v.as_str()) {
                 println!("Prompt:    {}", sha);
             }
+            if let Some(harness) = data.get("agent_harness")
+                && let Some(summary) = format_agent_harness_status(harness)
+            {
+                println!("Harness:   {}", summary);
+            }
         }
         Err(_) => println!("Core:      offline"),
     }
@@ -1742,6 +1747,33 @@ fn bfcl_llm_tool_catalog(cases: &[genie_core::eval::bfcl::BfclCase]) -> Vec<Stri
     }
 
     rows
+}
+
+fn format_agent_harness_status(harness: &serde_json::Value) -> Option<String> {
+    let pass = harness.get("pass")?.as_bool()?;
+    if pass {
+        return Some("pass".to_string());
+    }
+
+    let failed_checks: Vec<String> = harness
+        .get("checks")
+        .and_then(|checks| checks.as_array())
+        .into_iter()
+        .flatten()
+        .filter(|check| check.get("pass").and_then(|v| v.as_bool()) == Some(false))
+        .filter_map(|check| {
+            check
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .collect();
+
+    if failed_checks.is_empty() {
+        Some("FAIL".to_string())
+    } else {
+        Some(format!("FAIL ({})", failed_checks.join(", ")))
+    }
 }
 
 fn format_score_rate(rate: f64) -> String {
@@ -3256,5 +3288,36 @@ mod tests {
         let removed = remove_skill("hello_world", &skills_dir).unwrap();
         assert_eq!(removed.file_name().unwrap().to_string_lossy(), "hello.so");
         assert!(load_installed_skills(&skills_dir).unwrap().is_empty());
+    }
+
+    #[test]
+    fn format_agent_harness_status_reports_pass() {
+        let harness = serde_json::json!({
+            "pass": true,
+            "checks": [
+                {"name": "memory_hydration_budget", "pass": true, "detail": "ok"}
+            ]
+        });
+
+        assert_eq!(
+            format_agent_harness_status(&harness).as_deref(),
+            Some("pass")
+        );
+    }
+
+    #[test]
+    fn format_agent_harness_status_lists_failed_checks() {
+        let harness = serde_json::json!({
+            "pass": false,
+            "checks": [
+                {"name": "memory_hydration_budget", "pass": false, "detail": "over budget"},
+                {"name": "tool_manifest_budget", "pass": true, "detail": "ok"}
+            ]
+        });
+
+        assert_eq!(
+            format_agent_harness_status(&harness).as_deref(),
+            Some("FAIL (memory_hydration_budget)")
+        );
     }
 }


### PR DESCRIPTION
Fixes #363

## Summary

`/api/health` exposes `agent_harness` after #341, but `genie-ctl status` only printed `system_prompt_sha`. This PR surfaces harness pass/fail (and failed check names) from the existing health JSON without duplicating harness evaluation in `genie-ctl`.

## Changes

- Add `format_agent_harness_status()` to summarize pass or failed check names.
- Print `Harness:` line in `cmd_status()` when core health is available.
- Add unit tests for pass and fail formatting.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On x86_64 Linux dev host (`laptop` profile), branch `fix/issue-363-genie-ctl-harness-status`:

```bash
cd genie-claw
cargo fmt -p genie-ctl
cargo test -p genie-ctl format_agent_harness_status
cargo clippy -p genie-ctl -- -D warnings
```

### What I observed

- `format_agent_harness_status_reports_pass` and `format_agent_harness_status_lists_failed_checks` pass.
- Clippy clean on `genie-ctl`.

Jetson validation gap: display-only CLI change; verified via unit tests on dev host.

## Test plan

- [x] `cargo test -p genie-ctl format_agent_harness_status`
- [x] `cargo clippy -p genie-ctl -- -D warnings`

## Notes for reviewers

M1 operator visibility for #341 harness contract. Reads `/api/health` only — no duplicate harness logic.
