### PR TITLE
perf(voice/noise): reuse per-frame RMS in apply_noise_suppression (~1.6x faster)

### DIFF
--- a/crates/genie-core/src/voice/noise.rs
+++ b/crates/genie-core/src/voice/noise.rs
@@ -351,4 +351,18 @@ mod tests {
             rms_after
         );
     }
+
+    #[test]
+    fn noise_suppression_ignores_too_short_input() {
+        // Fewer than 3 frames can't estimate a noise floor (and strength <= 0 is a
+        // no-op): the buffer comes back untouched despite carrying suppressible signal.
+        let original: Vec<f32> = (0..1500).map(|i| (i as f32 * 0.3).sin() * 3000.0).collect();
+        let mut samples = original.clone();
+        apply_noise_suppression(&mut samples, 0.6, 48000); // frame_size 960 -> 1 frame < 3
+        assert_eq!(samples, original);
+
+        let mut zero_strength = original.clone();
+        apply_noise_suppression(&mut zero_strength, 0.0, 48000);
+        assert_eq!(zero_strength, original);
+    }
 }

--- a/crates/genie-core/src/voice/noise.rs
+++ b/crates/genie-core/src/voice/noise.rs
@@ -203,10 +203,9 @@ fn apply_noise_suppression(samples: &mut [f32], strength: f32, sample_rate: u32)
     // Apply suppression: attenuate frames that are close to the noise floor.
     let suppression_threshold = noise_floor * 3.0; // Frames below 3× noise floor get suppressed.
 
-    for i in 0..num_frames {
+    for (i, &frame_rms) in frame_rms_by_index.iter().enumerate() {
         let start = i * frame_size;
         let end = (start + frame_size).min(samples.len());
-        let frame_rms = frame_rms_by_index[i];
 
         if frame_rms < suppression_threshold {
             // This frame is mostly noise — attenuate.

--- a/crates/genie-core/src/voice/noise.rs
+++ b/crates/genie-core/src/voice/noise.rs
@@ -177,24 +177,24 @@ fn apply_noise_suppression(samples: &mut [f32], strength: f32, sample_rate: u32)
         return; // Too short to estimate noise.
     }
 
-    // Estimate noise floor from the quietest 20% of frames.
-    let mut frame_energies: Vec<(usize, f32)> = (0..num_frames)
+    // Per-frame RMS, computed once and reused for both the noise-floor
+    // estimate and the suppression pass below (the loop used to recompute
+    // frame_rms for every frame — a second full pass over the samples).
+    let frame_rms_by_index: Vec<f32> = (0..num_frames)
         .map(|i| {
             let start = i * frame_size;
             let end = (start + frame_size).min(samples.len());
-            (i, frame_rms(&samples[start..end]))
+            frame_rms(&samples[start..end])
         })
         .collect();
 
-    frame_energies.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-
     // Average RMS of quietest 20% = estimated noise floor.
+    let mut sorted_energies = frame_rms_by_index.clone();
+    sorted_energies.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
     let noise_frame_count = (num_frames / 5).max(1);
-    let noise_floor: f32 = frame_energies[..noise_frame_count]
-        .iter()
-        .map(|(_, e)| e)
-        .sum::<f32>()
-        / noise_frame_count as f32;
+    let noise_floor: f32 =
+        sorted_energies[..noise_frame_count].iter().sum::<f32>() / noise_frame_count as f32;
 
     if noise_floor < 10.0 {
         return; // Very quiet — no noise to suppress.
@@ -206,7 +206,7 @@ fn apply_noise_suppression(samples: &mut [f32], strength: f32, sample_rate: u32)
     for i in 0..num_frames {
         let start = i * frame_size;
         let end = (start + frame_size).min(samples.len());
-        let frame_rms = frame_rms(&samples[start..end]);
+        let frame_rms = frame_rms_by_index[i];
 
         if frame_rms < suppression_threshold {
             // This frame is mostly noise — attenuate.

--- a/crates/genie-core/src/voice/noise.rs
+++ b/crates/genie-core/src/voice/noise.rs
@@ -365,4 +365,14 @@ mod tests {
         apply_noise_suppression(&mut zero_strength, 0.0, 48000);
         assert_eq!(zero_strength, original);
     }
+
+    #[test]
+    fn noise_suppression_ignores_near_silence() {
+        // A long but near-silent buffer (per-frame RMS ~3.5) sits below the 10.0
+        // noise-floor threshold, so suppression bails and leaves it unchanged.
+        let original: Vec<f32> = (0..9600).map(|i| (i as f32 * 0.3).sin() * 5.0).collect();
+        let mut samples = original.clone();
+        apply_noise_suppression(&mut samples, 0.6, 48000); // 10 frames, noise_floor ~3.5 < 10
+        assert_eq!(samples, original);
+    }
 }


### PR DESCRIPTION
## What

`apply_noise_suppression` computed each frame's RMS **twice**:

```rust
// pass 1 — to estimate the noise floor
let mut frame_energies: Vec<(usize, f32)> = (0..num_frames)
    .map(|i| (i, frame_rms(&samples[start..end])))
    .collect();
...
for i in 0..num_frames {
    ...
    let frame_rms = frame_rms(&samples[start..end]);   // pass 2 — same value, recomputed
    if frame_rms < suppression_threshold { ... }
}
```

`frame_rms` is a full sum-of-squares + `sqrt` over `frame_size` samples. The suppression loop re-derives a value the noise-floor pass already computed for every frame. This computes each frame's RMS once into a `Vec<f32>` and indexes it in both places.

`frame_rms_by_index[i]` in the loop reads frame `i`'s **original** samples — the same data pass 1 saw, since frames are disjoint and frame `i` isn't attenuated until after its RMS is read — so the values are identical.

## Why it matters

`apply_noise_suppression` runs on **every** microphone recording before Whisper STT, in the input-latency path of the harness. Dropping a redundant full RMS pass cuts real per-utterance CPU on the Jetson-class targets this is built for.

## Measurement (truth, not theatre)

Extracted the old and new versions into a standalone `rustc -O` harness over a 3 s / 16 kHz buffer, 300 iterations, x86 Linux (not Jetson — pure CPU work, so the win is platform-independent):

```
OLD (2x frame_rms): 145.8 ms
NEW (1x + reuse)  :  92.0 ms
speedup           : 1.58x
```

The harness asserts the two versions produce **bit-identical** output (`f32::to_bits` equal for every sample), so this is a pure speedup with no behavior change. The only added allocation is a clone of the per-frame RMS vec (one `f32` per ~20 ms frame) for the sort, which is far cheaper than the eliminated second RMS pass.

## Behavior / tests

```
cargo test -p genie-core voice::noise::
test result: ok. 5 passed; 0 failed
```


## Real Behavior Proof

**What I ran:** extracted the old (2x frame_rms) and new (compute-once + reuse) versions of `apply_noise_suppression` into a standalone `rustc -O` harness over a 3 s / 16 kHz buffer, 300 iterations on x86 Linux, plus the crate's existing noise test suite. Also ran `cargo clippy --all-targets -- -D warnings`.

**What I observed:**
- OLD (2x frame_rms): 145.8 ms  ·  NEW (1x + reuse): 92.0 ms  ->  1.58x faster
- The harness asserts bit-identical output (`f32::to_bits` equal for every sample)
- `cargo test -p genie-core voice::noise::`  ->  5 passed; 0 failed
- `cargo clippy -p genie-core --all-targets -- -D warnings`  ->  clean

- [x] I verified this change with the measurement above (local x86, not Jetson — pure CPU work, so the win is platform-independent).
- [x] Output is bit-identical to the previous implementation; no behavior change.
