### PR TITLE
feat(tools): enforce single tool-call gate with confirmation and per-tool rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,22 @@
 
 ## Unreleased
 
-- Nothing yet.
+- **Tool-call gate: single chokepoint, confirmation, per-tool rate limits**
+  (#22): every tool invocation now passes one enforced gate. The voice
+  `web_search` quick-path (which renders its own speech output) and the
+  `voice::VoiceAssistant` / `voice::pipeline` fall-back paths no longer reach a
+  tool or provider directly with a defaulted origin — they flow through the
+  dispatcher gate as `RequestOrigin::Voice`, so per-origin ACLs, rate limits,
+  and the audit trail apply uniformly. Two new `[core.tool_policy]` mechanisms:
+  `max_actions_per_minute_by_tool` (per-tool sliding-window limit, `"*"`
+  catch-all) bounces a fast loop off the limit after N calls; and
+  `requires_confirmation_tools` + `confirmation_ttl_secs` require a sensitive
+  tool to be requested twice with the same arguments inside the TTL window
+  (first call returns a pending response with a stable token, the confirming
+  call passes `confirmed = true`; a confirming leg outside the window errors).
+  Every gate decision (`executed`, `denied_policy`, `rate_limited`,
+  `pending_confirmation`, `confirmation_expired`) is recorded on the tool-audit
+  line.
 
 ## 1.0.0-alpha.10 - 2026-05-29
 

--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -505,6 +505,23 @@ pub struct ToolPolicyConfig {
     /// Tools blocked by origin. Deny rules override allow rules.
     #[serde(default)]
     pub denied_tools_by_origin: HashMap<String, Vec<String>>,
+
+    /// Per-tool sliding-window rate limits, e.g. `{ play_media = 10 }`. A `"*"`
+    /// key applies to any tool without a more specific entry. Tools absent from
+    /// the map are unlimited. Enforced at the dispatcher gate for every origin.
+    #[serde(default)]
+    pub max_actions_per_minute_by_tool: HashMap<String, usize>,
+
+    /// Sensitive tools that must be requested twice with the same arguments
+    /// within `confirmation_ttl_secs` before they execute. A `"*"` entry makes
+    /// every tool confirmable. Empty by default (no tool requires confirmation).
+    #[serde(default)]
+    pub requires_confirmation_tools: Vec<String>,
+
+    /// Window, in seconds, in which the confirming leg of a sensitive tool call
+    /// must arrive after the first leg.
+    #[serde(default = "defaults::tool_confirmation_ttl_secs")]
+    pub confirmation_ttl_secs: u64,
 }
 
 impl Default for ToolPolicyConfig {
@@ -513,6 +530,9 @@ impl Default for ToolPolicyConfig {
             enabled: defaults::tool_policy_enabled(),
             allowed_tools_by_origin: HashMap::new(),
             denied_tools_by_origin: HashMap::new(),
+            max_actions_per_minute_by_tool: HashMap::new(),
+            requires_confirmation_tools: Vec::new(),
+            confirmation_ttl_secs: defaults::tool_confirmation_ttl_secs(),
         }
     }
 }
@@ -2405,6 +2425,42 @@ signature_key_dir = "/custom/keys"
         assert!(config.core.tool_policy.enabled);
         assert!(config.core.tool_policy.allowed_tools_by_origin.is_empty());
         assert!(config.core.tool_policy.denied_tools_by_origin.is_empty());
+        assert!(
+            config
+                .core
+                .tool_policy
+                .max_actions_per_minute_by_tool
+                .is_empty()
+        );
+        assert!(
+            config
+                .core
+                .tool_policy
+                .requires_confirmation_tools
+                .is_empty()
+        );
+        assert_eq!(config.core.tool_policy.confirmation_ttl_secs, 120);
+    }
+
+    #[test]
+    fn tool_policy_gate_extensions_parse() {
+        let config: ToolPolicyConfig = toml::from_str(
+            r#"
+enabled = true
+max_actions_per_minute_by_tool = { play_media = 10, "*" = 30 }
+requires_confirmation_tools = ["home_control", "play_media"]
+confirmation_ttl_secs = 45
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.max_actions_per_minute_by_tool["play_media"], 10);
+        assert_eq!(config.max_actions_per_minute_by_tool["*"], 30);
+        assert_eq!(
+            config.requires_confirmation_tools,
+            vec!["home_control", "play_media"]
+        );
+        assert_eq!(config.confirmation_ttl_secs, 45);
     }
 
     #[test]
@@ -2770,6 +2826,9 @@ mod defaults {
     }
     pub fn tool_policy_enabled() -> bool {
         true
+    }
+    pub fn tool_confirmation_ttl_secs() -> u64 {
+        120
     }
     pub fn actuation_safety_enabled() -> bool {
         true

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -141,6 +141,8 @@ pub struct ToolDispatcher {
     confirmations: Arc<ConfirmationManager>,
     action_ledger: Arc<ActionLedger>,
     actuation_rate_limiter: Arc<ActuationRateLimiter>,
+    tool_rate_limiter: Arc<ToolRateLimiter>,
+    tool_confirmations: Arc<ToolConfirmationGate>,
     audit_logger: AuditLogger,
     tool_audit_logger: ToolAuditLogger,
     pub(crate) timers: timer::TimerManager,
@@ -151,6 +153,73 @@ struct ActuationRateLimiter {
     attempts: Mutex<HashMap<RequestOrigin, VecDeque<u64>>>,
 }
 
+/// Per-tool sliding-window rate limiter for the dispatcher gate. Unlike
+/// [`ActuationRateLimiter`] (which buckets physical home actions by origin),
+/// this bounds *any* tool by name via `tool_policy.max_actions_per_minute_by_tool`
+/// so a fast loop (voice, skill, or LLM) bounces off the limit after N calls.
+#[derive(Debug, Default)]
+struct ToolRateLimiter {
+    attempts: Mutex<HashMap<String, VecDeque<u64>>>,
+}
+
+/// Two-step confirmation gate for sensitive tools (issue #22).
+///
+/// A tool listed in `tool_policy.requires_confirmation_tools` must be requested
+/// twice with the same `(origin, tool, arguments)` within a TTL window: the
+/// first leg (`confirmed = false`) records the request and returns a stable
+/// token asking the caller to repeat it; the confirming leg (`confirmed = true`)
+/// only executes when a matching first leg is still inside the window, otherwise
+/// it reports the confirmation as expired.
+#[derive(Debug, Default)]
+struct ToolConfirmationGate {
+    /// Map of `(origin, tool, args)` key -> first-seen epoch millis.
+    pending: Mutex<HashMap<String, u64>>,
+}
+
+/// Pending first legs are retained for an hour so a late confirming leg reports
+/// "expired" rather than silently restarting confirmation, while still bounding
+/// memory if a first leg is never followed up.
+const TOOL_CONFIRMATION_RETENTION_MS: u64 = 60 * 60 * 1000;
+
+/// Hard cap on tracked first legs; the oldest is evicted past this so a flood of
+/// distinct sensitive requests cannot grow the map without bound.
+const MAX_TOOL_CONFIRMATIONS: usize = 256;
+
+enum ToolConfirmDecision {
+    /// First leg recorded; caller must repeat the same request to proceed.
+    Pending { token: String },
+    /// A matching first leg is still inside the TTL window — proceed.
+    Confirmed,
+    /// The confirming leg arrived with no live first leg (never requested, or
+    /// the TTL window elapsed).
+    Expired,
+}
+
+/// How the gate resolved a tool call, recorded on every tool-audit line so the
+/// evidence trail distinguishes an execution from each refusal class.
+#[derive(Debug, Clone, Copy)]
+enum GateDecision {
+    Executed,
+    Error,
+    DeniedPolicy,
+    RateLimited,
+    PendingConfirmation,
+    ConfirmationExpired,
+}
+
+impl GateDecision {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Executed => "executed",
+            Self::Error => "error",
+            Self::DeniedPolicy => "denied_policy",
+            Self::RateLimited => "rate_limited",
+            Self::PendingConfirmation => "pending_confirmation",
+            Self::ConfirmationExpired => "confirmation_expired",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct ToolAuditEvent {
     ts_ms: u64,
@@ -158,6 +227,10 @@ struct ToolAuditEvent {
     action_class: ToolActionClass,
     origin: RequestOrigin,
     success: bool,
+    /// Which gate branch produced this line: `executed`, `error`,
+    /// `denied_policy`, `rate_limited`, `pending_confirmation`, or
+    /// `confirmation_expired`.
+    decision: &'static str,
     duration_ms: u64,
     argument_keys: Vec<String>,
     output_chars: usize,
@@ -212,6 +285,8 @@ impl ToolDispatcher {
             confirmations: Arc::new(ConfirmationManager::default()),
             action_ledger: Arc::new(ActionLedger::default()),
             actuation_rate_limiter: Arc::new(ActuationRateLimiter::default()),
+            tool_rate_limiter: Arc::new(ToolRateLimiter::default()),
+            tool_confirmations: Arc::new(ToolConfirmationGate::default()),
             audit_logger: AuditLogger::disabled(),
             tool_audit_logger: ToolAuditLogger::default(),
             timers: timer::TimerManager::new(),
@@ -282,6 +357,9 @@ impl ToolDispatcher {
                 "enabled": self.tool_policy.enabled,
                 "allowed_tools_by_origin": &self.tool_policy.allowed_tools_by_origin,
                 "denied_tools_by_origin": &self.tool_policy.denied_tools_by_origin,
+                "max_actions_per_minute_by_tool": &self.tool_policy.max_actions_per_minute_by_tool,
+                "requires_confirmation_tools": &self.tool_policy.requires_confirmation_tools,
+                "confirmation_ttl_secs": self.tool_policy.confirmation_ttl_secs,
             },
             "actuation_safety": {
                 "enabled": self.actuation_safety.enabled,
@@ -571,17 +649,12 @@ impl ToolDispatcher {
     ) -> ToolResult {
         let started = Instant::now();
         let action_class = tool_action_class(&call.name);
-        if let Err(err) =
-            tool_origin_allowed(&self.tool_policy, exec_ctx.request_origin, &call.name)
-        {
-            let tool_result = ToolResult {
-                tool: call.name.clone(),
-                action_class,
-                success: false,
-                output: format!("Tool blocked by origin policy: {err}"),
-            };
-            self.audit_tool_call(call, exec_ctx, started, &tool_result);
-            return tool_result;
+
+        // Single chokepoint: every tool call passes the gate (per-origin ACLs,
+        // two-step confirmation for sensitive tools, per-tool rate limits)
+        // before any tool body runs. Refusals are already audited.
+        if let Some(rejected) = self.run_gate(call, exec_ctx, started) {
+            return rejected;
         }
 
         let result = match call.name.as_str() {
@@ -618,17 +691,164 @@ impl ToolDispatcher {
             },
         };
 
-        self.audit_tool_call(call, exec_ctx, started, &tool_result);
+        let decision = if tool_result.success {
+            GateDecision::Executed
+        } else {
+            GateDecision::Error
+        };
+        self.audit_gate_decision(call, exec_ctx, started, &tool_result, decision);
 
         tool_result
     }
 
-    fn audit_tool_call(
+    /// Run the tool-call gate without dispatching: per-origin ACLs, two-step
+    /// confirmation for sensitive tools, then per-tool rate limits. Returns
+    /// `Some(rejection)` (already written to the tool-audit trail) when the gate
+    /// refuses, or `None` when the call may proceed. The caller audits the
+    /// eventual outcome of an allowed call.
+    fn run_gate(
+        &self,
+        call: &ToolCall,
+        exec_ctx: ToolExecutionContext,
+        started: Instant,
+    ) -> Option<ToolResult> {
+        let action_class = tool_action_class(&call.name);
+
+        // 1. Per-origin allow/deny ACLs (wildcards supported; deny wins).
+        if let Err(err) =
+            tool_origin_allowed(&self.tool_policy, exec_ctx.request_origin, &call.name)
+        {
+            let result = ToolResult {
+                tool: call.name.clone(),
+                action_class,
+                success: false,
+                output: format!("Tool blocked by origin policy: {err}"),
+            };
+            self.audit_gate_decision(call, exec_ctx, started, &result, GateDecision::DeniedPolicy);
+            return Some(result);
+        }
+
+        // 2. Two-step confirmation for configured sensitive tools. Skipped for
+        //    pre-confirmed re-entries of tools NOT in the list (e.g. the home
+        //    actuation confirm flow, which carries its own confirmation deeper).
+        if tool_requires_confirmation(&self.tool_policy, &call.name) {
+            let ttl_ms = self.tool_policy.confirmation_ttl_secs.saturating_mul(1000);
+            match self.tool_confirmations.evaluate(
+                exec_ctx.request_origin,
+                &call.name,
+                &call.arguments,
+                ttl_ms,
+                exec_ctx.confirmed,
+            ) {
+                ToolConfirmDecision::Pending { token } => {
+                    let result = ToolResult {
+                        tool: call.name.clone(),
+                        action_class,
+                        success: true,
+                        output: format!(
+                            "Confirmation required before I run '{}'. Re-issue the same request within {}s to proceed (confirmation token {}).",
+                            call.name, self.tool_policy.confirmation_ttl_secs, token
+                        ),
+                    };
+                    self.audit_gate_decision(
+                        call,
+                        exec_ctx,
+                        started,
+                        &result,
+                        GateDecision::PendingConfirmation,
+                    );
+                    return Some(result);
+                }
+                ToolConfirmDecision::Expired => {
+                    let result = ToolResult {
+                        tool: call.name.clone(),
+                        action_class,
+                        success: false,
+                        output: format!(
+                            "Confirmation for '{}' expired or was never requested; the {}s window elapsed. Request it again to restart confirmation.",
+                            call.name, self.tool_policy.confirmation_ttl_secs
+                        ),
+                    };
+                    self.audit_gate_decision(
+                        call,
+                        exec_ctx,
+                        started,
+                        &result,
+                        GateDecision::ConfirmationExpired,
+                    );
+                    return Some(result);
+                }
+                ToolConfirmDecision::Confirmed => {}
+            }
+        }
+
+        // 3. Per-tool sliding-window rate limit. Pre-confirmed re-entries skip
+        //    the recharge: the slot was already paid by the first leg.
+        if !exec_ctx.confirmed
+            && let Err(err) = self
+                .tool_rate_limiter
+                .check_and_record(&self.tool_policy, &call.name)
+        {
+            let result = ToolResult {
+                tool: call.name.clone(),
+                action_class,
+                success: false,
+                output: format!("Tool blocked by rate limit: {err}"),
+            };
+            self.audit_gate_decision(call, exec_ctx, started, &result, GateDecision::RateLimited);
+            return Some(result);
+        }
+
+        None
+    }
+
+    /// Public chokepoint entry for specialized fast-paths (e.g. the voice
+    /// `web_search` renderer) that need the gate's ACL / confirmation /
+    /// rate-limit decision and audit trail but render their own output.
+    ///
+    /// Returns `Some(rejection)` (already audited) when the gate refuses, or
+    /// `None` when the call may proceed — in which case the caller MUST record
+    /// the eventual outcome with [`ToolDispatcher::audit_gated_tool`] so the
+    /// single chokepoint still produces exactly one audit line per call.
+    pub fn gate_tool_call(
+        &self,
+        call: &ToolCall,
+        exec_ctx: ToolExecutionContext,
+    ) -> Option<ToolResult> {
+        self.run_gate(call, exec_ctx, Instant::now())
+    }
+
+    /// Record one tool-audit line for a call that passed [`gate_tool_call`] and
+    /// was executed by a specialized fast-path.
+    pub fn audit_gated_tool(
+        &self,
+        call: &ToolCall,
+        exec_ctx: ToolExecutionContext,
+        started: Instant,
+        success: bool,
+        output: &str,
+    ) {
+        let result = ToolResult {
+            tool: call.name.clone(),
+            action_class: tool_action_class(&call.name),
+            success,
+            output: output.to_string(),
+        };
+        let decision = if success {
+            GateDecision::Executed
+        } else {
+            GateDecision::Error
+        };
+        self.audit_gate_decision(call, exec_ctx, started, &result, decision);
+    }
+
+    fn audit_gate_decision(
         &self,
         call: &ToolCall,
         exec_ctx: ToolExecutionContext,
         started: Instant,
         result: &ToolResult,
+        decision: GateDecision,
     ) {
         self.tool_audit_logger.append_or_log(ToolAuditEvent {
             ts_ms: now_ms(),
@@ -636,6 +856,7 @@ impl ToolDispatcher {
             action_class: result.action_class,
             origin: exec_ctx.request_origin,
             success: result.success,
+            decision: decision.as_str(),
             duration_ms: started.elapsed().as_millis() as u64,
             argument_keys: tool_argument_keys(&call.arguments),
             output_chars: result.output.chars().count(),
@@ -1406,6 +1627,118 @@ fn actuation_rate_limit(config: &ActuationSafetyConfig, origin: RequestOrigin) -
         .unwrap_or(config.max_actions_per_minute)
 }
 
+impl ToolRateLimiter {
+    fn check_and_record(&self, policy: &ToolPolicyConfig, tool: &str) -> Result<()> {
+        let Some(limit) = tool_rate_limit(policy, tool) else {
+            return Ok(());
+        };
+        if limit == 0 {
+            anyhow::bail!("tool '{}' is rate-limited to zero calls per minute", tool);
+        }
+
+        let now = now_ms();
+        let cutoff = now.saturating_sub(ACTUATION_RATE_WINDOW_MS);
+        let mut attempts = self.attempts.lock().expect("tool rate limiter lock");
+        let bucket = attempts.entry(tool.to_string()).or_default();
+        while bucket.front().copied().is_some_and(|ts| ts < cutoff) {
+            bucket.pop_front();
+        }
+        if bucket.len() >= limit {
+            anyhow::bail!("tool '{}' exceeded {} call(s) per minute", tool, limit);
+        }
+        bucket.push_back(now);
+        Ok(())
+    }
+}
+
+/// Per-tool limit for `tool`, honoring an exact match first and a `"*"`
+/// catch-all fallback. `None` means the tool is unlimited.
+fn tool_rate_limit(policy: &ToolPolicyConfig, tool: &str) -> Option<usize> {
+    if !policy.enabled {
+        return None;
+    }
+    policy
+        .max_actions_per_minute_by_tool
+        .get(tool)
+        .or_else(|| policy.max_actions_per_minute_by_tool.get("*"))
+        .copied()
+}
+
+impl ToolConfirmationGate {
+    fn evaluate(
+        &self,
+        origin: RequestOrigin,
+        tool: &str,
+        args: &serde_json::Value,
+        ttl_ms: u64,
+        confirmed: bool,
+    ) -> ToolConfirmDecision {
+        let key = tool_confirmation_key(origin, tool, args);
+        let now = now_ms();
+        let mut pending = self.pending.lock().expect("tool confirmation gate lock");
+        pending.retain(|_, first_seen| {
+            now.saturating_sub(*first_seen) < TOOL_CONFIRMATION_RETENTION_MS
+        });
+
+        if !confirmed {
+            // First leg: record (or refresh) the request and ask for a repeat.
+            if pending.len() >= MAX_TOOL_CONFIRMATIONS
+                && !pending.contains_key(&key)
+                && let Some(oldest) = pending
+                    .iter()
+                    .min_by_key(|(_, first_seen)| **first_seen)
+                    .map(|(oldest_key, _)| oldest_key.clone())
+            {
+                pending.remove(&oldest);
+            }
+            pending.insert(key.clone(), now);
+            return ToolConfirmDecision::Pending {
+                token: tool_confirmation_token(&key),
+            };
+        }
+
+        // Confirming leg: succeed only when a matching first leg is still inside
+        // the TTL window. A missing or stale first leg reports as expired.
+        match pending.remove(&key) {
+            Some(first_seen) if now.saturating_sub(first_seen) <= ttl_ms => {
+                ToolConfirmDecision::Confirmed
+            }
+            _ => ToolConfirmDecision::Expired,
+        }
+    }
+}
+
+/// Whether `tool` is in `requires_confirmation_tools` (wildcards supported).
+/// Only consulted when the tool policy is enabled.
+fn tool_requires_confirmation(policy: &ToolPolicyConfig, tool: &str) -> bool {
+    policy.enabled
+        && policy
+            .requires_confirmation_tools
+            .iter()
+            .any(|entry| entry == "*" || entry.trim().eq_ignore_ascii_case(tool))
+}
+
+/// Stable key for a confirmable request: identical `(origin, tool, arguments)`
+/// triples map to the same key so the confirming leg matches its first leg.
+fn tool_confirmation_key(origin: RequestOrigin, tool: &str, args: &serde_json::Value) -> String {
+    format!(
+        "{}\u{1f}{}\u{1f}{}",
+        origin.as_policy_key(),
+        tool,
+        serde_json::to_string(args).unwrap_or_default()
+    )
+}
+
+/// Stable, non-secret token derived from the confirmation key. It only
+/// identifies the pending request (the args themselves are the authorization),
+/// so unlike a home-actuation token it is safe to surface to the caller.
+fn tool_confirmation_token(key: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    format!("conf-{:016x}", hasher.finish())
+}
+
 fn memory_query(args: &serde_json::Value) -> &str {
     let raw = args
         .get("query")
@@ -2143,6 +2476,7 @@ mod tests {
             action_class: ToolActionClass::ReadOnly,
             origin: RequestOrigin::Api,
             success: true,
+            decision: "executed",
             duration_ms: 1,
             argument_keys: vec!["expression".into()],
             output_chars: 3,
@@ -2166,6 +2500,7 @@ mod tests {
             action_class: ToolActionClass::ReadOnly,
             origin: RequestOrigin::Api,
             success: true,
+            decision: "executed",
             duration_ms: 1,
             argument_keys: vec!["expression".into()],
             output_chars: 3,

--- a/crates/genie-core/src/voice/mod.rs
+++ b/crates/genie-core/src/voice/mod.rs
@@ -265,7 +265,17 @@ impl VoiceOrchestrator {
                 name: call.tool,
                 arguments: call.arguments,
             };
-            return Some(self.tools.execute(&tc).await);
+            return Some(
+                self.tools
+                    .execute_with_context(
+                        &tc,
+                        crate::tools::ToolExecutionContext {
+                            request_origin: crate::tools::RequestOrigin::Voice,
+                            ..Default::default()
+                        },
+                    )
+                    .await,
+            );
         }
 
         // Try finding JSON embedded in the response.
@@ -280,7 +290,17 @@ impl VoiceOrchestrator {
                     name: call.tool,
                     arguments: call.arguments,
                 };
-                return Some(self.tools.execute(&tc).await);
+                return Some(
+                    self.tools
+                        .execute_with_context(
+                            &tc,
+                            crate::tools::ToolExecutionContext {
+                                request_origin: crate::tools::RequestOrigin::Voice,
+                                ..Default::default()
+                            },
+                        )
+                        .await,
+                );
             }
         }
 

--- a/crates/genie-core/src/voice/pipeline.rs
+++ b/crates/genie-core/src/voice/pipeline.rs
@@ -218,7 +218,17 @@ impl VoicePipeline {
             name: call.tool,
             arguments: call.arguments,
         };
-        Some(self.tools.execute(&tc).await)
+        Some(
+            self.tools
+                .execute_with_context(
+                    &tc,
+                    crate::tools::ToolExecutionContext {
+                        request_origin: crate::tools::RequestOrigin::Voice,
+                        ..Default::default()
+                    },
+                )
+                .await,
+        )
     }
 
     /// Clear conversation history.

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -705,6 +705,27 @@ async fn handle_quick_tool_for_voice(
         tools.has_web_search(),
     )?;
     if call.name == "web_search" {
+        // The voice web_search fast-path renders its own speech-optimized output
+        // instead of dispatching through `execute_with_context`, so it must
+        // still flow through the single gate chokepoint (ACLs, confirmation,
+        // per-tool rate limits, audit) rather than reaching the provider
+        // directly. Refusals are spoken back like any other tool result.
+        let exec_ctx = crate::tools::ToolExecutionContext {
+            memory_read_context: Some(read_context),
+            request_origin: crate::tools::RequestOrigin::Voice,
+            confirmed: false,
+        };
+        if let Some(rejected) = tools.gate_tool_call(&call, exec_ctx) {
+            let response = crate::security::sandbox::sanitize_output(&rejected.output);
+            conversations.append_or_log(conv_id, "assistant", &response, None);
+            let tts_engine = tts_engine_for_language(voice_cfg, audio_device, response_language);
+            let voice_text = format::for_voice(&response);
+            if !voice_text.is_empty() {
+                let _ = tts_engine.speak(&voice_text).await;
+            }
+            return Some(response);
+        }
+
         let query = call
             .arguments
             .get("query")
@@ -722,17 +743,19 @@ async fn handle_quick_tool_for_voice(
             .and_then(|value| value.as_bool())
             .unwrap_or(false);
 
-        let (response, voice_response) = match tools.web_search_response(query, limit, fresh).await
-        {
-            Ok(result) => {
-                let voice_response = result.render_voice();
-                (result.response, voice_response)
-            }
-            Err(e) => {
-                let error = format!("web_search failed: {}", e);
-                (error.clone(), error)
-            }
-        };
+        let started = std::time::Instant::now();
+        let (response, voice_response, success) =
+            match tools.web_search_response(query, limit, fresh).await {
+                Ok(result) => {
+                    let voice_response = result.render_voice();
+                    (result.response, voice_response, true)
+                }
+                Err(e) => {
+                    let error = format!("web_search failed: {}", e);
+                    (error.clone(), error, false)
+                }
+            };
+        tools.audit_gated_tool(&call, exec_ctx, started, success, &response);
         let response = crate::security::sandbox::sanitize_output(&response);
         let tool_json = serde_json::json!({
             "tool": call.name,

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -602,3 +602,220 @@ async fn home_status_rejects_invalid_arguments_and_audits() {
         assert_eq!(event["success"], false);
     }
 }
+
+// --- Issue #22: per-tool rate limits + two-step confirmation gate ----------
+
+#[tokio::test]
+async fn tool_gate_per_tool_rate_limit_bounces_after_n_and_audits() {
+    let paths = TestAuditPaths::new();
+    let mut policy = ToolPolicyConfig::default();
+    policy
+        .max_actions_per_minute_by_tool
+        .insert("calculate".into(), 2);
+
+    let dispatcher = paths.dispatcher(None, policy, ActuationSafetyConfig::default());
+    let call = ToolCall {
+        name: "calculate".into(),
+        arguments: serde_json::json!({"expression": "1 + 1"}),
+    };
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Api,
+        ..ToolExecutionContext::default()
+    };
+
+    let first = dispatcher.execute_with_context(&call, ctx).await;
+    let second = dispatcher.execute_with_context(&call, ctx).await;
+    let third = dispatcher.execute_with_context(&call, ctx).await;
+
+    assert!(first.success, "first call within limit: {}", first.output);
+    assert!(
+        second.success,
+        "second call within limit: {}",
+        second.output
+    );
+    assert!(!third.success, "third call must bounce off the limit");
+    assert!(
+        third.output.contains("rate limit"),
+        "expected rate-limit refusal, got: {}",
+        third.output
+    );
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(events.len(), 3, "every attempt is audited");
+    assert_eq!(events[0]["decision"], "executed");
+    assert_eq!(events[1]["decision"], "executed");
+    assert_eq!(events[2]["decision"], "rate_limited");
+    assert_eq!(events[2]["success"], false);
+}
+
+#[tokio::test]
+async fn tool_gate_confirmation_two_step_executes_within_ttl() {
+    let paths = TestAuditPaths::new();
+    let policy = ToolPolicyConfig {
+        requires_confirmation_tools: vec!["calculate".into()],
+        confirmation_ttl_secs: 120,
+        ..ToolPolicyConfig::default()
+    };
+
+    let dispatcher = paths.dispatcher(None, policy, ActuationSafetyConfig::default());
+    let call = ToolCall {
+        name: "calculate".into(),
+        arguments: serde_json::json!({"expression": "2 + 2"}),
+    };
+    let request_ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Api,
+        ..ToolExecutionContext::default()
+    };
+    let confirm_ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Api,
+        confirmed: true,
+        ..ToolExecutionContext::default()
+    };
+
+    let pending = dispatcher.execute_with_context(&call, request_ctx).await;
+    assert!(pending.success, "pending leg returns guidance, not failure");
+    assert!(
+        pending.output.contains("Confirmation required"),
+        "expected confirmation guidance, got: {}",
+        pending.output
+    );
+    assert!(
+        pending.output.contains("conf-"),
+        "expected a stable confirmation token, got: {}",
+        pending.output
+    );
+    assert!(
+        !pending.output.contains("= 4"),
+        "tool must not execute on the first leg: {}",
+        pending.output
+    );
+
+    let confirmed = dispatcher.execute_with_context(&call, confirm_ctx).await;
+    assert!(
+        confirmed.success,
+        "confirming leg within TTL executes: {}",
+        confirmed.output
+    );
+    assert!(
+        confirmed.output.contains("= 4"),
+        "expected calculation result, got: {}",
+        confirmed.output
+    );
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["decision"], "pending_confirmation");
+    assert_eq!(events[1]["decision"], "executed");
+}
+
+#[tokio::test]
+async fn tool_gate_confirmation_without_first_leg_is_refused() {
+    let paths = TestAuditPaths::new();
+    let policy = ToolPolicyConfig {
+        requires_confirmation_tools: vec!["calculate".into()],
+        ..ToolPolicyConfig::default()
+    };
+
+    let dispatcher = paths.dispatcher(None, policy, ActuationSafetyConfig::default());
+    let call = ToolCall {
+        name: "calculate".into(),
+        arguments: serde_json::json!({"expression": "9 + 9"}),
+    };
+    let confirm_ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Api,
+        confirmed: true,
+        ..ToolExecutionContext::default()
+    };
+
+    let result = dispatcher.execute_with_context(&call, confirm_ctx).await;
+    assert!(
+        !result.success,
+        "confirming with no pending first leg must error"
+    );
+    assert!(
+        result.output.contains("expired") || result.output.contains("never requested"),
+        "expected an expiry error, got: {}",
+        result.output
+    );
+    assert!(!result.output.contains("= 18"));
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["decision"], "confirmation_expired");
+}
+
+#[tokio::test]
+async fn tool_gate_confirmation_outside_ttl_errors() {
+    let paths = TestAuditPaths::new();
+    let policy = ToolPolicyConfig {
+        requires_confirmation_tools: vec!["calculate".into()],
+        confirmation_ttl_secs: 1,
+        ..ToolPolicyConfig::default()
+    };
+
+    let dispatcher = paths.dispatcher(None, policy, ActuationSafetyConfig::default());
+    let call = ToolCall {
+        name: "calculate".into(),
+        arguments: serde_json::json!({"expression": "3 + 3"}),
+    };
+    let request_ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Api,
+        ..ToolExecutionContext::default()
+    };
+    let confirm_ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Api,
+        confirmed: true,
+        ..ToolExecutionContext::default()
+    };
+
+    let pending = dispatcher.execute_with_context(&call, request_ctx).await;
+    assert!(pending.output.contains("Confirmation required"));
+
+    // Let the 1s confirmation window lapse before the confirming leg arrives.
+    tokio::time::sleep(std::time::Duration::from_millis(1_200)).await;
+
+    let confirmed = dispatcher.execute_with_context(&call, confirm_ctx).await;
+    assert!(
+        !confirmed.success,
+        "confirming after the TTL window must error: {}",
+        confirmed.output
+    );
+    assert!(confirmed.output.contains("expired"));
+}
+
+#[tokio::test]
+async fn gate_tool_call_rejects_denied_origin_and_audits() {
+    // The voice web_search fast-path uses `gate_tool_call` rather than
+    // `execute_with_context`; it must still refuse a denied origin and audit it.
+    let paths = TestAuditPaths::new();
+    let mut policy = ToolPolicyConfig::default();
+    policy
+        .denied_tools_by_origin
+        .insert("voice".into(), vec!["web_search".into()]);
+    let dispatcher = paths.dispatcher(None, policy, ActuationSafetyConfig::default());
+
+    let call = ToolCall {
+        name: "web_search".into(),
+        arguments: serde_json::json!({"query": "weather"}),
+    };
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Voice,
+        ..ToolExecutionContext::default()
+    };
+
+    let rejected = dispatcher
+        .gate_tool_call(&call, ctx)
+        .expect("gate must reject web_search denied from voice");
+    assert!(!rejected.success);
+    assert!(
+        rejected.output.contains("origin policy"),
+        "expected ACL refusal, got: {}",
+        rejected.output
+    );
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["decision"], "denied_policy");
+    assert_eq!(events[0]["origin"], "voice");
+    assert_eq!(events[0]["tool"], "web_search");
+}

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -176,10 +176,20 @@ wakeword_script = ""              # Empty = push-to-talk.
 
 # Optional per-origin tool policy. Defaults are allow unless a rule exists.
 # Use "*" as a wildcard origin or tool name. Deny rules override allow rules.
+# Every tool call (quick-tool, LLM dispatch, skill, summary) is enforced at one
+# dispatcher gate, so these rules apply uniformly regardless of how a tool runs.
 # [core.tool_policy]
 # enabled = true
 # allowed_tools_by_origin = { voice = ["get_time", "get_weather", "memory_recall", "home_status", "home_control"] }
 # denied_tools_by_origin = { telegram = ["play_media"], "*" = [] }
+# Per-tool sliding-window rate limits (calls/minute). "*" is a catch-all; tools
+# without an entry are unlimited. A fast loop bounces off the limit after N calls.
+# max_actions_per_minute_by_tool = { play_media = 10, web_search = 20 }
+# Sensitive tools that must be requested twice with the same arguments within
+# confirmation_ttl_secs before they run. The first call returns a pending
+# response with a stable token; the confirming call passes confirmed = true.
+# requires_confirmation_tools = ["play_media"]
+# confirmation_ttl_secs = 120
 
 # Final actuation safety gate for physical home-control execution:
 # [core.actuation_safety]


### PR DESCRIPTION
## Summary

Issue #22 asks for a single, consistently-enforced tool-call gate. Much of the gate already exists on `main` (per-origin ACLs, per-origin actuation rate limits, the home-actuation confirmation/token flow, skill-permission enforcement, and the tool-audit trail). This PR closes the remaining gaps so every acceptance criterion holds: it removes the last gate bypasses, adds per-tool rate limits, and adds a generic two-step confirmation flow. Defaults are unchanged, so existing deployments keep current behavior.

Closes #22

## Changes

- **Single chokepoint / no bypass.** The voice `web_search` quick-path (which renders its own speech output) previously called the search provider directly; it now passes the dispatcher gate via a new `gate_tool_call` / `audit_gated_tool` pair before rendering. The `voice::VoiceOrchestrator` and `voice::pipeline` fall-back paths previously called `tools.execute(...)` with a defaulted (`Unknown`) origin; they now go through `execute_with_context` as `RequestOrigin::Voice`. ACLs, rate limits, confirmation, and auditing now apply to these paths.
- **Per-tool rate limits.** New `tool_policy.max_actions_per_minute_by_tool` (e.g. `{ play_media = 10 }`, with a `"*"` catch-all) — a per-tool sliding-window limit enforced at the gate for every origin. A fast loop bounces off the limit after N calls.
- **Two-step confirmation.** New `tool_policy.requires_confirmation_tools` + `confirmation_ttl_secs`. A sensitive tool must be requested twice with the same `(origin, tool, arguments)` inside the TTL window: the first leg returns a pending response with a stable token; the confirming leg passes `confirmed = true`. A confirming leg with no live first leg (never requested, or the window elapsed) errors.
- **Audit every decision.** Each tool-audit line now carries a `decision` field: `executed`, `error`, `denied_policy`, `rate_limited`, `pending_confirmation`, or `confirmation_expired`.
- Sample `geniepod.toml` and `CHANGELOG.md` document the new `[core.tool_policy]` keys.

### Acceptance criteria (issue #22)

- No call sites bypass the gate — voice quick-path and voice fall-back paths now route through it (verified by grep + new tests).
- `denied_tools_by_origin` blocks a tool from an origin with an audit line — existing behavior, still covered.
- Confirmation flow: first call pending, confirming leg within TTL executes, confirming leg outside TTL errors — new tests.
- Rate limits bounce off after N calls — new per-tool test (plus the existing per-origin test).
- Skill manifest with a denied permission is rejected — existing behavior in `skills/loader.rs`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

x86_64 Linux (WSL2 Ubuntu, kernel 6.6), rustc/cargo 1.95.0. The change is gate/config logic in `genie-core` + `genie-common` — no Jetson-only path is touched.

```
cargo fmt --all -- --check
cargo clippy -p genie-core -p genie-common --all-targets -- -D warnings
cargo test -p genie-core --test tool_gate_integration_test
cargo test -p genie-common
cargo test -p genie-core --lib tools::dispatch
cargo test -p genie-core --test voice_loop_integration
cargo test -p genie-core --lib voice::
```

### What I observed

- `cargo fmt --all -- --check`: clean (exit 0).
- `cargo clippy ... -D warnings`: no warnings.
- `tool_gate_integration_test`: `12 passed; 0 failed` — the 7 existing gate tests plus 5 new ones (`tool_gate_per_tool_rate_limit_bounces_after_n_and_audits`, `tool_gate_confirmation_two_step_executes_within_ttl`, `tool_gate_confirmation_without_first_leg_is_refused`, `tool_gate_confirmation_outside_ttl_errors`, `gate_tool_call_rejects_denied_origin_and_audits`).
- `genie-common`: `101 passed; 0 failed` (includes new `tool_policy_gate_extensions_parse`).
- `genie-core --lib tools::dispatch`: `45 passed; 0 failed`.
- `voice_loop_integration`: `11 passed; 0 failed`.
- `genie-core --lib voice::`: `78 passed; 0 failed`.

**Not verified on Jetson.** I don't have a Jetson Orin available. The change is pure gate/config logic with no Jetson-specific behavior; verification is the clean `cargo fmt` / `clippy -D warnings` / unit + integration tests above. CI also runs the `aarch64-unknown-linux-gnu` cross-compile, `cargo audit`, and `cargo deny` gates.

## Test plan

1. Set `requires_confirmation_tools = ["play_media"]` under `[core.tool_policy]`; ask for media by voice — the first request returns a confirmation prompt, repeating it within `confirmation_ttl_secs` plays.
2. Set `max_actions_per_minute_by_tool = { web_search = 2 }`; issue 3 quick web searches — the third is refused with a rate-limit message and a `rate_limited` line in `runtime/tool-audit.jsonl`.
3. Set `denied_tools_by_origin = { voice = ["web_search"] }`; a voice web search is refused with a `denied_policy` audit line.

## Notes for reviewers

- Origin propagation: production entry points (server, REPL, voice loop, voice fall-backs) now carry an explicit `RequestOrigin`. I kept `ToolExecutionContext`'s `Default` (and the `execute` / bare `try_tool_call` convenience wrappers that default origin to `Unknown`) because they're used only by tests and eval; removing `Default` would churn the whole test suite without changing production behavior. Happy to do that as a follow-up if you'd prefer it removed.
- The generic confirmation gate is independent of the deeper home-actuation token flow; with the default empty `requires_confirmation_tools` it is inert, so `home_control` keeps its existing token/dashboard confirmation.