### PR TITLE
fix(tools): reject invalid web_search query before search backend

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -143,6 +143,15 @@ fn parse_play_media_query(args: &serde_json::Value) -> Result<&str> {
         .ok_or_else(|| anyhow::anyhow!("play_media requires non-empty string argument 'query'"))
 }
 
+fn parse_web_search_query(args: &serde_json::Value) -> Result<&str> {
+    args.get("query")
+        .or_else(|| args.get("q"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("web_search requires non-empty string argument 'query'"))
+}
+
 /// Tool definition for LLM function calling.
 ///
 /// These are sent to the configured LLM backend as part of the system prompt or
@@ -2082,12 +2091,7 @@ async fn exec_weather(args: &serde_json::Value) -> Result<String> {
 }
 
 async fn exec_web_search(args: &serde_json::Value, config: &WebSearchConfig) -> Result<String> {
-    let query = args
-        .get("query")
-        .or_else(|| args.get("q"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .trim();
+    let query = parse_web_search_query(args)?;
     let limit = args
         .get("limit")
         .and_then(|v| v.as_u64())

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -875,8 +875,10 @@ async fn play_media_rejects_invalid_arguments_and_audits() {
 #[tokio::test]
 async fn web_search_rejects_invalid_arguments_and_audits() {
     let paths = TestAuditPaths::new();
-    let mut web_search = WebSearchConfig::default();
-    web_search.enabled = true;
+    let web_search = WebSearchConfig {
+        enabled: true,
+        ..Default::default()
+    };
     let dispatcher = paths
         .dispatcher(
             None,

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -5,7 +5,7 @@
 //! proven without a real Home Assistant instance.
 
 use async_trait::async_trait;
-use genie_common::config::{ActuationSafetyConfig, ToolPolicyConfig};
+use genie_common::config::{ActuationSafetyConfig, ToolPolicyConfig, WebSearchConfig};
 use genie_core::ha::{
     ActionResult, DeviceRef, HomeAction, HomeActionKind, HomeAutomationProvider, HomeGraph,
     HomeState, HomeTarget, HomeTargetKind, IntegrationHealth, SceneRef,
@@ -867,6 +867,75 @@ async fn play_media_rejects_invalid_arguments_and_audits() {
     );
     for event in &events {
         assert_eq!(event["tool"], "play_media");
+        assert_eq!(event["origin"], "dashboard");
+        assert_eq!(event["success"], false);
+    }
+}
+
+#[tokio::test]
+async fn web_search_rejects_invalid_arguments_and_audits() {
+    let paths = TestAuditPaths::new();
+    let mut web_search = WebSearchConfig::default();
+    web_search.enabled = true;
+    let dispatcher = paths
+        .dispatcher(
+            None,
+            ToolPolicyConfig::default(),
+            ActuationSafetyConfig::default(),
+        )
+        .with_web_search_config(web_search);
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Dashboard,
+        ..ToolExecutionContext::default()
+    };
+
+    let invalid_calls = [
+        (
+            serde_json::json!({}),
+            "web_search requires non-empty string argument 'query'",
+        ),
+        (
+            serde_json::json!({"query": ""}),
+            "web_search requires non-empty string argument 'query'",
+        ),
+        (
+            serde_json::json!({"query": 42}),
+            "web_search requires non-empty string argument 'query'",
+        ),
+    ];
+    let expected_audit_count = invalid_calls.len();
+
+    for (arguments, expected_snippet) in &invalid_calls {
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "web_search".into(),
+                    arguments: arguments.clone(),
+                },
+                ctx,
+            )
+            .await;
+
+        assert!(
+            !result.success,
+            "expected schema rejection, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains(expected_snippet),
+            "expected output to contain {expected_snippet:?}, got: {}",
+            result.output
+        );
+    }
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(
+        events.len(),
+        expected_audit_count,
+        "each rejected call must be tool-audited"
+    );
+    for event in &events {
+        assert_eq!(event["tool"], "web_search");
         assert_eq!(event["origin"], "dashboard");
         assert_eq!(event["success"], false);
     }


### PR DESCRIPTION
Fixes #411

## Summary

`web_search` marked `query` as required in `ToolDef` but `exec_web_search` passed an empty string for missing or wrong-type arguments. The search backend returned `"Please specify what to search for."` as `Ok(...)`, which `execute_with_context` recorded as **`success: true`**. This PR adds `parse_web_search_query()` and rejects invalid arguments at the dispatch boundary before calling the search backend.

## Changes

- Add `parse_web_search_query()` with non-empty string validation (preserves existing `q` alias).
- Use parser in `exec_web_search()` before `search_with_options`.
- Add `web_search_rejects_invalid_arguments_and_audits` integration test with `WebSearchConfig { enabled: true, .. }`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On x86_64 Linux dev host (`laptop` profile), branch `fix/issue-411-web-search-schema-validation`:

```bash
cd genie-claw
cargo fmt -p genie-core
cargo test -p genie-core --test tool_gate_integration_test web_search_rejects_invalid_arguments_and_audits
cargo test -p genie-core --test tool_gate_integration_test
cargo clippy -p genie-core -- -D warnings
```

### What I observed

- `web_search_rejects_invalid_arguments_and_audits` passes for `{}`, empty `query`, and non-string `query`.
- Full `tool_gate_integration_test` suite passes (17/17).
- Clippy clean on `genie-core`.
- Invalid calls return `success: false` with a schema error and tool audit entry instead of soft success text.

Jetson validation gap: schema enforcement verified via integration tests on dev host; valid web_search calls still reach the existing search backend unchanged.

## Test plan

- `cargo test -p genie-core --test tool_gate_integration_test web_search_rejects_invalid_arguments_and_audits`
- `cargo test -p genie-core --test tool_gate_integration_test`
- `cargo clippy -p genie-core -- -D warnings`

## Notes for reviewers

M1 typed-tool reliability follow-up to closed #330 / #344 / #359 / #361 / #391 / #392. The empty-query fallback in `web_search.rs` remains as defense in depth for non-dispatch callers; dispatch now rejects invalid tool-call arguments first (same pattern as `play_media` and `calculate`).
