### PR TITLE
feat(deploy): env-configurable llama.cpp ctx-size + model — enable the 16k Nemotron-4B experiment (#376)

### DIFF
--- a/deploy/config/llm.env.example
+++ b/deploy/config/llm.env.example
@@ -1,0 +1,21 @@
+# Optional per-host overrides for the llama.cpp LLM server (genie-llm.service).
+#
+# Copy to /etc/geniepod/llm.env to override the served model and/or context size
+# WITHOUT editing the systemd unit or using drop-ins (setup-jetson.sh wipes
+# ctx.conf/model.conf drop-ins; this EnvironmentFile is left alone). Only
+# meaningful when [services.llm].backend = "llama_cpp" in geniepod.toml.
+#
+#   sudo cp deploy/config/llm.env.example /etc/geniepod/llm.env   # then edit
+#   sudo systemctl restart genie-llm.service
+
+# Model GGUF served by llama-server (default: the unit's phi-4-mini path).
+#GENIEPOD_LLM_MODEL=/opt/geniepod/models/Qwen3-4B-Q4_K_M.gguf
+
+# llama-server context window / KV-cache size (default: 2048). Raising this costs
+# unified memory — that trade-off is exactly what issue #376 evaluates.
+#GENIEPOD_LLM_CTX_SIZE=2048
+
+# --- Example: the 16k-context Nemotron-4B experiment (issue #376) -------------
+# Place a Nemotron-4B Q4_K_M GGUF on disk first, then uncomment:
+#GENIEPOD_LLM_MODEL=/opt/geniepod/models/nemotron-mini-4b-instruct-q4_k_m.gguf
+#GENIEPOD_LLM_CTX_SIZE=16384

--- a/deploy/systemd/genie-llm.service
+++ b/deploy/systemd/genie-llm.service
@@ -12,7 +12,7 @@ ExecStart=/opt/geniepod/bin/llama-server \
     --model ${GENIEPOD_LLM_MODEL} \
     --host 0.0.0.0 \
     --port 8080 \
-    --ctx-size 2048 \
+    --ctx-size ${GENIEPOD_LLM_CTX_SIZE} \
     --n-gpu-layers 999 \
     --threads 4 \
     --parallel 1 \
@@ -23,11 +23,18 @@ ExecStart=/opt/geniepod/bin/llama-server \
 # Tegra/aarch64 CUDA this combination currently crashes with
 # `GGML_ASSERT(ggml_is_contiguous(a)) failed` in ggml_reshape_2d via
 # llm_build_phi3::build_attn. Tracked upstream in llama.cpp; the
-# --ctx-size 2048 reduction alone (was 4096) is enough to ease the
+# --ctx-size default of 2048 (down from 4096) is enough to ease the
 # iGPU eviction pressure that was slowing STT after long LLM responses
 # (see #2 for the full memory-budget math).
 
+# Model + context size are env-driven so a host can override them WITHOUT editing
+# this unit or using systemd drop-ins (setup-jetson.sh wipes ctx.conf/model.conf
+# drop-ins; the optional EnvironmentFile below is left alone). The defaults keep
+# current behavior; /etc/geniepod/llm.env is where the issue #376 16k experiment
+# raises the context and points at a different model. See deploy/config/llm.env.example.
 Environment=GENIEPOD_LLM_MODEL=/opt/geniepod/models/phi-4-mini-instruct-q4_k_m.gguf
+Environment=GENIEPOD_LLM_CTX_SIZE=2048
+EnvironmentFile=-/etc/geniepod/llm.env
 Restart=on-failure
 RestartSec=5
 TimeoutStartSec=120

--- a/doc/experiments/nemotron-16k-llama-cpp.md
+++ b/doc/experiments/nemotron-16k-llama-cpp.md
@@ -1,0 +1,80 @@
+# Experiment: 16k context, llama.cpp backend, Nemotron-4B Q4 (issue #376)
+
+Evaluate whether a larger **16k context with Nemotron-4B (Q4)** on the
+`llama.cpp` backend changes tool-call accuracy / behavior versus the 4096-token
+Qwen baseline, on Jetson Orin Nano 8 GB.
+
+This is an **opt-in experiment.** The product default stays the 4096-token
+`genie-ai-runtime` + Qwen path. It intentionally exceeds the Jetson baseline, so
+the boot harness will log `jetson_baseline_context: fail` and `/api/runtime/contract`
+will report the larger context — that is **expected** for the experiment, not a
+regression. Nothing in the repo defaults changes.
+
+## Prerequisites
+
+- `llama-server` installed at `/opt/geniepod/bin/llama-server` (the legacy backend
+  path; see `setup-jetson.sh`).
+- A **Nemotron-4B Q4_K_M GGUF** on the Jetson — e.g. NVIDIA *Nemotron-Mini-4B-Instruct*.
+  There is no auto-download for nemotron yet, so fetch a GGUF quant and copy it:
+  ```bash
+  # from a dev machine
+  scp nemotron-mini-4b-instruct-q4_k_m.gguf aihpc@<jetson>:/tmp/
+  ssh aihpc@<jetson> 'sudo mv /tmp/nemotron-mini-4b-instruct-q4_k_m.gguf \
+      /opt/geniepod/models/nemotron-mini-4b-instruct-q4_k_m.gguf'
+  ```
+
+## Steps (on the Jetson)
+
+1. **Point llama-server at Nemotron + 16k context** via `/etc/geniepod/llm.env`
+   (template: `deploy/config/llm.env.example`):
+   ```ini
+   GENIEPOD_LLM_MODEL=/opt/geniepod/models/nemotron-mini-4b-instruct-q4_k_m.gguf
+   GENIEPOD_LLM_CTX_SIZE=16384
+   ```
+   `genie-llm.service` reads these via `EnvironmentFile=-/etc/geniepod/llm.env`, so
+   no unit edit and no drop-in (which `setup-jetson.sh` would wipe).
+
+2. **Switch the agent to the llama.cpp backend + a 16k budget** in
+   `/etc/geniepod/geniepod.toml`:
+   ```toml
+   [agent]
+   context_window_tokens = 16384   # intentionally above the 4096 baseline, this experiment only
+
+   [core]
+   llm_model_name = "nemotron-4b"  # selects the Nemotron prompt family
+
+   [services.llm]
+   backend = "llama_cpp"
+   systemd_unit = "genie-llm.service"
+   ```
+
+3. **Restart:**
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl restart genie-llm.service
+   sudo systemctl restart genie-core.service
+   ```
+
+4. **Confirm:** `genie-ctl status` shows the `llama.cpp` backend; `journalctl -u
+   genie-llm` shows `--ctx-size 16384` and the nemotron model loading. Watch
+   `tegrastats` for memory pressure / OOM during load.
+
+## Measure (vs the Qwen 4096 baseline)
+
+- **BFCL tool-call accuracy** on the same fixtures:
+  `genie-ctl bfcl-predict-llm` then `genie-ctl bfcl-score-llm` (baseline: 5.77%
+  strict on the 208 HA-Intents quick-router cases).
+- First-token + tool-response **latency**, and **unified-memory footprint** at
+  16k (`tegrastats`).
+- Whether nemotron-4b @ 16k **loads and serves without OOM** on the 8 GB pool —
+  note that the unit comment flags a `flash-attn` + large-ctx instability on
+  Tegra/aarch64 CUDA; if it crashes, retry with a smaller ctx (e.g. 8192) or
+  `--flash-attn off`.
+
+Record results on **issue #376**.
+
+## Revert
+
+Remove `/etc/geniepod/llm.env` (or unset the vars), restore the 4096
+`genie-ai-runtime` defaults in `geniepod.toml`, and restart — or just re-run
+`setup-jetson.sh`, which keeps the unit's 2048 default.


### PR DESCRIPTION
## Summary

Enables the issue #376 experiment — **16k context, llama.cpp backend, Nemotron-4B Q4** — *without* touching the product defaults or the 4096 Jetson baseline.

`genie-llm.service` hardcoded `--ctx-size 2048` and the model env, and `setup-jetson.sh` deliberately wipes systemd drop-ins (`ctx.conf`/`model.conf`), so there was no clean override path. This drives both from env vars with the **current defaults preserved** (2048 ctx, phi-4-mini), readable from an optional `/etc/geniepod/llm.env`.

## Changes
- `deploy/systemd/genie-llm.service`: `--ctx-size ${GENIEPOD_LLM_CTX_SIZE}` (default 2048) + `EnvironmentFile=-/etc/geniepod/llm.env` (optional, survives setup re-runs). Behavior unchanged unless the env file is present.
- `deploy/config/llm.env.example`: template documenting `GENIEPOD_LLM_MODEL` / `GENIEPOD_LLM_CTX_SIZE`, with the 16k-Nemotron values.
- `doc/experiments/nemotron-16k-llama-cpp.md`: runbook — place the Nemotron GGUF, set the env + `geniepod.toml` (`backend=llama_cpp`, `llm_model_name="nemotron-4b"`, `context_window_tokens=16384`), restart, and measure BFCL/latency/memory vs the Qwen 4096 baseline.

Nemotron is already a supported prompt family (`prompt.rs` → `ModelFamily::Nemotron`). 16k intentionally exceeds the baseline, so the boot harness logs `jetson_baseline_context: fail` — expected for this opt-in path, not a regression.

## Real Behavior Proof
- [x] Built/validated locally (laptop).
- [ ] Not yet run on Jetson — that's the experiment itself (#376).

### What I ran / observed
- `cargo test -p genie-core --test tool_dispatch_test`: `systemd_units_valid`, `config_parses`, and the other deploy tests pass (the unit edit + new files don't break anything; no test asserts the unit's literal ctx-size).
- Defaults unchanged: the repo `geniepod.toml` stays 4096 and the unit still defaults to 2048.