### PR TITLE
fix(ha): apply BFCL whole-home entity fidelity guard at runtime (#419)

### DIFF
--- a/crates/genie-core/src/eval/bfcl.rs
+++ b/crates/genie-core/src/eval/bfcl.rs
@@ -472,13 +472,6 @@ const ENTITY_ARG_KEYS: [&str; 4] = ["entity", "name", "target", "device"];
 /// agent executes identically (e.g. `deactivate` == `turn_off`) are credited.
 const ACTION_ARG_KEYS: [&str; 1] = ["action"];
 
-/// Query words that do not pin a request to a specific place. Used by the
-/// whole-home fidelity guard to decide whether leftover tokens name a real area.
-const BENIGN_QUERY_TOKENS: &[&str] = &[
-    "all", "the", "a", "an", "every", "any", "my", "our", "this", "that", "please", "now", "here",
-    "turn", "switch", "set", "get", "status", "of", "to", "in",
-];
-
 /// Reference home that mirrors the HA-Intents reference home used by the BFCL
 /// dataset. It is intentionally minimal and dataset-specific: it contains
 /// exactly the four physical entities needed to unify the eight distinct gold
@@ -594,16 +587,7 @@ fn canonicalize_entity_value(value: &Value, graph: &HomeGraph) -> Value {
     };
 
     match HomeAssistantProvider::resolve_target_in_graph(graph, text, None) {
-        // An area-specific resolution is trusted directly. A whole-home domain
-        // fallback (`area == None`) is only trusted when it passes the fidelity
-        // guard — otherwise a query naming a place the home does not have (e.g.
-        // "upstairs lights", or "living room light" when no light lives there)
-        // would silently collapse to the only device of that domain and be
-        // credited as correct.
-        Some(target)
-            if !target.entity_ids.is_empty()
-                && (target.area.is_some() || whole_home_resolution_is_trustworthy(graph, text)) =>
-        {
+        Some(target) if !target.entity_ids.is_empty() => {
             let mut ids = target.entity_ids;
             ids.sort();
             Value::String(format!("ids:{}", ids.join(",")))
@@ -625,57 +609,6 @@ fn canon_action(text: &str) -> String {
         "activate" | "enable" | "switch_on" | "power_on" | "turn_on" => "turn_on".to_string(),
         _ => normalized,
     }
-}
-
-/// Split a free-text query into lowercase alphanumeric tokens.
-fn query_tokens(text: &str) -> Vec<String> {
-    text.to_lowercase()
-        .split(|c: char| !c.is_alphanumeric())
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-        .collect()
-}
-
-/// Map a single query word to a device domain, mirroring the runtime
-/// `infer_domain`. Used only by the fidelity guard.
-fn domain_of_word(word: &str) -> Option<&'static str> {
-    Some(match word {
-        "light" | "lights" | "lamp" | "lamps" => "light",
-        "fan" | "fans" => "fan",
-        "thermostat" | "temperature" | "heat" | "heating" | "cooling" | "ac" => "climate",
-        "blind" | "blinds" | "shade" | "shades" | "curtain" | "curtains" | "cover" | "covers"
-        | "garage" => "cover",
-        "lock" | "locks" | "unlock" => "lock",
-        "switch" | "switches" | "plug" | "outlet" => "switch",
-        _ => return None,
-    })
-}
-
-/// Fidelity guard for whole-home (area-less) resolutions. A query that resolved
-/// only because every device of its domain happens to live in one place is
-/// trustworthy *iff* every place-token it names belongs to an area that actually
-/// contains a device of the inferred domain. This rejects foreign rooms the home
-/// does not have ("upstairs lights") and known rooms lacking the device ("living
-/// room light"), while still crediting bare-domain ("lights") and correctly
-/// room-qualified ("kitchen lights") requests.
-fn whole_home_resolution_is_trustworthy(graph: &HomeGraph, text: &str) -> bool {
-    let tokens = query_tokens(text);
-    let Some(domain) = tokens.iter().find_map(|t| domain_of_word(t)) else {
-        // No recognizable domain word — not a case this guard reasons about.
-        return true;
-    };
-    let valid_place: std::collections::HashSet<String> = graph
-        .entities
-        .iter()
-        .filter(|entity| entity.domain == domain)
-        .filter_map(|entity| entity.area.as_deref())
-        .flat_map(query_tokens)
-        .collect();
-    tokens.iter().all(|token| {
-        domain_of_word(token).is_some()
-            || BENIGN_QUERY_TOKENS.contains(&token.as_str())
-            || valid_place.contains(token)
-    })
 }
 
 struct BfclCatalogHomeStub;

--- a/crates/genie-core/src/ha/entity_fidelity.rs
+++ b/crates/genie-core/src/ha/entity_fidelity.rs
@@ -1,0 +1,112 @@
+//! Shared whole-home entity resolution fidelity rules for runtime HA and BFCL scoring.
+
+/// Domain + area view used by the fidelity guard (avoids a dependency on `HomeGraph`).
+#[derive(Clone, Copy)]
+pub struct DomainArea<'a> {
+    pub domain: &'a str,
+    pub area: Option<&'a str>,
+}
+
+/// Query words that do not pin a request to a specific place.
+const BENIGN_QUERY_TOKENS: &[&str] = &[
+    "all", "the", "a", "an", "every", "any", "my", "our", "this", "that", "please", "now", "here",
+    "turn", "switch", "set", "get", "status", "of", "to", "in",
+];
+
+/// Split a free-text query into lowercase alphanumeric tokens.
+pub fn query_tokens(text: &str) -> Vec<String> {
+    text.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Map a single query word to a device domain, mirroring the runtime `infer_domain`.
+pub fn domain_of_word(word: &str) -> Option<&'static str> {
+    Some(match word {
+        "light" | "lights" | "lamp" | "lamps" => "light",
+        "fan" | "fans" => "fan",
+        "thermostat" | "temperature" | "heat" | "heating" | "cooling" | "ac" => "climate",
+        "blind" | "blinds" | "shade" | "shades" | "curtain" | "curtains" | "cover" | "covers"
+        | "garage" => "cover",
+        "lock" | "locks" | "unlock" => "lock",
+        "switch" | "switches" | "plug" | "outlet" => "switch",
+        _ => return None,
+    })
+}
+
+/// Fidelity guard for whole-home (area-less) resolutions. A query that resolved
+/// only because every device of its domain happens to live in one place is
+/// trustworthy *iff* every place-token it names belongs to an area that actually
+/// contains a device of the inferred domain. This rejects foreign rooms the home
+/// does not have ("upstairs lights") and known rooms lacking the device ("living
+/// room light"), while still allowing bare-domain ("lights") and correctly
+/// room-qualified ("kitchen lights") requests.
+pub fn whole_home_resolution_is_trustworthy(
+    entities: &[DomainArea<'_>],
+    text: &str,
+) -> bool {
+    let tokens = query_tokens(text);
+    let Some(domain) = tokens.iter().find_map(|t| domain_of_word(t)) else {
+        return true;
+    };
+    let valid_place: std::collections::HashSet<String> = entities
+        .iter()
+        .filter(|entity| entity.domain == domain)
+        .filter_map(|entity| entity.area)
+        .flat_map(query_tokens)
+        .collect();
+    tokens.iter().all(|token| {
+        domain_of_word(token).is_some()
+            || BENIGN_QUERY_TOKENS.contains(&token.as_str())
+            || valid_place.contains(token)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kitchen_light_home() -> Vec<DomainArea<'static>> {
+        vec![
+            DomainArea {
+                domain: "light",
+                area: Some("Kitchen"),
+            },
+            DomainArea {
+                domain: "fan",
+                area: Some("Kitchen"),
+            },
+            DomainArea {
+                domain: "climate",
+                area: Some("Kitchen"),
+            },
+            DomainArea {
+                domain: "cover",
+                area: Some("Living Room"),
+            },
+        ]
+    }
+
+    #[test]
+    fn rejects_foreign_and_deviceless_rooms() {
+        let entities = kitchen_light_home();
+        for foreign in ["upstairs lights", "upstairs_lights", "living room light"] {
+            assert!(
+                !whole_home_resolution_is_trustworthy(&entities, foreign),
+                "'{foreign}' must not pass the whole-home fidelity guard"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_bare_domain_and_room_qualified() {
+        let entities = kitchen_light_home();
+        assert!(whole_home_resolution_is_trustworthy(&entities, "lights"));
+        assert!(whole_home_resolution_is_trustworthy(
+            &entities,
+            "kitchen lights"
+        ));
+    }
+}

--- a/crates/genie-core/src/ha/entity_fidelity.rs
+++ b/crates/genie-core/src/ha/entity_fidelity.rs
@@ -43,10 +43,7 @@ pub fn domain_of_word(word: &str) -> Option<&'static str> {
 /// does not have ("upstairs lights") and known rooms lacking the device ("living
 /// room light"), while still allowing bare-domain ("lights") and correctly
 /// room-qualified ("kitchen lights") requests.
-pub fn whole_home_resolution_is_trustworthy(
-    entities: &[DomainArea<'_>],
-    text: &str,
-) -> bool {
+pub fn whole_home_resolution_is_trustworthy(entities: &[DomainArea<'_>], text: &str) -> bool {
     let tokens = query_tokens(text);
     let Some(domain) = tokens.iter().find_map(|t| domain_of_word(t)) else {
         return true;

--- a/crates/genie-core/src/ha/mod.rs
+++ b/crates/genie-core/src/ha/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use genie_common::config::Config;
 
 mod client;
+pub mod entity_fidelity;
 mod policy;
 mod provider;
 

--- a/crates/genie-core/src/ha/provider.rs
+++ b/crates/genie-core/src/ha/provider.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
 use super::client::{Entity, HaClient};
+use super::entity_fidelity::{self, DomainArea};
 
 const AREA_TEMPLATE: &str = r#"
 {% set ns = namespace(items=[]) %}
@@ -367,6 +368,24 @@ impl HomeAssistantProvider {
         Self::resolve_named_entity(graph, query, action_hint)
     }
 
+    fn query_rejects_whole_home_fidelity(graph: &HomeGraph, query: &str) -> bool {
+        let query_lower = normalize(query);
+        let area_match = best_area_match(&graph.areas, &query_lower);
+        let domain_match = infer_domain(&query_lower);
+        if area_match.is_some() || domain_match.is_none() {
+            return false;
+        }
+        let entity_views: Vec<DomainArea<'_>> = graph
+            .entities
+            .iter()
+            .map(|entity| DomainArea {
+                domain: entity.domain.as_str(),
+                area: entity.area.as_deref(),
+            })
+            .collect();
+        !entity_fidelity::whole_home_resolution_is_trustworthy(&entity_views, query)
+    }
+
     fn resolve_exact_entity_id(
         graph: &HomeGraph,
         query: &str,
@@ -427,6 +446,18 @@ impl HomeAssistantProvider {
             .collect();
 
         if entity_ids.is_empty() {
+            return None;
+        }
+
+        let entity_views: Vec<DomainArea<'_>> = graph
+            .entities
+            .iter()
+            .map(|entity| DomainArea {
+                domain: entity.domain.as_str(),
+                area: entity.area.as_deref(),
+            })
+            .collect();
+        if !entity_fidelity::whole_home_resolution_is_trustworthy(&entity_views, query) {
             return None;
         }
 
@@ -633,6 +664,10 @@ impl HomeAutomationProvider for HomeAssistantProvider {
                     );
                 }
             }
+        }
+
+        if Self::query_rejects_whole_home_fidelity(&graph, query) {
+            anyhow::bail!("I couldn't find '{}' in this home", query);
         }
 
         anyhow::bail!("no Home Assistant target matched '{}'", query)
@@ -1244,6 +1279,23 @@ mod tests {
         assert_eq!(target.display_name, "All lights");
         assert_eq!(target.domain.as_deref(), Some("light"));
         assert_eq!(target.entity_ids, vec!["light.living_room_lamp"]);
+    }
+
+    #[test]
+    fn resolve_target_rejects_foreign_room_whole_home_fallback() {
+        let graph = sample_graph();
+        assert!(
+            HomeAssistantProvider::resolve_target_in_graph(&graph, "upstairs lights", None).is_none()
+        );
+    }
+
+    #[test]
+    fn query_rejects_whole_home_fidelity_for_foreign_room() {
+        let graph = sample_graph();
+        assert!(HomeAssistantProvider::query_rejects_whole_home_fidelity(
+            &graph,
+            "upstairs lights"
+        ));
     }
 
     #[test]

--- a/crates/genie-core/src/ha/provider.rs
+++ b/crates/genie-core/src/ha/provider.rs
@@ -1285,7 +1285,8 @@ mod tests {
     fn resolve_target_rejects_foreign_room_whole_home_fallback() {
         let graph = sample_graph();
         assert!(
-            HomeAssistantProvider::resolve_target_in_graph(&graph, "upstairs lights", None).is_none()
+            HomeAssistantProvider::resolve_target_in_graph(&graph, "upstairs lights", None)
+                .is_none()
         );
     }
 


### PR DESCRIPTION
Extract `whole_home_resolution_is_trustworthy` into `ha/entity_fidelity` and reject foreign-room whole-home fallbacks in `resolve_domain_target` so `home_status` and `home_control` align with the BFCL scorer (#387).

## Summary

Fixes #419

Promotes the BFCL whole-home entity fidelity guard from eval-only code into the live Home Assistant resolver. Foreign-room queries such as `"upstairs lights"` no longer collapse to an `All lights` whole-home group at runtime; `home_status` and `home_control` now fail with an explicit resolution error instead of reporting or attempting actuation against unrelated devices. Closes the runtime slice of #387.

## Changes

- Add `crates/genie-core/src/ha/entity_fidelity.rs` with shared `whole_home_resolution_is_trustworthy`, `query_tokens`, `domain_of_word`, and unit tests.
- Apply the fidelity guard in `HomeAssistantProvider::resolve_domain_target` before returning whole-home group targets.
- Return `I couldn't find '<query>' in this home` from `resolve_target` when a query would be rejected by the whole-home fidelity guard.
- Remove duplicate fidelity-guard logic from `eval/bfcl.rs`; BFCL grounded scoring now uses the same runtime resolver path.
- Add provider tests for foreign-room rejection (`upstairs lights`) while preserving bare-domain resolution (`lights`).

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

```bash
cd genie-claw
git checkout fix/issue-419-ha-entity-fidelity-guard

# Build + unit/integration tests for the fidelity guard and resolver
cargo test -p genie-core fidelity
cargo test -p genie-core resolve_target_rejects
cargo test -p genie-core resolve_domain_target_for_whole_home_status
cargo clippy -p genie-core -- -D warnings
```

Environment: x86_64 Linux dev host (`laptop` profile). Jetson Orin Nano 8 GB not available for this PR; live HA repro steps below are the reviewer path using `deploy/homeassistant/`.

Optional live HA repro (same mock home as #400):

```bash
docker compose -f deploy/homeassistant/docker-compose.yml up -d
# wire HA token + [services.homeassistant] per deploy/homeassistant/README.md
genie-ctl chat "what is the state of upstairs lights?"
genie-ctl chat "turn on the kitchen lights"
curl -s -H "Authorization: Bearer $HA_TOKEN" \
  http://127.0.0.1:8123/api/states/light.kitchen_lights | jq .state
```

### What I observed

**Before (issue #419 on `main`):**

- `resolve_target_in_graph(graph, "upstairs lights", None)` returned `Some(HomeTarget { display_name: "All lights", area: None, confidence: 0.72, ... })`.
- `home_status` could aggregate state for every light in the house when the user named a non-existent room.
- `home_control` was blocked later by the runtime confidence gate with an opaque message (`target match confidence 0.72 is below required 0.88`).

**After (this PR):**

```text
$ cargo test -p genie-core fidelity
running 4 tests
test ha::entity_fidelity::tests::allows_bare_domain_and_room_qualified ... ok
test ha::entity_fidelity::tests::rejects_foreign_and_deviceless_rooms ... ok
test ha::provider::tests::query_rejects_whole_home_fidelity_for_foreign_room ... ok
test eval::bfcl::tests::fidelity_guard_rejects_foreign_and_deviceless_rooms ... ok

$ cargo test -p genie-core resolve_target_rejects
test ha::provider::tests::resolve_target_rejects_foreign_room_whole_home_fallback ... ok

$ cargo test -p genie-core resolve_domain_target_for_whole_home_status
test ha::provider::tests::resolve_domain_target_for_whole_home_status ... ok
```

- `"upstairs lights"` → `resolve_target_in_graph` returns `None`; `resolve_target` bails with `I couldn't find 'upstairs lights' in this home`.
- Bare `"lights"` still resolves to the whole-home group (intended).
- `cargo clippy -p genie-core -- -D warnings` — clean.

**Jetson validation gap:** not run on Jetson hardware. Resolver logic is platform-independent; reviewer can re-run unit tests above and optional live HA repro on `deploy/homeassistant/`.

## Test plan

- [x] `cargo test -p genie-core fidelity`
- [x] `cargo test -p genie-core resolve_target_rejects`
- [x] `cargo test -p genie-core resolve_domain_target_for_whole_home_status`
- [x] `cargo clippy -p genie-core -- -D warnings`
- [ ] Live HA: `docker compose -f deploy/homeassistant/docker-compose.yml up -d`, then `genie-ctl chat "what is the state of upstairs lights?"` — expect resolution error, not all-lights summary
- [ ] Live HA control: `genie-ctl chat "turn on the kitchen lights"` + `curl` `light.kitchen_lights` state — expect `on`

## Notes for reviewers

- Parent epic: #387 (runtime entity-resolution item 2). Eval-side grounded metric work landed in #388 / #390 / #399; this PR aligns **runtime** `home_control` / `home_status` with the same whole-home fidelity rule.
- Not a duplicate of #416 (memory typed-tool schema) or #400 (action synonym canonicalization).
- BFCL grounded strict accuracy should be unchanged — scorer and runtime now share one resolver codepath instead of duplicate guard logic.
