### PR TITLE
feat(tools): complete the single tool-call gate — per-tool rate limits + confirmation (closes #22)

### DIFF
--- a/crates/genie-common/src/config.rs
+++ b/crates/genie-common/src/config.rs
@@ -505,6 +505,26 @@ pub struct ToolPolicyConfig {
     /// Tools blocked by origin. Deny rules override allow rules.
     #[serde(default)]
     pub denied_tools_by_origin: HashMap<String, Vec<String>>,
+
+    /// Per-tool sliding-window rate limit, in calls per minute, enforced at the
+    /// dispatch gate for *every* origin (issue #22). A tool not listed has no
+    /// per-tool cap; this is independent of the per-origin home actuation
+    /// limits in `[actuation_safety]`. Example:
+    /// `max_actions_per_minute_by_tool = { play_media = 10 }`.
+    #[serde(default)]
+    pub max_actions_per_minute_by_tool: HashMap<String, usize>,
+
+    /// Tools that require a two-call confirmation before they execute (issue
+    /// #22). The first call returns a pending token without running the tool; a
+    /// second call with the same origin and arguments within
+    /// `confirmation_ttl_secs` proceeds. `home_control` keeps its own richer
+    /// risk-based confirmation regardless of this list.
+    #[serde(default)]
+    pub requires_confirmation_tools: Vec<String>,
+
+    /// Validity window for a pending tool confirmation, in seconds (issue #22).
+    #[serde(default = "defaults::tool_confirmation_ttl_secs")]
+    pub confirmation_ttl_secs: u64,
 }
 
 impl Default for ToolPolicyConfig {
@@ -513,6 +533,9 @@ impl Default for ToolPolicyConfig {
             enabled: defaults::tool_policy_enabled(),
             allowed_tools_by_origin: HashMap::new(),
             denied_tools_by_origin: HashMap::new(),
+            max_actions_per_minute_by_tool: HashMap::new(),
+            requires_confirmation_tools: Vec::new(),
+            confirmation_ttl_secs: defaults::tool_confirmation_ttl_secs(),
         }
     }
 }
@@ -2405,6 +2428,21 @@ signature_key_dir = "/custom/keys"
         assert!(config.core.tool_policy.enabled);
         assert!(config.core.tool_policy.allowed_tools_by_origin.is_empty());
         assert!(config.core.tool_policy.denied_tools_by_origin.is_empty());
+        assert!(
+            config
+                .core
+                .tool_policy
+                .max_actions_per_minute_by_tool
+                .is_empty()
+        );
+        assert!(
+            config
+                .core
+                .tool_policy
+                .requires_confirmation_tools
+                .is_empty()
+        );
+        assert_eq!(config.core.tool_policy.confirmation_ttl_secs, 120);
     }
 
     #[test]
@@ -2414,6 +2452,9 @@ signature_key_dir = "/custom/keys"
 enabled = true
 allowed_tools_by_origin = { telegram = ["get_time", "memory_recall"] }
 denied_tools_by_origin = { voice = ["web_search"], "*" = ["play_media"] }
+max_actions_per_minute_by_tool = { play_media = 10 }
+requires_confirmation_tools = ["play_media"]
+confirmation_ttl_secs = 90
 "#,
         )
         .unwrap();
@@ -2425,6 +2466,9 @@ denied_tools_by_origin = { voice = ["web_search"], "*" = ["play_media"] }
         );
         assert_eq!(config.denied_tools_by_origin["voice"], vec!["web_search"]);
         assert_eq!(config.denied_tools_by_origin["*"], vec!["play_media"]);
+        assert_eq!(config.max_actions_per_minute_by_tool["play_media"], 10);
+        assert_eq!(config.requires_confirmation_tools, vec!["play_media"]);
+        assert_eq!(config.confirmation_ttl_secs, 90);
     }
 
     #[test]
@@ -2770,6 +2814,9 @@ mod defaults {
     }
     pub fn tool_policy_enabled() -> bool {
         true
+    }
+    pub fn tool_confirmation_ttl_secs() -> u64 {
+        120
     }
     pub fn actuation_safety_enabled() -> bool {
         true

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -141,6 +141,8 @@ pub struct ToolDispatcher {
     confirmations: Arc<ConfirmationManager>,
     action_ledger: Arc<ActionLedger>,
     actuation_rate_limiter: Arc<ActuationRateLimiter>,
+    tool_rate_limiter: Arc<ToolRateLimiter>,
+    tool_confirmations: Arc<ToolConfirmationGate>,
     audit_logger: AuditLogger,
     tool_audit_logger: ToolAuditLogger,
     pub(crate) timers: timer::TimerManager,
@@ -212,6 +214,8 @@ impl ToolDispatcher {
             confirmations: Arc::new(ConfirmationManager::default()),
             action_ledger: Arc::new(ActionLedger::default()),
             actuation_rate_limiter: Arc::new(ActuationRateLimiter::default()),
+            tool_rate_limiter: Arc::new(ToolRateLimiter::default()),
+            tool_confirmations: Arc::new(ToolConfirmationGate::default()),
             audit_logger: AuditLogger::disabled(),
             tool_audit_logger: ToolAuditLogger::default(),
             timers: timer::TimerManager::new(),
@@ -282,6 +286,9 @@ impl ToolDispatcher {
                 "enabled": self.tool_policy.enabled,
                 "allowed_tools_by_origin": &self.tool_policy.allowed_tools_by_origin,
                 "denied_tools_by_origin": &self.tool_policy.denied_tools_by_origin,
+                "max_actions_per_minute_by_tool": &self.tool_policy.max_actions_per_minute_by_tool,
+                "requires_confirmation_tools": &self.tool_policy.requires_confirmation_tools,
+                "confirmation_ttl_secs": self.tool_policy.confirmation_ttl_secs,
             },
             "actuation_safety": {
                 "enabled": self.actuation_safety.enabled,
@@ -564,6 +571,11 @@ impl ToolDispatcher {
             .await
     }
 
+    /// The single tool-call gate (issue #22). Every tool invocation — quick
+    /// router, LLM-driven dispatch, voice, and skill calls — flows through here,
+    /// so per-origin tool ACLs, per-tool rate limits, the two-call confirmation
+    /// flow, and the tool audit log are all enforced in one place with no
+    /// bypass. `execute` is a thin wrapper that uses the default internal origin.
     pub async fn execute_with_context(
         &self,
         call: &ToolCall,
@@ -579,6 +591,54 @@ impl ToolDispatcher {
                 action_class,
                 success: false,
                 output: format!("Tool blocked by origin policy: {err}"),
+            };
+            self.audit_tool_call(call, exec_ctx, started, &tool_result);
+            return tool_result;
+        }
+
+        // Per-tool rate limit (issue #22): enforced at the gate for every origin
+        // and tool, independent of the per-origin home actuation limit. A tool
+        // with no configured limit is unaffected.
+        if self.tool_policy.enabled
+            && let Err(reason) = self
+                .tool_rate_limiter
+                .check_and_record(&self.tool_policy, &call.name)
+        {
+            let tool_result = ToolResult {
+                tool: call.name.clone(),
+                action_class,
+                success: false,
+                output: format!("Tool blocked by rate limit: {reason}"),
+            };
+            self.audit_tool_call(call, exec_ctx, started, &tool_result);
+            return tool_result;
+        }
+
+        // Two-call confirmation for configured sensitive tools (issue #22). The
+        // first call records a pending entry and returns without executing; an
+        // identical call (same origin + arguments) within the TTL clears it and
+        // proceeds. An explicit `confirmed` context (e.g. a dashboard confirm
+        // re-dispatch) skips the dance. `home_control` is exempt here because it
+        // runs its own richer risk-based confirmation below.
+        if self.tool_policy.enabled
+            && !exec_ctx.confirmed
+            && call.name != "home_control"
+            && tool_requires_confirmation(&self.tool_policy, &call.name)
+            && let ToolConfirm::Pending { token } = self.tool_confirmations.check(
+                exec_ctx.request_origin,
+                &call.name,
+                &call.arguments,
+                self.tool_policy.confirmation_ttl_secs,
+            )
+        {
+            let tool_result = ToolResult {
+                tool: call.name.clone(),
+                action_class,
+                success: true,
+                output: format!(
+                    "Confirmation required before running '{}'. Repeat the same request within {}s to confirm (pending {}).",
+                    call.name, self.tool_policy.confirmation_ttl_secs, token
+                ),
             };
             self.audit_tool_call(call, exec_ctx, started, &tool_result);
             return tool_result;
@@ -1406,6 +1466,108 @@ fn actuation_rate_limit(config: &ActuationSafetyConfig, origin: RequestOrigin) -
         .unwrap_or(config.max_actions_per_minute)
 }
 
+/// Per-tool sliding-window rate limiter (issue #22). Independent of the
+/// per-origin actuation limiter; keyed by tool name across all origins and
+/// applied at the dispatch gate before any tool runs.
+#[derive(Debug, Default)]
+struct ToolRateLimiter {
+    attempts: Mutex<HashMap<String, VecDeque<u64>>>,
+}
+
+impl ToolRateLimiter {
+    /// Record a call and return `Err` if this tool's per-minute cap is
+    /// exceeded. A tool with no configured limit is always `Ok`.
+    fn check_and_record(&self, policy: &ToolPolicyConfig, tool: &str) -> Result<(), String> {
+        let Some(limit) = tool_rate_limit(policy, tool) else {
+            return Ok(());
+        };
+        if limit == 0 {
+            return Err(format!("'{tool}' is limited to zero calls per minute"));
+        }
+        let now = now_ms();
+        let cutoff = now.saturating_sub(ACTUATION_RATE_WINDOW_MS);
+        let mut attempts = self.attempts.lock().expect("tool rate limiter lock");
+        let bucket = attempts.entry(tool.to_string()).or_default();
+        while bucket.front().copied().is_some_and(|ts| ts < cutoff) {
+            bucket.pop_front();
+        }
+        if bucket.len() >= limit {
+            return Err(format!("'{tool}' exceeded {limit} call(s) per minute"));
+        }
+        bucket.push_back(now);
+        Ok(())
+    }
+}
+
+fn tool_rate_limit(policy: &ToolPolicyConfig, tool: &str) -> Option<usize> {
+    policy
+        .max_actions_per_minute_by_tool
+        .iter()
+        .find(|(key, _)| key.trim().eq_ignore_ascii_case(tool))
+        .map(|(_, limit)| *limit)
+}
+
+fn tool_requires_confirmation(policy: &ToolPolicyConfig, tool: &str) -> bool {
+    policy
+        .requires_confirmation_tools
+        .iter()
+        .any(|name| name.trim().eq_ignore_ascii_case(tool))
+}
+
+/// Outcome of the two-call tool confirmation gate (issue #22).
+enum ToolConfirm {
+    /// A matching un-expired pending entry was found and consumed — proceed.
+    Confirmed,
+    /// No pending entry existed; one was recorded. Caller must repeat the same
+    /// request within the TTL to confirm.
+    Pending { token: String },
+}
+
+/// Tracks pending two-call confirmations keyed by origin + tool + arguments,
+/// each with an expiry. In-memory and process-local, matching the existing
+/// home `ConfirmationManager`.
+#[derive(Debug, Default)]
+struct ToolConfirmationGate {
+    pending: Mutex<HashMap<String, u64>>,
+}
+
+impl ToolConfirmationGate {
+    fn check(
+        &self,
+        origin: RequestOrigin,
+        tool: &str,
+        args: &serde_json::Value,
+        ttl_secs: u64,
+    ) -> ToolConfirm {
+        let key = tool_confirmation_key(origin, tool, args);
+        let now = now_ms();
+        let mut pending = self.pending.lock().expect("tool confirmation lock");
+        pending.retain(|_, expiry| *expiry > now);
+        if pending.remove(&key).is_some() {
+            ToolConfirm::Confirmed
+        } else {
+            pending.insert(
+                key.clone(),
+                now.saturating_add(ttl_secs.saturating_mul(1000)),
+            );
+            ToolConfirm::Pending {
+                token: format!("confirm-{}", &key[..key.len().min(12)]),
+            }
+        }
+    }
+}
+
+/// Stable key for a pending confirmation: the same origin + tool + arguments
+/// always hash identically, so a repeated request clears the pending entry.
+fn tool_confirmation_key(origin: RequestOrigin, tool: &str, args: &serde_json::Value) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    origin.as_policy_key().hash(&mut hasher);
+    tool.hash(&mut hasher);
+    args.to_string().hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
 fn memory_query(args: &serde_json::Value) -> &str {
     let raw = args
         .get("query")
@@ -2019,6 +2181,151 @@ mod tests {
 
         assert!(!result.success);
         assert!(result.output.contains("origin policy"));
+    }
+
+    #[tokio::test]
+    async fn gate_per_tool_rate_limit_blocks_after_limit() {
+        // Issue #22: a per-tool cap applies at the gate for any origin/tool,
+        // independent of the per-origin home actuation limiter.
+        let mut policy = ToolPolicyConfig::default();
+        policy
+            .max_actions_per_minute_by_tool
+            .insert("get_time".into(), 2);
+        let dispatcher = ToolDispatcher::new(None).with_tool_policy_config(policy);
+        let call = ToolCall {
+            name: "get_time".into(),
+            arguments: serde_json::json!({}),
+        };
+
+        assert!(dispatcher.execute(&call).await.success);
+        assert!(dispatcher.execute(&call).await.success);
+        let blocked = dispatcher.execute(&call).await;
+        assert!(!blocked.success, "third call must bounce off the limit");
+        assert!(blocked.output.contains("rate limit"));
+    }
+
+    #[tokio::test]
+    async fn gate_confirmation_pends_then_executes_on_repeat() {
+        // Issue #22: a confirmation-required tool returns pending on the first
+        // call and executes on an identical repeat within the TTL.
+        let policy = ToolPolicyConfig {
+            requires_confirmation_tools: vec!["get_time".into()],
+            ..Default::default()
+        };
+        let dispatcher = ToolDispatcher::new(None).with_tool_policy_config(policy);
+        let call = ToolCall {
+            name: "get_time".into(),
+            arguments: serde_json::json!({}),
+        };
+
+        let first = dispatcher.execute(&call).await;
+        assert!(
+            first.output.contains("Confirmation required"),
+            "first call must request confirmation, got: {}",
+            first.output
+        );
+        let second = dispatcher.execute(&call).await;
+        assert!(
+            second.success && !second.output.contains("Confirmation required"),
+            "identical repeat within the TTL must execute, got: {}",
+            second.output
+        );
+    }
+
+    #[tokio::test]
+    async fn gate_expired_confirmation_never_executes() {
+        // Issue #22: an expired pending confirmation must re-pend, not execute.
+        // ttl=0 makes every pending expire immediately, so repeats keep pending.
+        let policy = ToolPolicyConfig {
+            requires_confirmation_tools: vec!["get_time".into()],
+            confirmation_ttl_secs: 0,
+            ..Default::default()
+        };
+        let dispatcher = ToolDispatcher::new(None).with_tool_policy_config(policy);
+        let call = ToolCall {
+            name: "get_time".into(),
+            arguments: serde_json::json!({}),
+        };
+
+        assert!(
+            dispatcher
+                .execute(&call)
+                .await
+                .output
+                .contains("Confirmation required")
+        );
+        assert!(
+            dispatcher
+                .execute(&call)
+                .await
+                .output
+                .contains("Confirmation required"),
+            "an expired confirmation must re-pend, not execute"
+        );
+    }
+
+    #[tokio::test]
+    async fn gate_explicit_confirmed_context_skips_confirmation() {
+        // Issue #22: an already-confirmed context (e.g. a dashboard confirm
+        // re-dispatch) bypasses the two-call dance and executes immediately.
+        let policy = ToolPolicyConfig {
+            requires_confirmation_tools: vec!["get_time".into()],
+            ..Default::default()
+        };
+        let dispatcher = ToolDispatcher::new(None).with_tool_policy_config(policy);
+
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "get_time".into(),
+                    arguments: serde_json::json!({}),
+                },
+                ToolExecutionContext {
+                    confirmed: true,
+                    ..ToolExecutionContext::default()
+                },
+            )
+            .await;
+        assert!(result.success);
+        assert!(!result.output.contains("Confirmation required"));
+    }
+
+    #[tokio::test]
+    async fn gate_audits_rate_limited_decision() {
+        // Issue #22: every gate decision is written to the tool audit log,
+        // including a rate-limit block — it is not silently dropped.
+        let dir = std::env::temp_dir().join(format!("genie-gate-audit-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let audit_path = dir.join("tool-audit.jsonl");
+        let _ = std::fs::remove_file(&audit_path);
+
+        let mut policy = ToolPolicyConfig::default();
+        policy
+            .max_actions_per_minute_by_tool
+            .insert("get_time".into(), 1);
+        let dispatcher = ToolDispatcher::new(None)
+            .with_tool_policy_config(policy)
+            .with_tool_audit_path(audit_path.clone());
+        let call = ToolCall {
+            name: "get_time".into(),
+            arguments: serde_json::json!({}),
+        };
+
+        assert!(dispatcher.execute(&call).await.success);
+        let blocked = dispatcher.execute(&call).await;
+        assert!(!blocked.success);
+
+        let log = std::fs::read_to_string(&audit_path).unwrap_or_default();
+        assert_eq!(
+            log.lines().count(),
+            2,
+            "both the allowed and the rate-limited call must be audited"
+        );
+        assert!(
+            log.contains("\"success\":false"),
+            "the blocked decision must appear in the audit log"
+        );
+        let _ = std::fs::remove_file(&audit_path);
     }
 
     #[tokio::test]

--- a/deploy/config/geniepod.toml
+++ b/deploy/config/geniepod.toml
@@ -180,6 +180,13 @@ wakeword_script = ""              # Empty = push-to-talk.
 # enabled = true
 # allowed_tools_by_origin = { voice = ["get_time", "get_weather", "memory_recall", "home_status", "home_control"] }
 # denied_tools_by_origin = { telegram = ["play_media"], "*" = [] }
+# Per-tool rate limit (calls/min) and two-call confirmation, enforced at the
+# single dispatch gate for every origin (issue #22). A confirmation-required
+# tool returns a pending token on first call and runs on an identical repeat
+# within confirmation_ttl_secs:
+# max_actions_per_minute_by_tool = { play_media = 10 }
+# requires_confirmation_tools = ["play_media"]
+# confirmation_ttl_secs = 120
 
 # Final actuation safety gate for physical home-control execution:
 # [core.actuation_safety]


### PR DESCRIPTION
## Summary

Closes #22. Completes the single tool-call gate. Every tool invocation already
funnels through `ToolDispatcher::execute_with_context` (quick-router fast path,
LLM-driven dispatch via `try_tool_call_with_context`, voice, REPL, OpenAI-compat,
and skill calls), so this makes that one method the complete gate the issue asks
for — rather than adding a parallel path.

### Already existed (kept as the gate's first checks)
- Per-origin × per-tool ACLs with `*` wildcards and deny-over-allow
  (`tool_origin_allowed`, enforced for every tool).
- Every tool call audited (`audit_tool_call`).
- Skill denied-permissions (`SkillPolicyConfig.denied_permissions`).
- `home_control`'s own confidence/risk-based confirmation, per-origin actuation
  rate limit, and confirmation tokens.

### Net-new in this PR
- **Per-tool rate limit** — `[core.tool_policy].max_actions_per_minute_by_tool`,
  a sliding window enforced at the gate for every origin, independent of the
  per-origin home actuation limiter.
- **Generic two-call confirmation** — `requires_confirmation_tools` +
  `confirmation_ttl_secs`. The first call records a pending entry (keyed by
  origin + tool + arguments) and returns a token *without executing*; an
  identical repeat within the TTL clears it and runs. An explicit `confirmed`
  context (e.g. a dashboard confirm re-dispatch) skips the dance. `home_control`
  is exempt — it keeps its richer risk-based flow below.
- **Audit every decision** — rate-limit and pending-confirmation now join deny
  in the tool audit log.
- **Observability** — the three new fields are surfaced in `policy_status`.

## Changes
- `crates/genie-common/src/config.rs`: three new `ToolPolicyConfig` fields with
  serde defaults (TTL default 120s); parse + default tests.
- `crates/genie-core/src/tools/dispatch.rs`: `ToolRateLimiter` +
  `ToolConfirmationGate`, the gate steps inside `execute_with_context` (now
  documented as the #22 chokepoint), policy_status fields, and 5 gate tests.
- `deploy/config/geniepod.toml`: documents the new keys.

## Acceptance criteria (issue #22)
- **Single chokepoint, no bypass** — all live callers route through
  `execute_with_context`; `parse_tool_calls_for_eval` is the only other parser
  path and is intentionally non-executing.
- **Deny by origin blocks** — existing `tool_policy_blocks_denied_tool_by_origin`.
- **Confirmation** — first pending → identical repeat executes → expired re-pends
  (three new tests).
- **Rate limit bounces after N** — new test.
- **Skill denied-permission rejected** — pre-existing `SkillPolicyConfig`.
- **Every gate decision audited** — new test asserts the rate-limited decision
  is written to the audit log.

## Real Behavior Proof

- [x] I have built and run the affected code locally.
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the validation gap below.

Tested profile / hardware:
- [x] `laptop`

### What I ran

    cargo fmt --all --check
    cargo clippy --workspace --all-targets --locked -- -D warnings
    cargo test -p genie-core -p genie-common -- --skip binary_size_budget

### What I observed
- fmt + clippy clean. 706 genie-core lib tests, 100 genie-common tests, and the
  #112 tool-gate integration test (10) all pass — including the 5 new gate tests.
- The change is agent-side dispatch/config logic (no Jetson runtime, voice, or HA
  hardware required), exercised deterministically by unit tests.

### Note on `binary_size_budget`
Locally (rustc 1.90.0) the release `genie-core` is 6.58 MB vs the 6.4 MB budget —
but current `main` is already **6.57 MB on the same local toolchain**, so this is
not a regression from this change (~10 KB). CI builds with
`dtolnay/rust-toolchain@stable` (newer), where `main` passes this check, so I
expect CI's `binary_size_budget` to pass. Flagging it explicitly rather than
touching the budget, which the test comment marks as a deliberate maintainer gate.
