### PR TITLE
docs(readme): add Discord Join badge before the CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # GenieClaw
 
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/r6B22DP83k)
 [![CI](https://github.com/GeniePod/genie-claw/actions/workflows/ci.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/ci.yml)
 [![Jetson cross-compile](https://github.com/GeniePod/genie-claw/actions/workflows/cross.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/cross.yml)
 [![Audit](https://github.com/GeniePod/genie-claw/actions/workflows/audit.yml/badge.svg)](https://github.com/GeniePod/genie-claw/actions/workflows/audit.yml)


### PR DESCRIPTION
Adds a Discord **Join** badge (shields.io, same style as referenced) as the first badge in the README header, linking to https://discord.gg/r6B22DP83k — so the community invite sits in front of the CI/cross-compile/audit badges.

## Real Behavior Proof

Docs-only change.

**What I ran:** reviewed the rendered `README.md` header diff — the Discord badge renders before the CI badge and links to the invite.
**What I observed:** Markdown/badge renders; no code or build surfaces touched — static checks apply.

- [x] Docs-only change verified by review; no code paths affected.
