### PR TITLE
fix(tools): enforce memory_forget and memory_store schema at dispatch boundary

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -151,6 +151,22 @@ fn parse_get_weather_location(args: &serde_json::Value) -> Result<&str> {
         .ok_or_else(|| anyhow::anyhow!("get_weather requires non-empty string argument 'location'"))
 }
 
+fn parse_memory_forget_query(args: &serde_json::Value) -> Result<&str> {
+    args.get("query")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("memory_forget requires non-empty string argument 'query'"))
+}
+
+fn parse_memory_store_content(args: &serde_json::Value) -> Result<&str> {
+    args.get("content")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("memory_store requires non-empty string argument 'content'"))
+}
+
 /// Tool definition for LLM function calling.
 ///
 /// These are sent to the configured LLM backend as part of the system prompt or
@@ -1375,6 +1391,7 @@ impl ToolDispatcher {
         args: &serde_json::Value,
         exec_ctx: ToolExecutionContext,
     ) -> Result<String> {
+        let query = parse_memory_forget_query(args)?;
         let mem = self
             .memory
             .as_ref()
@@ -1382,11 +1399,6 @@ impl ToolDispatcher {
         let mem = mem
             .lock()
             .map_err(|e| anyhow::anyhow!("memory lock: {}", e))?;
-        let query = args.get("query").and_then(|v| v.as_str()).unwrap_or("");
-
-        if query.is_empty() {
-            return Ok("Please specify what to forget.".to_string());
-        }
 
         // Gate deletes through the same MemoryReadContext that exec_memory_recall
         // uses. Without it, an LLM that cannot READ a person-scoped row could
@@ -1413,6 +1425,7 @@ impl ToolDispatcher {
     }
 
     fn exec_memory_store(&self, args: &serde_json::Value) -> Result<String> {
+        parse_memory_store_content(args)?;
         let mem = self
             .memory
             .as_ref()
@@ -1421,9 +1434,6 @@ impl ToolDispatcher {
             .lock()
             .map_err(|e| anyhow::anyhow!("memory lock: {}", e))?;
         let memories = normalize_memories_to_store(args);
-        if memories.is_empty() {
-            return Ok("Please specify what to remember.".to_string());
-        }
 
         let mut stored = Vec::new();
         let mut stored_categories = Vec::new();

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -743,6 +743,149 @@ async fn memory_recall_rejects_invalid_arguments_and_audits() {
 }
 
 #[tokio::test]
+async fn memory_forget_rejects_invalid_arguments_and_audits() {
+    let paths = TestAuditPaths::new();
+    let memory_path = paths.data_dir.join("memory.db");
+    let memory = genie_core::memory::Memory::open(&memory_path).unwrap();
+    memory.store("identity", "User's name is Jared").unwrap();
+    let dispatcher = paths
+        .dispatcher(
+            None,
+            ToolPolicyConfig::default(),
+            ActuationSafetyConfig::default(),
+        )
+        .with_memory(Arc::new(Mutex::new(memory)));
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Dashboard,
+        ..ToolExecutionContext::default()
+    };
+
+    let invalid_calls = [
+        (
+            serde_json::json!({}),
+            "memory_forget requires non-empty string argument 'query'",
+        ),
+        (
+            serde_json::json!({"query": ""}),
+            "memory_forget requires non-empty string argument 'query'",
+        ),
+        (
+            serde_json::json!({"query": 123}),
+            "memory_forget requires non-empty string argument 'query'",
+        ),
+    ];
+    let expected_audit_count = invalid_calls.len();
+
+    for (arguments, expected_snippet) in &invalid_calls {
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "memory_forget".into(),
+                    arguments: arguments.clone(),
+                },
+                ctx,
+            )
+            .await;
+
+        assert!(
+            !result.success,
+            "expected schema rejection, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains(expected_snippet),
+            "expected output to contain {expected_snippet:?}, got: {}",
+            result.output
+        );
+    }
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(
+        events.len(),
+        expected_audit_count,
+        "each rejected call must be tool-audited"
+    );
+    for event in &events {
+        assert_eq!(event["tool"], "memory_forget");
+        assert_eq!(event["origin"], "dashboard");
+        assert_eq!(event["success"], false);
+    }
+}
+
+#[tokio::test]
+async fn memory_store_rejects_invalid_arguments_and_audits() {
+    let paths = TestAuditPaths::new();
+    let memory_path = paths.data_dir.join("memory.db");
+    let memory = genie_core::memory::Memory::open(&memory_path).unwrap();
+    let dispatcher = paths
+        .dispatcher(
+            None,
+            ToolPolicyConfig::default(),
+            ActuationSafetyConfig::default(),
+        )
+        .with_memory(Arc::new(Mutex::new(memory)));
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Dashboard,
+        ..ToolExecutionContext::default()
+    };
+
+    let invalid_calls = [
+        (
+            serde_json::json!({}),
+            "memory_store requires non-empty string argument 'content'",
+        ),
+        (
+            serde_json::json!({"content": ""}),
+            "memory_store requires non-empty string argument 'content'",
+        ),
+        (
+            serde_json::json!({"content": 123}),
+            "memory_store requires non-empty string argument 'content'",
+        ),
+        (
+            serde_json::json!({"name": "Jared"}),
+            "memory_store requires non-empty string argument 'content'",
+        ),
+    ];
+    let expected_audit_count = invalid_calls.len();
+
+    for (arguments, expected_snippet) in &invalid_calls {
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "memory_store".into(),
+                    arguments: arguments.clone(),
+                },
+                ctx,
+            )
+            .await;
+
+        assert!(
+            !result.success,
+            "expected schema rejection, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains(expected_snippet),
+            "expected output to contain {expected_snippet:?}, got: {}",
+            result.output
+        );
+    }
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(
+        events.len(),
+        expected_audit_count,
+        "each rejected call must be tool-audited"
+    );
+    for event in &events {
+        assert_eq!(event["tool"], "memory_store");
+        assert_eq!(event["origin"], "dashboard");
+        assert_eq!(event["success"], false);
+    }
+}
+
+#[tokio::test]
 async fn calculate_rejects_invalid_arguments_and_audits() {
     let paths = TestAuditPaths::new();
     let dispatcher = paths.dispatcher(


### PR DESCRIPTION
Fixes #416

## Summary

`memory_forget` and `memory_store` marked required arguments in `ToolDef` but returned polite help strings as **`success: true`** when `query` or `content` was missing, empty, or wrong-type. This PR adds `parse_memory_forget_query()` and `parse_memory_store_content()` and rejects invalid arguments at the dispatch boundary before the memory subsystem runs.

## Changes

- Add `parse_memory_forget_query()` with non-empty string `query` validation.
- Add `parse_memory_store_content()` with non-empty string `content` validation (ToolDef field, not alias keys like `name`).
- Wire parsers into `exec_memory_forget()` and `exec_memory_store()`.
- Add `memory_forget_rejects_invalid_arguments_and_audits` integration test with `with_memory()`.
- Add `memory_store_rejects_invalid_arguments_and_audits` integration test (includes `{"name": "Jared"}` without `content`).

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On x86_64 Linux dev host (`laptop` profile), branch `fix/issue-416-memory-forget-store-schema-validation`:

```bash
cd genie-claw
cargo fmt -p genie-core
cargo test -p genie-core --test tool_gate_integration_test memory_forget_rejects_invalid_arguments_and_audits
cargo test -p genie-core --test tool_gate_integration_test memory_store_rejects_invalid_arguments_and_audits
cargo test -p genie-core --test tool_gate_integration_test
cargo clippy --workspace --all-targets --locked -- -D warnings
```

### What I observed

- `memory_forget_rejects_invalid_arguments_and_audits` passes for `{}`, empty `query`, and non-string `query`.
- `memory_store_rejects_invalid_arguments_and_audits` passes for `{}`, empty `content`, non-string `content`, and alias-only `name` without required `content`.
- Full `tool_gate_integration_test` suite passes (19/19).
- Clippy clean on workspace.
- Invalid calls return `success: false` with schema errors and tool audit entries instead of soft success text.

Jetson validation gap: schema enforcement verified via integration tests on dev host; valid memory forget/store behavior unchanged after schema validation passes.

## Test plan

- `cargo test -p genie-core --test tool_gate_integration_test memory_forget_rejects_invalid_arguments_and_audits`
- `cargo test -p genie-core --test tool_gate_integration_test memory_store_rejects_invalid_arguments_and_audits`
- `cargo test -p genie-core --test tool_gate_integration_test`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`

## Notes for reviewers

M1 typed-tool reliability follow-up completing the memory write-path after #361 (`memory_recall`). `memory_forget` delete gating via `MemoryReadContext` is unchanged; only schema-invalid calls fail earlier with proper audit semantics.
