### PR TITLE
fix(tools): reject invalid get_weather location before evaluation

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -135,6 +135,14 @@ fn parse_play_media_query(args: &serde_json::Value) -> Result<&str> {
         .ok_or_else(|| anyhow::anyhow!("play_media requires non-empty string argument 'query'"))
 }
 
+fn parse_get_weather_location(args: &serde_json::Value) -> Result<&str> {
+    args.get("location")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("get_weather requires non-empty string argument 'location'"))
+}
+
 /// Tool definition for LLM function calling.
 ///
 /// These are sent to the configured LLM backend as part of the system prompt or
@@ -2060,10 +2068,7 @@ fn exec_calculate(args: &serde_json::Value) -> Result<String> {
 }
 
 async fn exec_weather(args: &serde_json::Value) -> Result<String> {
-    let location = args
-        .get("location")
-        .and_then(|v| v.as_str())
-        .unwrap_or("Denver");
+    let location = parse_get_weather_location(args)?;
     let forecast = args
         .get("forecast")
         .and_then(|v| v.as_bool())

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -807,6 +807,71 @@ async fn play_media_rejects_invalid_arguments_and_audits() {
     }
 }
 
+#[tokio::test]
+async fn get_weather_rejects_invalid_arguments_and_audits() {
+    let paths = TestAuditPaths::new();
+    let dispatcher = paths.dispatcher(
+        None,
+        ToolPolicyConfig::default(),
+        ActuationSafetyConfig::default(),
+    );
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Dashboard,
+        ..ToolExecutionContext::default()
+    };
+
+    let invalid_calls = [
+        (
+            serde_json::json!({}),
+            "get_weather requires non-empty string argument 'location'",
+        ),
+        (
+            serde_json::json!({"location": ""}),
+            "get_weather requires non-empty string argument 'location'",
+        ),
+        (
+            serde_json::json!({"location": 42}),
+            "get_weather requires non-empty string argument 'location'",
+        ),
+    ];
+    let expected_audit_count = invalid_calls.len();
+
+    for (arguments, expected_snippet) in &invalid_calls {
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "get_weather".into(),
+                    arguments: arguments.clone(),
+                },
+                ctx,
+            )
+            .await;
+
+        assert!(
+            !result.success,
+            "expected schema rejection, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains(expected_snippet),
+            "expected output to contain {expected_snippet:?}, got: {}",
+            result.output
+        );
+    }
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(
+        events.len(),
+        expected_audit_count,
+        "each rejected call must be tool-audited"
+    );
+    for event in &events {
+        assert_eq!(event["tool"], "get_weather");
+        assert_eq!(event["origin"], "dashboard");
+        assert_eq!(event["success"], false);
+    }
+}
+
 // --- Issue #22: per-tool rate limits + two-step confirmation gate ----------
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #408

## Summary

`get_weather` marked `location` as required in `ToolDef` but `exec_weather` silently defaulted missing values to `"Denver"` and returned a successful weather response. This PR adds `parse_get_weather_location()` and rejects missing, empty, or wrong-type `location` before calling Open-Meteo.

## Changes

- Add `parse_get_weather_location()` with non-empty string `location` validation.
- Use parser in `exec_weather()` before calling the weather backend.
- Add `get_weather_rejects_invalid_arguments_and_audits` integration test.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On x86_64 Linux dev host (`laptop` profile), branch `fix/issue-408-get-weather-schema-validation`:

```bash
cd genie-claw
cargo fmt -p genie-core
cargo test -p genie-core --test tool_gate_integration_test get_weather_rejects_invalid_arguments_and_audits
cargo test -p genie-core --test tool_gate_integration_test
cargo clippy -p genie-core -- -D warnings
```

### What I observed

- `get_weather_rejects_invalid_arguments_and_audits` passes for `{}`, empty `location`, and non-string `location`.
- Full `tool_gate_integration_test` suite passes (16/16).
- Clippy clean on `genie-core`.
- Invalid calls return `success: false` with a schema error and tool audit entry instead of Denver weather.

Jetson validation gap: schema enforcement verified via integration tests on dev host; no Open-Meteo/network behavior change for valid calls.

## Test plan

- `cargo test -p genie-core --test tool_gate_integration_test get_weather_rejects_invalid_arguments_and_audits`
- `cargo test -p genie-core --test tool_gate_integration_test`
- `cargo clippy -p genie-core -- -D warnings`

## Notes for reviewers

M1 typed-tool reliability follow-up to closed #330 / #344 / #359 / #361 / #391. Valid weather calls with a proper `location` are unchanged; Open-Meteo/network errors still surface after schema validation passes.
