### PR TITLE
fix(tools): reject missing value for home_control set_brightness/set_temperature at execution boundary

### DIFF
--- a/crates/genie-core/src/ha/provider.rs
+++ b/crates/genie-core/src/ha/provider.rs
@@ -721,7 +721,13 @@ impl HomeAutomationProvider for HomeAssistantProvider {
             ),
             HomeActionKind::SetBrightness => {
                 ensure_domain(&domain, &["light"])?;
-                let brightness = normalize_brightness(action.value.unwrap_or(50.0));
+                // No silent default: a value-less set_brightness is rejected at
+                // the dispatch boundary (issue #421); error here too as defense
+                // in depth rather than actuating an arbitrary brightness.
+                let brightness =
+                    normalize_brightness(action.value.ok_or_else(|| {
+                        anyhow::anyhow!("set_brightness requires a numeric 'value'")
+                    })?);
                 (
                     "light".into(),
                     "turn_on",
@@ -730,7 +736,12 @@ impl HomeAutomationProvider for HomeAssistantProvider {
             }
             HomeActionKind::SetTemperature => {
                 ensure_domain(&domain, &["climate"])?;
-                let temp = action.value.unwrap_or(20.0);
+                // No silent default: a value-less set_temperature is rejected at
+                // the dispatch boundary (issue #421); error here too as defense
+                // in depth rather than actuating an arbitrary temperature.
+                let temp = action
+                    .value
+                    .ok_or_else(|| anyhow::anyhow!("set_temperature requires a numeric 'value'"))?;
                 (
                     "climate".into(),
                     "set_temperature",

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -65,7 +65,23 @@ fn parse_home_control_args(args: &serde_json::Value) -> Result<(&str, &str, Opti
             anyhow::anyhow!("home_control 'value' must be a number when provided")
         })?),
     };
+    // set_brightness / set_temperature actuate a numeric setpoint, so a call with
+    // no `value` is under-specified. The provider used to substitute a hardcoded
+    // default (brightness 50 / temperature 20) and report success, actuating a
+    // setpoint the user never asked for. Reject the missing value at the boundary
+    // so the agent asks for the number instead of guessing — the same boundary
+    // #414 uses to reject a *non-numeric* value. (issue #421)
+    if value.is_none() && action_requires_value(action) {
+        anyhow::bail!("home_control '{action}' requires a numeric argument 'value'");
+    }
     Ok((entity, action, value))
+}
+
+/// Actions that actuate a numeric setpoint and therefore require a `value`.
+/// Every other action (turn_on, turn_off, toggle, open, close, lock, unlock,
+/// activate) is a no-op for `value` and leaves it `None`.
+fn action_requires_value(action: &str) -> bool {
+    matches!(action, "set_brightness" | "set_temperature")
 }
 
 /// Canonicalize a model-emitted action verb to one of [`HOME_CONTROL_ACTIONS`].
@@ -2702,6 +2718,47 @@ mod tests {
                 err.contains("web_search 'limit' must be an integer when provided"),
                 "unexpected error: {err}"
             );
+        }
+    }
+
+    #[test]
+    fn home_control_set_actions_require_value() {
+        // set_brightness / set_temperature with a value parse through.
+        for ok in [
+            serde_json::json!({"entity": "kitchen light", "action": "set_brightness", "value": 60}),
+            serde_json::json!({"entity": "thermostat", "action": "set_temperature", "value": 21}),
+        ] {
+            let (_, _, value) = parse_home_control_args(&ok).expect("value provided parses");
+            assert!(value.is_some());
+        }
+
+        // The bug (issue #421): a value-requiring action with NO value used to be
+        // silently defaulted by the provider (brightness 50 / temperature 20) and
+        // reported success. It must now be rejected at the boundary. Absent and
+        // explicit null both count as missing.
+        for bad in [
+            serde_json::json!({"entity": "kitchen light", "action": "set_brightness"}),
+            serde_json::json!({"entity": "kitchen light", "action": "set_brightness", "value": null}),
+            serde_json::json!({"entity": "thermostat", "action": "set_temperature"}),
+            serde_json::json!({"entity": "thermostat", "action": "set_temperature", "value": null}),
+        ] {
+            let err = parse_home_control_args(&bad)
+                .expect_err("missing value must be rejected")
+                .to_string();
+            assert!(
+                err.contains("requires a numeric argument 'value'"),
+                "unexpected error: {err}"
+            );
+        }
+
+        // Non-value actions are unaffected: no value is the correct no-op.
+        for ok in [
+            serde_json::json!({"entity": "kitchen light", "action": "turn_on"}),
+            serde_json::json!({"entity": "front door", "action": "lock"}),
+            serde_json::json!({"entity": "movie night", "action": "activate"}),
+        ] {
+            let (_, _, value) = parse_home_control_args(&ok).expect("no-value action parses");
+            assert_eq!(value, None);
         }
     }
 

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -2763,6 +2763,19 @@ mod tests {
     }
 
     #[test]
+    fn action_requires_value_only_for_setpoint_actions() {
+        // Only the two numeric-setpoint actions require a value (#421).
+        for a in ["set_brightness", "set_temperature"] {
+            assert!(action_requires_value(a), "{a} should require a value");
+        }
+        for a in [
+            "turn_on", "turn_off", "toggle", "open", "close", "lock", "unlock", "activate",
+        ] {
+            assert!(!action_requires_value(a), "{a} must not require a value");
+        }
+    }
+
+    #[test]
     fn tool_action_class_maps_side_effecting_tools() {
         assert_eq!(
             tool_action_class("home_control"),

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -496,6 +496,17 @@ async fn home_control_rejects_invalid_arguments_and_audits() {
             serde_json::json!({"entity": "kitchen light", "action": "turn_on", "value": "hot"}),
             "home_control 'value' must be a number when provided",
         ),
+        // issue #421: a value-requiring action with no `value` must be rejected
+        // at the boundary, not silently defaulted (brightness 50 / temp 20) and
+        // executed against the device.
+        (
+            serde_json::json!({"entity": "kitchen light", "action": "set_brightness"}),
+            "home_control 'set_brightness' requires a numeric argument 'value'",
+        ),
+        (
+            serde_json::json!({"entity": "kitchen light", "action": "set_temperature"}),
+            "home_control 'set_temperature' requires a numeric argument 'value'",
+        ),
     ];
     let expected_audit_count = invalid_calls.len();
 

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -552,6 +552,46 @@ async fn home_control_rejects_invalid_arguments_and_audits() {
 }
 
 #[tokio::test]
+async fn home_control_set_brightness_with_value_actuates() {
+    // The missing-value guard (#421) must not reject a valid setpoint.
+    let paths = TestAuditPaths::new();
+    let executed = Arc::new(Mutex::new(Vec::new()));
+    let dispatcher = paths.dispatcher(
+        Some(Arc::new(FakeHomeProvider::light(executed.clone()))),
+        ToolPolicyConfig::default(),
+        ActuationSafetyConfig::default(),
+    );
+    let result = dispatcher
+        .execute_with_context(
+            &ToolCall {
+                name: "home_control".into(),
+                arguments: serde_json::json!({
+                    "entity": "kitchen light",
+                    "action": "set_brightness",
+                    "value": 60
+                }),
+            },
+            ToolExecutionContext {
+                request_origin: RequestOrigin::Dashboard,
+                ..ToolExecutionContext::default()
+            },
+        )
+        .await;
+
+    assert!(
+        result.success,
+        "valid set_brightness must actuate, got: {}",
+        result.output
+    );
+    let exec = executed.lock().unwrap();
+    assert_eq!(exec.len(), 1);
+    assert!(matches!(exec[0], HomeActionKind::SetBrightness));
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(events.last().unwrap()["tool"], "home_control");
+    assert_eq!(events.last().unwrap()["success"], true);
+}
+
+#[tokio::test]
 async fn home_status_rejects_invalid_arguments_and_audits() {
     let paths = TestAuditPaths::new();
     let dispatcher = paths.dispatcher(


### PR DESCRIPTION
## Summary

`set_brightness` and `set_temperature` actuate a numeric setpoint, but a `home_control` call with **no `value`** was silently defaulted by the provider (brightness → 50, temperature → 20) and reported success — executing an arbitrary setpoint the user never asked for. An under-specified request like "set the thermostat" got actuated at a guess instead of being rejected so the agent can ask for the number. This rejects a missing `value` for those two actions at the dispatch boundary and audits it as a failure, complementing #414 (which only rejects a *non-numeric provided* value). Closes #421.

## Changes

- `crates/genie-core/src/tools/dispatch.rs`: `parse_home_control_args` now rejects `set_brightness`/`set_temperature` when `value` is absent or null (`home_control '<action>' requires a numeric argument 'value'`), via a small `action_requires_value` helper. Absent/null stays a no-op `None` for every other action (turn_on, toggle, open, lock, activate, …).
- `crates/genie-core/src/ha/provider.rs`: dropped the silent `action.value.unwrap_or(50.0)` / `unwrap_or(20.0)` fallbacks — a value-less setpoint now errors (`ok_or_else`) as defense in depth rather than actuating a hardcoded default.
- `crates/genie-core/src/tools/dispatch.rs`: unit test `home_control_set_actions_require_value` (absent/null rejected for both actions; value-bearing and non-value actions still parse).
- `crates/genie-core/tests/tool_gate_integration_test.rs`: extended `home_control_rejects_invalid_arguments_and_audits` with the two missing-value cases (rejected at the boundary, never reach the provider, audited `success: false`).

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware.
- [ ] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Built genie-core from source and ran the affected tests **on the target Jetson**: NVIDIA Jetson Orin Nano (Engineering Reference Developer Kit Super, 8 GB), L4T R36.4.7, `Linux 5.15.148-tegra aarch64`, `rustc 1.95.0`, debug profile. The change is pure tool-dispatch argument validation plus a provider guard, with no model/voice/HA/dashboard subsystem, so the dispatcher unit tests and the tool-gate integration test ARE the affected code path. Applied this change onto a fresh upstream-`main` clone (base `6ea5197`) and built from scratch on the device:

```
# on the Jetson Orin Nano — aarch64, L4T R36.4.7
cargo test -p genie-core --lib -- \
  home_control_set_actions_require_value \
  home_control_value_must_be_numeric_when_provided

cargo test -p genie-core --test tool_gate_integration_test -- \
  home_control_rejects_invalid_arguments_and_audits
```

Also on an x86_64 dev box (`rustc 1.95.0`): the same tests plus `cargo fmt -p genie-core -- --check` and `cargo clippy -p genie-core --tests` (both clean), and the provider tests (`ha::provider::tests`, no regression).

### What I observed

All tests pass on the Jetson Orin Nano (genie-core built from scratch on-device: lib 1m50s, integration test binary 51s):

```
# unit — target/debug/deps/genie_core-19794b9c31c74abc
running 2 tests
test tools::dispatch::tests::home_control_value_must_be_numeric_when_provided ... ok
test tools::dispatch::tests::home_control_set_actions_require_value ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 717 filtered out

# integration — tests/tool_gate_integration_test.rs
running 1 test
test home_control_rejects_invalid_arguments_and_audits ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 18 filtered out
```

The integration test asserts the missing-value calls are rejected at the boundary, never reach the home provider (`executed` stays empty), and are written to the tool-audit log as `success: false`. Behavior at the boundary:

| Call | Before | After |
| --- | --- | --- |
| `home_control {"entity":"kitchen light","action":"set_brightness"}` | success — brightness silently 50 | rejected + audited |
| `home_control {"entity":"thermostat","action":"set_temperature"}` | success — temperature silently 20 | rejected + audited |
| `home_control {"entity":"kitchen light","action":"set_brightness","value":60}` | brightness 60 | brightness 60 (unchanged) |
| `home_control {"entity":"kitchen light","action":"turn_on"}` | turn_on | turn_on (unchanged — no value needed) |

### Test plan

- `cargo test -p genie-core --lib -- home_control_set_actions_require_value home_control_value_must_be_numeric_when_provided`
- `cargo test -p genie-core --test tool_gate_integration_test -- home_control_rejects_invalid_arguments_and_audits`
- Optional manual: issue `home_control {"entity":"<light>","action":"set_brightness"}` with no `value` and confirm it is rejected with `home_control 'set_brightness' requires a numeric argument 'value'` and audited `success:false`, instead of dimming to 50%.

### Notes for reviewers

- Two layers: the boundary rejection (user-facing + audited) is the fix; dropping the provider `unwrap_or` defaults is defense in depth so no future caller can reach a silent default.
- Out of scope (noted in the issue as a separate follow-up): `set_temperature` still has no range check on a *provided* value (e.g. `9999` / `-5`); brightness is clamped via `normalize_brightness`, temperature is not.