### PR TITLE
feat(deploy): ship all deploy/scripts to Jetson + add genie-drop-caches.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ BINARIES = genie-core genie-ctl genie-governor genie-health genie-api
 RELEASE_DIR = target/release
 CROSS_DIR = target/$(AARCH64)/release
 INSTALL_DIR = /opt/geniepod
+# Every helper under deploy/scripts/ deploys to $(INSTALL_DIR)/bin on the Jetson.
+# A wildcard means a newly added script ships automatically (no list to update).
+JETSON_SCRIPTS = $(wildcard deploy/scripts/*)
 
 .PHONY: all build test release jetson deploy deploy-config deploy-systemd clean check fmt jetson-ai-runtime soak-selfcheck
 
@@ -127,12 +130,9 @@ deploy-docker:
 
 deploy-setup:
 	scp deploy/setup-jetson.sh $(JETSON_TARGET):/tmp/
-	scp deploy/scripts/genie-wake-listen.py deploy/scripts/genie-wakeword.py deploy/scripts/detect-audio-device.sh deploy/scripts/genie-restart-all.sh deploy/scripts/start_all.sh deploy/scripts/stop_all.sh deploy/scripts/genie-model-cache-status.sh deploy/scripts/genie-audio-init $(JETSON_TARGET):/tmp/
-	ssh $(JETSON_TARGET) 'sudo cp /tmp/setup-jetson.sh $(INSTALL_DIR)/setup-jetson.sh && \
-		sudo chmod +x $(INSTALL_DIR)/setup-jetson.sh && \
-		sudo mkdir -p $(INSTALL_DIR)/bin && \
-		sudo cp /tmp/genie-wake-listen.py /tmp/genie-wakeword.py /tmp/detect-audio-device.sh /tmp/genie-restart-all.sh /tmp/start_all.sh /tmp/stop_all.sh /tmp/genie-model-cache-status.sh /tmp/genie-audio-init $(INSTALL_DIR)/bin/ && \
-		sudo chmod +x $(INSTALL_DIR)/bin/genie-wake-listen.py $(INSTALL_DIR)/bin/genie-wakeword.py $(INSTALL_DIR)/bin/detect-audio-device.sh $(INSTALL_DIR)/bin/genie-restart-all.sh $(INSTALL_DIR)/bin/start_all.sh $(INSTALL_DIR)/bin/stop_all.sh $(INSTALL_DIR)/bin/genie-model-cache-status.sh $(INSTALL_DIR)/bin/genie-audio-init'
+	ssh $(JETSON_TARGET) 'rm -rf /tmp/geniepod-scripts && mkdir -p /tmp/geniepod-scripts'
+	scp $(JETSON_SCRIPTS) $(JETSON_TARGET):/tmp/geniepod-scripts/
+	ssh $(JETSON_TARGET) 'sudo cp /tmp/setup-jetson.sh $(INSTALL_DIR)/setup-jetson.sh && sudo chmod +x $(INSTALL_DIR)/setup-jetson.sh && sudo mkdir -p $(INSTALL_DIR)/bin && sudo cp /tmp/geniepod-scripts/* $(INSTALL_DIR)/bin/ && sudo chmod +x $(addprefix $(INSTALL_DIR)/bin/,$(notdir $(JETSON_SCRIPTS))) && rm -rf /tmp/geniepod-scripts'
 
 # ── Alternate LLM runtime: genie-ai-runtime (issue #54) ─────────
 #

--- a/crates/genie-core/tests/tool_dispatch_test.rs
+++ b/crates/genie-core/tests/tool_dispatch_test.rs
@@ -252,25 +252,41 @@ fn jetson_lifecycle_scripts_are_valid_shell() {
     }
 }
 
-/// Verify the deploy pipeline copies the Jetson lifecycle helper scripts.
+/// Verify the deploy pipeline ships the Jetson helper scripts. They are deployed
+/// via the `JETSON_SCRIPTS = $(wildcard deploy/scripts/*)` glob, so this guards
+/// the mechanism (glob + install into bin) and that each critical helper exists
+/// under deploy/scripts/ so the glob actually picks it up.
 #[test]
 fn makefile_deploys_lifecycle_helpers() {
-    let path = workspace_root().join("Makefile");
-    let contents = std::fs::read_to_string(&path).unwrap();
+    let makefile = std::fs::read_to_string(workspace_root().join("Makefile")).unwrap();
+
+    assert!(
+        makefile.contains("JETSON_SCRIPTS = $(wildcard deploy/scripts/*)"),
+        "Makefile should glob deploy/scripts/* into JETSON_SCRIPTS so new scripts ship automatically"
+    );
+    assert!(
+        makefile.contains("scp $(JETSON_SCRIPTS)"),
+        "deploy-setup should scp every script in JETSON_SCRIPTS to the Jetson"
+    );
+    assert!(
+        makefile.contains("$(addprefix $(INSTALL_DIR)/bin/,$(notdir $(JETSON_SCRIPTS)))"),
+        "deploy-setup should install the JETSON_SCRIPTS into $(INSTALL_DIR)/bin"
+    );
 
     for script in [
         "genie-restart-all.sh",
         "start_all.sh",
         "stop_all.sh",
         "genie-model-cache-status.sh",
+        "genie-disable-gui.sh",
+        "genie-drop-caches.sh",
     ] {
         assert!(
-            contents.contains(&format!("deploy/scripts/{script}")),
-            "Makefile should copy {script} during deploy"
-        );
-        assert!(
-            contents.contains(&format!("$(INSTALL_DIR)/bin/{script}")),
-            "Makefile should install {script} into /opt/geniepod/bin"
+            workspace_root()
+                .join("deploy/scripts")
+                .join(script)
+                .exists(),
+            "{script} should exist under deploy/scripts/ so the deploy glob ships it"
         );
     }
 }

--- a/deploy/scripts/genie-disable-gui.sh
+++ b/deploy/scripts/genie-disable-gui.sh
@@ -7,8 +7,8 @@
 # this drops to a console-only boot and frees that memory for the agent.
 #
 # Usage (run on the Jetson, as root):
-#   sudo bash /opt/geniepod/scripts/genie-disable-gui.sh          # disable GUI
-#   sudo bash /opt/geniepod/scripts/genie-disable-gui.sh --enable # restore GUI
+#   sudo bash /opt/geniepod/bin/genie-disable-gui.sh          # disable GUI
+#   sudo bash /opt/geniepod/bin/genie-disable-gui.sh --enable # restore GUI
 #
 # It is idempotent and reversible. Best run over SSH — it tears down the local
 # desktop session immediately, so a monitor/keyboard session would be dropped

--- a/deploy/scripts/genie-drop-caches.sh
+++ b/deploy/scripts/genie-drop-caches.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# GeniePod — drop kernel caches to reclaim RAM on the Jetson.
+#
+# The Linux page cache, dentries, and inode caches are reclaimable memory, but
+# on the Orin Nano's tight 8 GB *unified* pool they can crowd out a large model
+# load or inflate memory-pressure readings. This drops them on demand — useful
+# before loading the LLM, between soak/test runs, or when checking the true
+# free-memory headroom. It is safe (caches just re-warm from disk), so the only
+# cost is a brief slowdown as hot files are re-read.
+#
+# Usage (on the Jetson, as root):
+#   sudo bash /opt/geniepod/bin/genie-drop-caches.sh        # drop everything (3)
+#   sudo bash /opt/geniepod/bin/genie-drop-caches.sh 1      # page cache only
+#   sudo bash /opt/geniepod/bin/genie-drop-caches.sh 2      # dentries + inodes
+#
+# Levels follow /proc/sys/vm/drop_caches: 1=pagecache, 2=slab (dentries/inodes),
+# 3=both (default).
+
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "This script must run as root. Re-run with: sudo $0 $*" >&2
+  exit 1
+fi
+
+level="${1:-3}"
+case "$level" in
+  1 | 2 | 3) ;;
+  *)
+    echo "usage: $0 [1|2|3]   (1=pagecache, 2=slab, 3=both; default 3)" >&2
+    exit 1
+    ;;
+esac
+
+avail_mb() { free -m | awk '/^Mem:/ {print $7}'; }
+
+before="$(avail_mb)"
+
+# Flush dirty pages first so they are reclaimable, then drop the requested caches.
+sync
+echo "$level" > /proc/sys/vm/drop_caches
+
+# Best-effort: compact free memory so large contiguous allocations (model load /
+# KV cache) are easier to satisfy. Not present on every kernel — ignore failures.
+echo 1 > /proc/sys/vm/compact_memory 2>/dev/null || true
+
+after="$(avail_mb)"
+
+echo "drop_caches=${level}  available RAM: ${before} MB -> ${after} MB"


### PR DESCRIPTION
## Summary

Two things, both Jetson memory/ops helpers:

1. **`make deploy-setup` now ships every `deploy/scripts/*`** via a wildcard (`JETSON_SCRIPTS`). The old recipe hardcoded the list, so `genie-disable-gui.sh` (added in #380) — and any future script — silently never reached the Jetson. `chmod +x` targets exactly the copied scripts (computed with `addprefix`/`notdir`), so the Rust binaries in `bin/` aren't touched.
2. **New `deploy/scripts/genie-drop-caches.sh`** — drops kernel page/slab caches (`/proc/sys/vm/drop_caches`) + best-effort `compact_memory` to reclaim RAM on the Orin Nano's 8 GB unified pool. Reports available RAM before/after. Levels 1/2/3 (default 3).

Also fixes the `genie-disable-gui.sh` usage comment to its real install path (`/opt/geniepod/bin`, where deploy-setup puts it).

## Real Behavior Proof

- [x] Built/validated locally (laptop).
- [x] Not run on Jetson — deploy tooling; validated by dry-run.

### What I ran / observed
- `make -n deploy-setup` expands correctly: scp's all 10 scripts (incl. `genie-disable-gui.sh` + `genie-drop-caches.sh`) to a temp dir, installs to `/opt/geniepod/bin`, and chmods exactly those files.
- `bash -n` clean on both scripts; the new one mirrors `genie-disable-gui.sh`'s shellcheck-clean style.