### PR TITLE
fix(tools): reject non-numeric home_control value at execution boundary

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -52,7 +52,20 @@ fn parse_home_control_args(args: &serde_json::Value) -> Result<(&str, &str, Opti
             HOME_CONTROL_ACTIONS.join(", ")
         )
     })?;
-    Ok((entity, action, args.get("value").and_then(|v| v.as_f64())))
+    // `value` stays optional, but a *provided* value must be a number. The old
+    // `args.get("value").and_then(|v| v.as_f64())` silently dropped a non-numeric
+    // value (e.g. a model emitting `"value": "72"` or `"value": true`) to `None`,
+    // so `set_temperature` / `set_brightness` actuated with no value instead of
+    // the user's intent. Reject the malformed value at the boundary the same way
+    // set_timer rejects a non-integer `seconds`; an absent or null value is still
+    // a no-op None.
+    let value = match args.get("value") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(provided) => Some(provided.as_f64().ok_or_else(|| {
+            anyhow::anyhow!("home_control 'value' must be a number when provided")
+        })?),
+    };
+    Ok((entity, action, value))
 }
 
 /// Canonicalize a model-emitted action verb to one of [`HOME_CONTROL_ACTIONS`].
@@ -2511,6 +2524,42 @@ mod tests {
             parse_home_control_args(&args).expect("'turn off' should canonicalize and parse");
         assert_eq!(entity, "kitchen lights");
         assert_eq!(action, "turn_off");
+    }
+
+    #[test]
+    fn home_control_value_must_be_numeric_when_provided() {
+        // A numeric value parses through to Some(..).
+        let args =
+            serde_json::json!({"entity": "thermostat", "action": "set_temperature", "value": 72});
+        let (_, _, value) = parse_home_control_args(&args).expect("numeric value parses");
+        assert_eq!(value, Some(72.0));
+
+        // An absent value is a legitimate no-op None — value stays optional.
+        let args = serde_json::json!({"entity": "kitchen lights", "action": "turn_on"});
+        let (_, _, value) = parse_home_control_args(&args).expect("absent value parses");
+        assert_eq!(value, None);
+
+        // An explicit null is also None, not a rejection.
+        let args =
+            serde_json::json!({"entity": "kitchen lights", "action": "turn_on", "value": null});
+        let (_, _, value) = parse_home_control_args(&args).expect("null value parses");
+        assert_eq!(value, None);
+
+        // The bug: a provided but non-numeric value used to be silently dropped
+        // to None, so the action actuated without it. It must now be rejected.
+        for bad in [
+            serde_json::json!({"entity": "thermostat", "action": "set_temperature", "value": "72"}),
+            serde_json::json!({"entity": "thermostat", "action": "set_temperature", "value": true}),
+            serde_json::json!({"entity": "thermostat", "action": "set_temperature", "value": [72]}),
+        ] {
+            let err = parse_home_control_args(&bad)
+                .expect_err("non-numeric value must be rejected")
+                .to_string();
+            assert!(
+                err.contains("home_control 'value' must be a number when provided"),
+                "unexpected error: {err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -492,6 +492,10 @@ async fn home_control_rejects_invalid_arguments_and_audits() {
             serde_json::json!({"entity": "kitchen light"}),
             "home_control requires string argument 'action'",
         ),
+        (
+            serde_json::json!({"entity": "kitchen light", "action": "turn_on", "value": "hot"}),
+            "home_control 'value' must be a number when provided",
+        ),
     ];
     let expected_audit_count = invalid_calls.len();
 


### PR DESCRIPTION
## Summary

`home_control` silently dropped a *provided* non-numeric `value` argument instead of rejecting it, so a `set_temperature` / `set_brightness` intent could actuate the device with no value at all. This validates the argument at the execution boundary, the same way `set_timer` rejects a non-integer `seconds`.

## Changes

- In `parse_home_control_args`, replace `args.get("value").and_then(|v| v.as_f64())` with an explicit match:
  - absent or `null` → `None` (value stays optional — no behavior change);
  - a number → `Some(..)`;
  - a provided non-number (e.g. `"72"`, `true`, `[72]`) → rejected with `home_control 'value' must be a number when provided`.
- The rejected call now fails at the boundary and is tool-audited as a failure (and never reaches the home provider) instead of silently mis-actuating.
- Add a `parse_home_control_args` unit test pinning the contract (numeric → `Some`, absent/null → `None`, string/bool/array → rejected) and extend the existing `home_control_rejects_invalid_arguments_and_audits` integration test with a non-numeric `value` case.

Valid calls are unaffected: a numeric `value` and an omitted `value` both behave exactly as before.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

`x86_64-unknown-linux-gnu` laptop, Rust stable 1.96.0, from the repo root:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test -p genie-core --lib tools::dispatch
cargo test -p genie-core --test tool_gate_integration_test
cargo clippy -p genie-core -p genie-ctl --no-default-features --all-targets --locked -- -D warnings
cargo test  -p genie-core -p genie-ctl --no-default-features --all-targets --locked
```

This is pure argument parsing (`serde_json` + `anyhow`) with no Jetson-, ALSA-, or hardware-specific path; the changed boundary is exercised end-to-end by the `tool_gate_integration_test` dispatcher tests (via the in-test `FakeHomeProvider`, which asserts the rejected call never reaches `execute`). The `aarch64-unknown-linux-gnu` release build is left to the `Cross-compile (aarch64 / Jetson)` CI job; nothing in the diff is target-conditional.

### What I observed

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean (0 warnings).
- `tools::dispatch` unit tests: **50 passed; 0 failed**, including the new `home_control_value_must_be_numeric_when_provided`.
- `tool_gate_integration_test`: **17 passed; 0 failed**. The new `{"action":"turn_on","value":"hot"}` case returned `success=false` with output containing `home_control 'value' must be a number when provided`, produced one tool-audit event with `"success":false`, and the test's `executed` provider log stayed empty (the malformed call never actuated).
- `--no-default-features` clippy: clean; `--no-default-features` tests: pass.

## Test plan

1. `cargo test -p genie-core --lib home_control_value_must_be_numeric_when_provided`
2. `cargo test -p genie-core --test tool_gate_integration_test home_control_rejects_invalid_arguments_and_audits`
3. Optionally, on a device with Home Assistant, call `home_control` with `{"entity":"thermostat","action":"set_temperature","value":"72"}` and confirm it is rejected and audited with `success:false`, while `{"value":72}` still sets the temperature.

## Notes for reviewers

Scope is intentionally one argument. `value` remains optional; this only rejects a value that is explicitly provided but not a number. No range/domain checking (e.g. brightness 0–100) is added here — that is a separate concern.
