### PR TITLE
fix(tools): reject malformed optional get_weather forecast and web_search limit at execution boundary

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -173,12 +173,49 @@ fn parse_web_search_query(args: &serde_json::Value) -> Result<&str> {
         .ok_or_else(|| anyhow::anyhow!("web_search requires non-empty string argument 'query'"))
 }
 
+/// `limit` stays optional — an absent or null value defaults to 3 results. But a
+/// *provided* value must be a non-negative integer. The old
+/// `args.get("limit").and_then(|v| v.as_u64()).unwrap_or(3)` silently coerced a
+/// malformed limit (a stringified `"5"`, a float `2.5`, or a negative) to the
+/// default 3, quietly returning a different result count than the caller asked
+/// for. Reject the malformed value at the boundary the same way home_control
+/// rejects a non-numeric `value` (PR #414); a valid integer outside 1..=5 still
+/// clamps into range rather than erroring.
+fn parse_web_search_limit(args: &serde_json::Value) -> Result<usize> {
+    match args.get("limit") {
+        None | Some(serde_json::Value::Null) => Ok(3),
+        Some(provided) => {
+            let limit = provided.as_u64().ok_or_else(|| {
+                anyhow::anyhow!("web_search 'limit' must be an integer when provided")
+            })?;
+            Ok(limit.clamp(1, 5) as usize)
+        }
+    }
+}
+
 fn parse_get_weather_location(args: &serde_json::Value) -> Result<&str> {
     args.get("location")
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| anyhow::anyhow!("get_weather requires non-empty string argument 'location'"))
+}
+
+/// `forecast` stays optional — an absent or null value means current weather
+/// (the no-op default). But a *provided* value must be a real boolean. The old
+/// `args.get("forecast").and_then(|v| v.as_bool()).unwrap_or(false)` silently
+/// coerced a stringified `"true"` (a form small models routinely emit) to
+/// `false`, returning current weather when the user asked for the 7-day
+/// forecast. Reject the malformed value at the boundary the same way
+/// home_control rejects a non-numeric `value` (PR #414).
+fn parse_get_weather_forecast(args: &serde_json::Value) -> Result<bool> {
+    match args.get("forecast") {
+        None | Some(serde_json::Value::Null) => Ok(false),
+        Some(serde_json::Value::Bool(value)) => Ok(*value),
+        Some(_) => Err(anyhow::anyhow!(
+            "get_weather 'forecast' must be a boolean when provided"
+        )),
+    }
 }
 
 /// Tool definition for LLM function calling.
@@ -2107,10 +2144,7 @@ fn exec_calculate(args: &serde_json::Value) -> Result<String> {
 
 async fn exec_weather(args: &serde_json::Value) -> Result<String> {
     let location = parse_get_weather_location(args)?;
-    let forecast = args
-        .get("forecast")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let forecast = parse_get_weather_forecast(args)?;
 
     if forecast {
         super::weather::get_forecast(location).await
@@ -2121,11 +2155,7 @@ async fn exec_weather(args: &serde_json::Value) -> Result<String> {
 
 async fn exec_web_search(args: &serde_json::Value, config: &WebSearchConfig) -> Result<String> {
     let query = parse_web_search_query(args)?;
-    let limit = args
-        .get("limit")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(3)
-        .clamp(1, 5) as usize;
+    let limit = parse_web_search_limit(args)?;
     let fresh = args
         .get("fresh")
         .or_else(|| args.get("cache_bypass"))
@@ -2572,6 +2602,95 @@ mod tests {
                 .to_string();
             assert!(
                 err.contains("home_control 'value' must be a number when provided"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn get_weather_forecast_must_be_boolean_when_provided() {
+        // A real boolean parses through.
+        let args = serde_json::json!({"location": "Denver", "forecast": true});
+        assert!(parse_get_weather_forecast(&args).expect("bool forecast parses"));
+
+        // Absent and explicit null both default to current weather (false),
+        // not a rejection — forecast stays optional.
+        assert!(
+            !parse_get_weather_forecast(&serde_json::json!({"location": "Denver"}))
+                .expect("absent forecast parses")
+        );
+        assert!(
+            !parse_get_weather_forecast(
+                &serde_json::json!({"location": "Denver", "forecast": null})
+            )
+            .expect("null forecast parses")
+        );
+
+        // The bug: a provided but non-boolean forecast (a stringified "true", a
+        // number) used to be silently dropped to false, returning current
+        // weather when the user asked for the forecast. It must now be rejected.
+        for bad in [
+            serde_json::json!({"location": "Denver", "forecast": "true"}),
+            serde_json::json!({"location": "Denver", "forecast": 1}),
+            serde_json::json!({"location": "Denver", "forecast": "yes"}),
+        ] {
+            let err = parse_get_weather_forecast(&bad)
+                .expect_err("non-boolean forecast must be rejected")
+                .to_string();
+            assert!(
+                err.contains("get_weather 'forecast' must be a boolean when provided"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn web_search_limit_must_be_integer_when_provided() {
+        // A valid integer parses through.
+        assert_eq!(
+            parse_web_search_limit(&serde_json::json!({"query": "rust", "limit": 5}))
+                .expect("integer limit parses"),
+            5
+        );
+
+        // Absent and explicit null both default to 3 — limit stays optional.
+        assert_eq!(
+            parse_web_search_limit(&serde_json::json!({"query": "rust"}))
+                .expect("absent limit parses"),
+            3
+        );
+        assert_eq!(
+            parse_web_search_limit(&serde_json::json!({"query": "rust", "limit": null}))
+                .expect("null limit parses"),
+            3
+        );
+
+        // A valid integer outside 1..=5 still clamps into range rather than
+        // erroring, preserving the prior lenient behavior for in-type values.
+        assert_eq!(
+            parse_web_search_limit(&serde_json::json!({"query": "rust", "limit": 0}))
+                .expect("zero clamps up"),
+            1
+        );
+        assert_eq!(
+            parse_web_search_limit(&serde_json::json!({"query": "rust", "limit": 99}))
+                .expect("large clamps down"),
+            5
+        );
+
+        // The bug: a provided but non-integer limit (a stringified "5", a float,
+        // a negative) used to be silently dropped to the default 3. It must now
+        // be rejected.
+        for bad in [
+            serde_json::json!({"query": "rust", "limit": "5"}),
+            serde_json::json!({"query": "rust", "limit": 2.5}),
+            serde_json::json!({"query": "rust", "limit": -1}),
+        ] {
+            let err = parse_web_search_limit(&bad)
+                .expect_err("non-integer limit must be rejected")
+                .to_string();
+            assert!(
+                err.contains("web_search 'limit' must be an integer when provided"),
                 "unexpected error: {err}"
             );
         }

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -984,6 +984,20 @@ async fn web_search_rejects_invalid_arguments_and_audits() {
             serde_json::json!({"query": 42}),
             "web_search requires non-empty string argument 'query'",
         ),
+        // A valid query with a provided-but-malformed `limit` is rejected at the
+        // boundary rather than silently falling back to the default 3.
+        (
+            serde_json::json!({"query": "rust news", "limit": "5"}),
+            "web_search 'limit' must be an integer when provided",
+        ),
+        (
+            serde_json::json!({"query": "rust news", "limit": 2.5}),
+            "web_search 'limit' must be an integer when provided",
+        ),
+        (
+            serde_json::json!({"query": "rust news", "limit": -1}),
+            "web_search 'limit' must be an integer when provided",
+        ),
     ];
     let expected_audit_count = invalid_calls.len();
 
@@ -1048,6 +1062,16 @@ async fn get_weather_rejects_invalid_arguments_and_audits() {
         (
             serde_json::json!({"location": 42}),
             "get_weather requires non-empty string argument 'location'",
+        ),
+        // A valid location with a provided-but-malformed `forecast` is rejected
+        // at the boundary rather than silently returning current weather.
+        (
+            serde_json::json!({"location": "Denver", "forecast": "true"}),
+            "get_weather 'forecast' must be a boolean when provided",
+        ),
+        (
+            serde_json::json!({"location": "Denver", "forecast": 1}),
+            "get_weather 'forecast' must be a boolean when provided",
         ),
     ];
     let expected_audit_count = invalid_calls.len();


### PR DESCRIPTION
## Summary

`get_weather.forecast` and `web_search.limit` silently coerced a provided-but-malformed value to a default instead of rejecting it: a stringified `"forecast": "true"` returned current weather when the user asked for the 7-day forecast, and a `"limit": "5"` / `2.5` / `-1` quietly fell back to 3 results. This rejects wrong-typed optional values at the dispatch boundary and audits them, the same way #414 handles `home_control`'s `value`; absent/null stays the optional default and a valid `limit` still clamps to `1..=5`. Closes #422.

## Changes

- `crates/genie-core/src/tools/dispatch.rs`: added `parse_get_weather_forecast` (None/null → false; real bool → value; else reject) and `parse_web_search_limit` (None/null → 3; valid integer → clamp `1..=5`; non-integer → reject), wired into `exec_weather` / `exec_web_search`.
- `crates/genie-core/src/tools/dispatch.rs`: two unit tests (`get_weather_forecast_must_be_boolean_when_provided`, `web_search_limit_must_be_integer_when_provided`) modeled on `home_control_value_must_be_numeric_when_provided`.
- `crates/genie-core/tests/tool_gate_integration_test.rs`: extended `web_search_rejects_invalid_arguments_and_audits` and `get_weather_rejects_invalid_arguments_and_audits` with the malformed-optional-arg cases (each rejection is audited as a failure).
- No internal caller is affected: `quick.rs`, `genie-ctl`, and the voice path already pass `forecast` as a bool and `limit` as an integer. Out of scope (separate surfaces): `web_search.fresh` and the `/api/web-search` HTTP endpoint in `server.rs`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware.
- [ ] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Built genie-core from source and ran the affected tests **on the target Jetson**: NVIDIA Jetson Orin Nano (Engineering Reference Developer Kit Super, 8 GB), L4T R36.4.7, `Linux 5.15.148-tegra aarch64`, `rustc 1.95.0`, debug profile. This change is pure tool-dispatch argument validation (JSON → typed value) with no model, voice, audio, Home Assistant, or dashboard subsystem, so the dispatcher unit tests and the tool-gate integration tests ARE the affected code path — running them on the Orin Nano exercises the fix on the real aarch64/L4T target. Cloned the PR branch fresh (`11a795f`) and built from scratch on the device:

```
# on the Jetson Orin Nano — aarch64, L4T R36.4.7
cargo test -p genie-core --lib -- \
  get_weather_forecast_must_be_boolean_when_provided \
  web_search_limit_must_be_integer_when_provided

cargo test -p genie-core --test tool_gate_integration_test -- \
  web_search_rejects_invalid_arguments_and_audits \
  get_weather_rejects_invalid_arguments_and_audits
```

Also on an x86_64 dev box (`rustc 1.95.0`): the same tests plus `cargo fmt -p genie-core -- --check` and `cargo clippy -p genie-core --tests` (both clean).

### What I observed

All four tests pass on the Jetson Orin Nano (genie-core built from scratch on-device: lib 2m13s, integration test binary 1m08s):

```
# unit — target/debug/deps/genie_core-19794b9c31c74abc
running 2 tests
test tools::dispatch::tests::get_weather_forecast_must_be_boolean_when_provided ... ok
test tools::dispatch::tests::web_search_limit_must_be_integer_when_provided ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 718 filtered out

# integration — tests/tool_gate_integration_test.rs
running 2 tests
test get_weather_rejects_invalid_arguments_and_audits ... ok
test web_search_rejects_invalid_arguments_and_audits ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 17 filtered out
```

The integration tests assert each malformed optional arg is rejected at the dispatch boundary AND written to the tool-audit log as `success: false`. Behavior at the boundary:

| Call | Before | After |
| --- | --- | --- |
| `get_weather {"location":"Denver","forecast":"true"}` | current weather (silent) | rejected + audited |
| `get_weather {"location":"Denver","forecast":true}` | forecast | forecast (unchanged) |
| `web_search {"query":"x","limit":"5"}` | 3 results (silent) | rejected + audited |
| `web_search {"query":"x","limit":99}` | 5 results (clamped) | 5 results (clamped, unchanged) |

Scope note: this is the on-device test run on the real aarch64/L4T target. The change has no model/voice/HA/dashboard surface, so there is no separate running-service path to exercise beyond these tests.

## Test plan

- `cargo test -p genie-core --lib -- get_weather_forecast_must_be_boolean_when_provided web_search_limit_must_be_integer_when_provided`
- `cargo test -p genie-core --test tool_gate_integration_test -- web_search_rejects_invalid_arguments_and_audits get_weather_rejects_invalid_arguments_and_audits`
- Optional manual: issue `get_weather` with `"forecast":"true"` and `web_search` with `"limit":"5"` and confirm each is rejected with the boundary error and written to the tool-audit log as `success:false`.