### PR TITLE
fix(skills): record signature status in audit trail and flag writable…

### DIFF
--- a/crates/genie-core/src/security/audit.rs
+++ b/crates/genie-core/src/security/audit.rs
@@ -425,8 +425,9 @@ mod tests {
         let mut findings = Vec::new();
         check_skills_dir_permissions(&path, &mut findings);
         assert!(
-            findings.iter().any(|f| f.id == "fs.skills_dir.group_writable"
-                && f.severity == Severity::Warning),
+            findings
+                .iter()
+                .any(|f| f.id == "fs.skills_dir.group_writable" && f.severity == Severity::Warning),
             "group-writable skills dir must be a Warning finding"
         );
 
@@ -438,10 +439,8 @@ mod tests {
     fn audit_safe_skills_dir_has_no_permission_findings() {
         use std::os::unix::fs::PermissionsExt;
 
-        let path = std::env::temp_dir().join(format!(
-            "geniepod-audit-skills-safe-{}",
-            std::process::id()
-        ));
+        let path =
+            std::env::temp_dir().join(format!("geniepod-audit-skills-safe-{}", std::process::id()));
         let _ = fs::remove_dir_all(&path);
         fs::create_dir_all(&path).unwrap();
         fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();

--- a/crates/genie-core/src/security/audit.rs
+++ b/crates/genie-core/src/security/audit.rs
@@ -43,6 +43,12 @@ pub fn run_audit(config_path: &Path, data_dir: &Path) -> Vec<AuditFinding> {
     // 5. Check if API port is bound to localhost only.
     check_localhost_binding(&mut findings);
 
+    // 6. Check skills directory permissions. A world- or group-writable skills
+    //    dir allows an attacker to plant a malicious .so before genie-core reads
+    //    it — even the sealed-memfd TOCTOU fix reads bytes from disk, so the
+    //    write window is before the read, not between verify and dlopen.
+    check_skills_dir_permissions(&crate::skills::skills_dir(), &mut findings);
+
     // Log all findings.
     for finding in &findings {
         match finding.severity {
@@ -257,6 +263,50 @@ fn check_not_root(findings: &mut Vec<AuditFinding>) {
     }
 }
 
+fn check_skills_dir_permissions(skills_dir: &Path, findings: &mut Vec<AuditFinding>) {
+    if !skills_dir.exists() {
+        return;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(skills_dir) {
+            let bits = meta.permissions().mode() & 0o777;
+
+            if bits & 0o002 != 0 {
+                findings.push(AuditFinding {
+                    id: "fs.skills_dir.world_writable".into(),
+                    severity: Severity::Critical,
+                    message: format!(
+                        "skills directory is world-writable (mode {:o}) — \
+                         an untrusted process can plant a malicious .so before \
+                         genie-core reads it, bypassing signature verification",
+                        bits
+                    ),
+                    remediation: format!(
+                        "chmod 755 {0} && chown root:root {0}",
+                        skills_dir.display()
+                    ),
+                });
+            }
+
+            if bits & 0o020 != 0 {
+                findings.push(AuditFinding {
+                    id: "fs.skills_dir.group_writable".into(),
+                    severity: Severity::Warning,
+                    message: format!(
+                        "skills directory is group-writable (mode {:o}) — \
+                         a process in the same group can replace skill binaries",
+                        bits
+                    ),
+                    remediation: format!("chmod 755 {}", skills_dir.display()),
+                });
+            }
+        }
+    }
+}
+
 fn check_localhost_binding(findings: &mut Vec<AuditFinding>) {
     // This is informational — we always bind to 127.0.0.1.
     findings.push(AuditFinding {
@@ -333,5 +383,76 @@ mod tests {
     fn severity_ordering() {
         assert_ne!(Severity::Critical, Severity::Warning);
         assert_ne!(Severity::Warning, Severity::Info);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn audit_world_writable_skills_dir_is_critical() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-audit-skills-world-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o777)).unwrap();
+
+        let mut findings = Vec::new();
+        check_skills_dir_permissions(&path, &mut findings);
+        assert!(
+            findings.iter().any(|f| f.id == "fs.skills_dir.world_writable"
+                && f.severity == Severity::Critical),
+            "world-writable skills dir must be a Critical finding"
+        );
+
+        let _ = fs::remove_dir_all(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn audit_group_writable_skills_dir_is_warning() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-audit-skills-group-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o775)).unwrap();
+
+        let mut findings = Vec::new();
+        check_skills_dir_permissions(&path, &mut findings);
+        assert!(
+            findings.iter().any(|f| f.id == "fs.skills_dir.group_writable"
+                && f.severity == Severity::Warning),
+            "group-writable skills dir must be a Warning finding"
+        );
+
+        let _ = fs::remove_dir_all(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn audit_safe_skills_dir_has_no_permission_findings() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-audit-skills-safe-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut findings = Vec::new();
+        check_skills_dir_permissions(&path, &mut findings);
+        assert!(
+            findings.is_empty(),
+            "mode 755 skills dir must produce no permission findings"
+        );
+
+        let _ = fs::remove_dir_all(&path);
     }
 }

--- a/crates/genie-core/src/security/taint.rs
+++ b/crates/genie-core/src/security/taint.rs
@@ -23,6 +23,10 @@ pub enum TaintLabel {
     Secret,
     /// Output from LLM (may contain hallucinated secrets or injected instructions).
     LlmOutput,
+    /// Return value from a loaded native skill (.so). Propagated so audit
+    /// layers can observe skill output flowing to display or network sinks.
+    /// Not currently blocked by any sink — enforcement is future work.
+    NativeSkill,
 }
 
 /// Operations that have taint restrictions.

--- a/crates/genie-core/src/skills/loader.rs
+++ b/crates/genie-core/src/skills/loader.rs
@@ -602,7 +602,15 @@ impl SkillLoader {
             if path.extension().is_some_and(|ext| ext == "so") {
                 match self.load_skill(&path) {
                     Ok(name) => {
-                        tracing::info!(skill = %name, path = %path.display(), "skill loaded");
+                        // SAFETY: load_skill always pushes before returning Ok.
+                        let skill = self.loaded().last().expect("just pushed");
+                        tracing::info!(
+                            skill = %name,
+                            path = %path.display(),
+                            signed = skill.manifest.signed,
+                            key_id = %skill.manifest.key_id,
+                            "skill loaded"
+                        );
                         loaded_names.push(name);
                     }
                     Err(e) => {

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -660,7 +660,6 @@ impl ToolDispatcher {
             })
             .unwrap_or((None, None));
 
-        self.tool_audit_logger.append(ToolAuditEvent {
         self.tool_audit_logger.append_or_log(ToolAuditEvent {
             ts_ms: now_ms(),
             tool: call.name.clone(),
@@ -2216,6 +2215,8 @@ mod tests {
         // (Verified indirectly: this test only checks a skill invocation.)
 
         let _ = std::fs::remove_file(&path);
+    }
+
     #[test]
     fn tool_audit_logger_disabled_appends_ok() {
         let logger = ToolAuditLogger::default();
@@ -2228,6 +2229,8 @@ mod tests {
             duration_ms: 1,
             argument_keys: vec!["expression".into()],
             output_chars: 3,
+            skill_signed: None,
+            skill_key_id: None,
         };
         assert!(logger.append(event).is_ok());
     }
@@ -2251,6 +2254,8 @@ mod tests {
             duration_ms: 1,
             argument_keys: vec!["expression".into()],
             output_chars: 3,
+            skill_signed: None,
+            skill_key_id: None,
         };
         let err = logger.append(event).expect_err("append must fail");
         assert!(matches!(

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -653,8 +653,8 @@ impl ToolDispatcher {
                     .iter()
                     .find(|s| s.name == call.name)
                     .map(|s| {
-                        let key_id = (!s.manifest.key_id.is_empty())
-                            .then(|| s.manifest.key_id.clone());
+                        let key_id =
+                            (!s.manifest.key_id.is_empty()).then(|| s.manifest.key_id.clone());
                         (Some(s.manifest.signed), key_id)
                     })
             })

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -155,6 +155,16 @@ struct ToolAuditEvent {
     duration_ms: u64,
     argument_keys: Vec<String>,
     output_chars: usize,
+    /// Present only for native skill invocations. `true` means the .so bytes
+    /// were verified against a trusted Ed25519 key before loading; `false`
+    /// means the skill loaded without a valid signature (only possible when
+    /// `require_signature = false`). Absent for built-in tools.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skill_signed: Option<bool>,
+    /// Key id of the trusted public key that verified the skill, if any.
+    /// Absent when the skill has no manifest, was unsigned, or is a built-in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skill_key_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -623,6 +633,26 @@ impl ToolDispatcher {
         started: Instant,
         result: &ToolResult,
     ) {
+        // Look up signature metadata if the tool name matches a loaded native
+        // skill.  The skills lock is not held across any await here, so this
+        // brief synchronous acquisition cannot deadlock or starve.
+        let (skill_signed, skill_key_id) = self
+            .skills
+            .as_ref()
+            .and_then(|skills| skills.lock().ok())
+            .and_then(|loader| {
+                loader
+                    .loaded()
+                    .iter()
+                    .find(|s| s.name == call.name)
+                    .map(|s| {
+                        let key_id = (!s.manifest.key_id.is_empty())
+                            .then(|| s.manifest.key_id.clone());
+                        (Some(s.manifest.signed), key_id)
+                    })
+            })
+            .unwrap_or((None, None));
+
         self.tool_audit_logger.append(ToolAuditEvent {
             ts_ms: now_ms(),
             tool: call.name.clone(),
@@ -632,6 +662,8 @@ impl ToolDispatcher {
             duration_ms: started.elapsed().as_millis() as u64,
             argument_keys: tool_argument_keys(&call.arguments),
             output_chars: result.output.chars().count(),
+            skill_signed,
+            skill_key_id,
         });
     }
 
@@ -2123,6 +2155,57 @@ mod tests {
         assert_eq!(event["argument_keys"], serde_json::json!(["expression"]));
         assert!(event["duration_ms"].as_u64().is_some());
         assert!(!line.contains("secret-token-value"));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Native skill invocations must include `skill_signed` (and `skill_key_id`
+    /// when present) in the tool-audit JSONL so operators can see whether the
+    /// executed code was cryptographically verified.
+    #[tokio::test]
+    async fn skill_audit_event_includes_signature_fields() {
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-skill-audit-sig-test-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let dispatcher = ToolDispatcher::new(None)
+            .with_skill_loader(sample_skill_loader())
+            .with_tool_audit_path(path.clone());
+
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "hello_world".into(),
+                    arguments: serde_json::json!({"name": "AuditTest"}),
+                },
+                ToolExecutionContext {
+                    request_origin: RequestOrigin::Api,
+                    ..ToolExecutionContext::default()
+                },
+            )
+            .await;
+
+        assert!(result.success);
+
+        let line = std::fs::read_to_string(&path).unwrap();
+        let event: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+
+        assert_eq!(event["tool"], "hello_world");
+        // The sample skill has no sidecar manifest, so it must be reported as
+        // unsigned — never silently absent from the audit record.
+        assert_eq!(
+            event["skill_signed"], false,
+            "unsigned skill must appear as skill_signed=false in audit"
+        );
+        // key_id is empty for unsigned skills — field is omitted (skip_serializing_if).
+        assert!(
+            event.get("skill_key_id").is_none(),
+            "unsigned skill with no key_id must omit skill_key_id from audit"
+        );
+        // Built-in tools must not have skill_signed in their audit records.
+        // (Verified indirectly: this test only checks a skill invocation.)
 
         let _ = std::fs::remove_file(&path);
     }


### PR DESCRIPTION
## Summary

Closes #370 (skills/loader TOCTOU). The core TOCTOU race — verify bytes, then `dlopen` the same path again — was already sealed by the `memfd_create` fix. This PR closes the remaining audit gaps called out in the issue: unsigned skill loads were silent, the skills directory itself was never checked for attacker-writable permissions (the write window is *before* any read, so the sealed-memfd fix doesn't help there), skill invocations in `tool-audit.jsonl` carried no signature metadata, and `NativeSkill` was missing from the taint label set.

## Changes

- `skills/loader.rs`: `"skill loaded"` tracing event now includes `signed=` and `key_id=` fields — unsigned skill loads are no longer silent in structured logs
- `security/audit.rs`: added `check_skills_dir_permissions`; startup audit now emits a `Critical` finding for a world-writable skills directory and a `Warning` for group-writable — an attacker with write access can plant a `.so` before any read, bypassing the memfd protection
- `security/taint.rs`: added `TaintLabel::NativeSkill` so skill return values can be tagged and observed flowing to display or network sinks
- `tools/dispatch.rs`: `ToolAuditEvent` gains `skill_signed: Option<bool>` and `skill_key_id: Option<String>` (omitted for built-in tools via `skip_serializing_if`); `audit_tool_call` populates them by looking up the manifest in the loaded skills list — every skill invocation in `tool-audit.jsonl` now records whether the executed code was cryptographically verified

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

```
RUSTUP_TOOLCHAIN=stable cargo check -p genie-core
RUSTUP_TOOLCHAIN=stable cargo clippy -p genie-core -- -D warnings
RUSTUP_TOOLCHAIN=stable cargo test -p genie-core -- security::audit
RUSTUP_TOOLCHAIN=stable cargo test -p genie-core -- skills::loader
RUSTUP_TOOLCHAIN=stable cargo test -p genie-core -- skill_audit_event
```

Linux x86_64 dev machine, no Jetson hardware available. The changed paths are pure Rust logic (taint enum, filesystem permission checks, structured log fields, JSONL serialization) with no voice/audio/HA dependency — the test suite covers the full behaviour.

### What I observed

All tests pass, zero clippy warnings:

```
test security::audit::tests::audit_world_writable_skills_dir_is_critical ... ok
test security::audit::tests::audit_group_writable_skills_dir_is_warning ... ok
test security::audit::tests::audit_safe_skills_dir_has_no_permission_findings ... ok
test skills::loader::tests::loader_toctou_disk_swap_after_load_has_no_effect ... ok
test skills::loader::tests::loader_accepts_valid_signature ... ok
test skills::loader::tests::loader_rejects_tampered_so ... ok
test tools::dispatch::tests::skill_audit_event_includes_signature_fields ... ok
```

The new dispatch test confirms that executing `hello_world` (unsigned, no manifest) writes `"skill_signed": false` to `tool-audit.jsonl` and omits `skill_key_id` — verifying that unsigned skill loads are recorded, not silently accepted.

## Test plan

1. Create a world-writable skills directory and start `genie-core` — `journalctl -u genie-core` should show a `SECURITY: skills directory is world-writable` Critical finding at startup.
2. Load a signed skill (`genie-ctl skills install …`) and invoke it via chat — `tool-audit.jsonl` entry should have `"skill_signed": true` and `"skill_key_id": "<your-key-id>"`.
3. Load an unsigned skill with `require_signature = false` and invoke it — `tool-audit.jsonl` should have `"skill_signed": false` with no `skill_key_id` field.
4. Run `cargo test -p genie-core -- skills::loader security::audit skill_audit_event` — all must pass.

## Notes for reviewers

- The `NativeSkill` taint label is added but not yet wired into any sink policy (no call sites in `exec_skill` yet). It is a structural prerequisite for future enforcement — tagging skill outputs at call sites is the obvious next step but is out of scope for this fix.
- The skills-dir permission check calls `crate::skills::skills_dir()` directly inside `run_audit`; no circular dependency (neither `skills/loader.rs` nor `skills/signature.rs` imports from `security`).
- The `skill_signed` / `skill_key_id` lookup in `audit_tool_call` acquires the skills `Mutex` briefly and synchronously — no lock is held across any `await` point, so there is no deadlock or `await_holding_lock` hazard.
