### PR TITLE
chore(build): faster local builds — skip release LTO in cargo test, lighter dev debuginfo

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,21 @@ linker = "aarch64-linux-gnu-gcc"
 [target.aarch64-unknown-linux-gnu.env]
 CC_aarch64_unknown_linux_gnu = "aarch64-linux-gnu-gcc"
 AR_aarch64_unknown_linux_gnu = "aarch64-linux-gnu-ar"
+
+# ---------------------------------------------------------------------------
+# Optional: faster LOCAL linking (host x86_64 Linux only).
+#
+# Linking the genie-core binary dominates every incremental rebuild, and the
+# default GNU `ld` (bfd) is the slowest linker. Uncomment ONE block below to
+# speed up local builds. Left opt-in so a build never breaks for a contributor
+# who lacks the linker; CI is unaffected because its RUSTFLAGS env overrides
+# per-target rustflags, and the aarch64 cross build above is untouched.
+#
+# gold — ships with binutils, usually already installed:
+# [target.x86_64-unknown-linux-gnu]
+# rustflags = ["-C", "link-arg=-fuse-ld=gold"]
+#
+# mold — fastest; install with `sudo apt install mold`:
+# [target.x86_64-unknown-linux-gnu]
+# linker = "clang"
+# rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      # Run the slow release-build tests (binary_size_budget, core_binary_builds)
+      # here; they skip locally so `cargo test` stays fast for contributors.
+      GENIE_RUN_RELEASE_TESTS: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,15 @@ zeroize = { version = "1", features = ["derive", "serde"] }
 # Workspace crate references
 genie-common = { path = "crates/genie-common" }
 
+# Faster local/debug builds: line-tables keep backtraces readable but skip the
+# heavy per-variable debuginfo, and dependencies need no debuginfo at all. This
+# cuts compile + link time without touching the release (Jetson) build below.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false
+
 [profile.release]
 opt-level = "z"     # Optimize for binary size
 lto = true

--- a/crates/genie-core/tests/tool_dispatch_test.rs
+++ b/crates/genie-core/tests/tool_dispatch_test.rs
@@ -4,9 +4,22 @@
 
 use std::process::Command;
 
+/// The two release-build tests below each run a size-optimized LTO
+/// `cargo build --release` (slow, ~1-2 min). They are skipped locally so
+/// `cargo test` stays fast, and run in CI where `GENIE_RUN_RELEASE_TESTS` is set
+/// (see `.github/workflows/ci.yml`). Run them locally with:
+///   `GENIE_RUN_RELEASE_TESTS=1 cargo test -p genie-core --test tool_dispatch_test`
+fn release_tests_enabled() -> bool {
+    std::env::var_os("GENIE_RUN_RELEASE_TESTS").is_some()
+}
+
 /// Verify genie-core builds successfully.
 #[test]
 fn core_binary_builds() {
+    if !release_tests_enabled() {
+        eprintln!("skipping core_binary_builds (release build); set GENIE_RUN_RELEASE_TESTS=1");
+        return;
+    }
     let output = build_release_genie_core();
 
     assert!(
@@ -30,6 +43,10 @@ const RELEASE_BINARY_SIZE_BUDGET_MB: f64 = 6.4;
 /// Verify release binary stays within the release size budget.
 #[test]
 fn binary_size_budget() {
+    if !release_tests_enabled() {
+        eprintln!("skipping binary_size_budget (release build); set GENIE_RUN_RELEASE_TESTS=1");
+        return;
+    }
     let output = build_release_genie_core();
     assert!(
         output.status.success(),


### PR DESCRIPTION
## Summary

`cargo test` was silently doing a size-optimized **LTO release build** (~80-100s) on every run: the `binary_size_budget` and `core_binary_builds` integration tests shell out to `cargo build --release -p genie-core`, and `[profile.release]` is `opt-level=z` + `lto=true` + `codegen-units=1` (deliberately slow for the Jetson size budget). That made the local edit→test loop painful.

## Changes

- **`tests/tool_dispatch_test.rs`** — gate the two release-building tests behind `GENIE_RUN_RELEASE_TESTS`. They skip locally and run in CI.
- **`.github/workflows/ci.yml`** — set `GENIE_RUN_RELEASE_TESTS=1` on the `test` job only, so the size budget is still enforced in CI (the `--no-default-features` job no longer redundantly builds release either).
- **`Cargo.toml`** — `[profile.dev]` `debug = "line-tables-only"` + no debuginfo for deps: faster compile + link, backtraces still readable.
- **`.cargo/config.toml`** — commented opt-in fast-linker recipe (gold/mold) for host Linux. Left opt-in so no contributor's build breaks; CI/Jetson unaffected.

No production code changes; the release/Jetson build is untouched.

## Real Behavior Proof

- [x] Built and run locally (laptop).
- [x] Not on Jetson — pure host build-tooling, no device path touched.

### Measured
- Warm `cargo test -p genie-core --test tool_dispatch_test`: **~80s → 0.36s** (no release build).
- `binary_size_budget` / `core_binary_builds` skip locally (`test result: ok`, 0.02s) and still run in CI via the env.
- `cargo fmt --all --check` clean; `cargo clippy --tests -- -D warnings` clean; ci.yml validated as YAML.