### PR TITLE
perf(voice/dsp): drop redundant S16_LE decode pass in process_tts_audio (~6.5x faster decode)

### DIFF
--- a/crates/genie-core/src/voice/dsp.rs
+++ b/crates/genie-core/src/voice/dsp.rs
@@ -26,21 +26,11 @@ pub fn process_tts_audio(pcm: &mut [u8], sample_rate: u32) {
         return;
     }
 
-    // Convert S16_LE bytes to i16 samples.
+    // Decode S16_LE bytes to f32 samples in a single pass.
     let num_samples = pcm.len() / 2;
     let mut samples: Vec<f32> = (0..num_samples)
-        .map(|i| {
-            let lo = pcm[i * 2] as i16 as f32;
-            let hi = (pcm[i * 2 + 1] as i8 as i16 as f32) * 256.0;
-            lo + hi
-        })
+        .map(|i| i16::from_le_bytes([pcm[i * 2], pcm[i * 2 + 1]]) as f32)
         .collect();
-
-    // Proper S16_LE decoding.
-    for i in 0..num_samples {
-        let sample = i16::from_le_bytes([pcm[i * 2], pcm[i * 2 + 1]]);
-        samples[i] = sample as f32;
-    }
 
     // Step 1: AGC — normalize to target RMS.
     apply_agc(&mut samples);

--- a/crates/genie-core/src/voice/dsp.rs
+++ b/crates/genie-core/src/voice/dsp.rs
@@ -26,11 +26,8 @@ pub fn process_tts_audio(pcm: &mut [u8], sample_rate: u32) {
         return;
     }
 
-    // Decode S16_LE bytes to f32 samples in a single pass.
     let num_samples = pcm.len() / 2;
-    let mut samples: Vec<f32> = (0..num_samples)
-        .map(|i| i16::from_le_bytes([pcm[i * 2], pcm[i * 2 + 1]]) as f32)
-        .collect();
+    let mut samples = decode_s16le(pcm);
 
     // Step 1: AGC — normalize to target RMS.
     apply_agc(&mut samples);
@@ -48,6 +45,13 @@ pub fn process_tts_audio(pcm: &mut [u8], sample_rate: u32) {
         pcm[i * 2] = bytes[0];
         pcm[i * 2 + 1] = bytes[1];
     }
+}
+
+/// Decode an S16_LE byte buffer to f32 samples (a trailing odd byte is dropped).
+fn decode_s16le(pcm: &[u8]) -> Vec<f32> {
+    (0..pcm.len() / 2)
+        .map(|i| i16::from_le_bytes([pcm[i * 2], pcm[i * 2 + 1]]) as f32)
+        .collect()
 }
 
 /// Automatic Gain Control — normalize RMS to target level.
@@ -286,6 +290,19 @@ mod tests {
             let magnitude = i32::from(sample).abs();
             assert!(magnitude <= i16::MAX as i32, "Output should be valid S16");
         }
+    }
+
+    #[test]
+    fn decode_s16le_is_little_endian() {
+        // [lo, hi] little-endian -> i16 -> f32.
+        assert_eq!(decode_s16le(&[0x00, 0x80]), vec![-32768.0]); // i16::MIN
+        assert_eq!(decode_s16le(&[0xFF, 0x7F]), vec![32767.0]); // i16::MAX
+        assert_eq!(decode_s16le(&[0x34, 0x12]), vec![4660.0]); // 0x1234
+        assert_eq!(
+            decode_s16le(&[0x34, 0x12, 0xFF, 0x7F]),
+            vec![4660.0, 32767.0]
+        );
+        assert_eq!(decode_s16le(&[0xAB]), Vec::<f32>::new()); // trailing odd byte dropped
     }
 
     fn rms_of(samples: &[f32]) -> f32 {


### PR DESCRIPTION
## What

`process_tts_audio` decoded the PCM buffer **twice**:

```rust
let mut samples: Vec<f32> = (0..num_samples)
    .map(|i| {
        let lo = pcm[i * 2] as i16 as f32;
        let hi = (pcm[i * 2 + 1] as i8 as i16 as f32) * 256.0;
        lo + hi
    })
    .collect();                       // pass 1 — every element...

for i in 0..num_samples {             // ...immediately overwritten by pass 2
    let sample = i16::from_le_bytes([pcm[i * 2], pcm[i * 2 + 1]]);
    samples[i] = sample as f32;
}
```

The first `map`/`collect` pass is **dead work**: the second loop (the one the code itself comments as "Proper S16_LE decoding") overwrites all `num_samples` elements before any of pass 1's values are ever read. This folds the decode into a single correct pass:

```rust
let mut samples: Vec<f32> = (0..num_samples)
    .map(|i| i16::from_le_bytes([pcm[i * 2], pcm[i * 2 + 1]]) as f32)
    .collect();
```

## Why it matters

`process_tts_audio` runs on **every** Piper TTS output buffer before `aplay`, i.e. directly in the voice-output latency path. Halving the decode (and dropping the redundant per-sample float math + double-write) trims real per-utterance CPU on the Jetson-class targets this harness is built for.

## Measurement (truth, not theatre)

Extracted both decode variants into a standalone `rustc -O` harness over a 3 s / 22 050 Hz / S16 mono buffer (66 150 samples), 2 000 iterations, x86 Linux (not Jetson — I don't have the hardware, but this is pure integer/float CPU work so the win is platform-independent):

```
OLD two-pass : 288.7 ms  (2.2 ns/sample)
NEW one-pass :  44.4 ms  (0.3 ns/sample)
speedup      : 6.51x faster decode
```

The harness also asserts the two implementations produce **byte-identical** `Vec<f32>` output, so this is a pure speedup with no behavior change.

## Behavior / tests

Output is identical (pass 1 was fully overwritten), so no behavior change. All existing dsp tests pass:

```
cargo test -p genie-core voice::dsp::
test result: ok. 10 passed; 0 failed
```


## Real Behavior Proof

**What I ran:** extracted the old (two-pass) and new (single-pass) PCM decode into a standalone `rustc -O` harness over a 3 s / 22 050 Hz / S16 mono buffer (66 150 samples), 2 000 iterations on x86 Linux, plus the crate's existing dsp test suite.

**What I observed:**
- OLD two-pass: 288.7 ms  ·  NEW one-pass: 44.4 ms  ->  6.51x faster decode
- The harness asserts byte-identical `Vec<f32>` output between the two implementations
- `cargo test -p genie-core voice::dsp::`  ->  10 passed; 0 failed

- [x] I verified this change with the measurement above (local x86, not Jetson — pure integer/float CPU work, so the win is platform-independent).
- [x] Output is byte-identical to the previous implementation; no behavior change.
