### PR TITLE
fix(tools): enforce memory_store content schema at dispatch boundary (#416)

### DIFF
--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -135,6 +135,17 @@ fn parse_memory_forget_query(args: &serde_json::Value) -> Result<&str> {
         .ok_or_else(|| anyhow::anyhow!("memory_forget requires non-empty string argument 'query'"))
 }
 
+/// Reject a `memory_store` call with no usable `content` (#416). Delegates to
+/// `normalize_memories_to_store` so all valid shapes (aliases, catch-all, `name`)
+/// still pass; only missing/empty/wrong-type content is rejected.
+fn parse_memory_store_content(args: &serde_json::Value) -> Result<Vec<(String, String)>> {
+    let memories = normalize_memories_to_store(args);
+    if memories.is_empty() {
+        anyhow::bail!("memory_store requires non-empty string argument 'content'");
+    }
+    Ok(memories)
+}
+
 fn parse_calculate_expression(args: &serde_json::Value) -> Result<&str> {
     args.get("expression")
         .and_then(|v| v.as_str())
@@ -1433,6 +1444,8 @@ impl ToolDispatcher {
     }
 
     fn exec_memory_store(&self, args: &serde_json::Value) -> Result<String> {
+        // Validate content before the lock; previously a soft Ok() audited as success (#416).
+        let memories = parse_memory_store_content(args)?;
         let mem = self
             .memory
             .as_ref()
@@ -1440,10 +1453,6 @@ impl ToolDispatcher {
         let mem = mem
             .lock()
             .map_err(|e| anyhow::anyhow!("memory lock: {}", e))?;
-        let memories = normalize_memories_to_store(args);
-        if memories.is_empty() {
-            return Ok("Please specify what to remember.".to_string());
-        }
 
         let mut stored = Vec::new();
         let mut stored_categories = Vec::new();

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -819,6 +819,97 @@ async fn memory_forget_rejects_invalid_arguments_and_audits() {
 }
 
 #[tokio::test]
+async fn memory_store_rejects_invalid_arguments_and_audits() {
+    let paths = TestAuditPaths::new();
+    let memory_path = paths.data_dir.join("memory.db");
+    let memory = genie_core::memory::Memory::open(&memory_path).unwrap();
+    memory.store("identity", "User's name is Jared").unwrap();
+    let dispatcher = paths
+        .dispatcher(
+            None,
+            ToolPolicyConfig::default(),
+            ActuationSafetyConfig::default(),
+        )
+        .with_memory(Arc::new(Mutex::new(memory)));
+    let ctx = ToolExecutionContext {
+        request_origin: RequestOrigin::Dashboard,
+        ..ToolExecutionContext::default()
+    };
+
+    let invalid_calls = [
+        (
+            serde_json::json!({}),
+            "memory_store requires non-empty string argument 'content'",
+        ),
+        (
+            serde_json::json!({"content": ""}),
+            "memory_store requires non-empty string argument 'content'",
+        ),
+        (
+            serde_json::json!({"content": "   "}),
+            "memory_store requires non-empty string argument 'content'",
+        ),
+        (
+            serde_json::json!({"content": 123}),
+            "memory_store requires non-empty string argument 'content'",
+        ),
+    ];
+    let expected_audit_count = invalid_calls.len();
+
+    for (arguments, expected_snippet) in &invalid_calls {
+        let result = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "memory_store".into(),
+                    arguments: arguments.clone(),
+                },
+                ctx,
+            )
+            .await;
+
+        assert!(
+            !result.success,
+            "expected schema rejection, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains(expected_snippet),
+            "expected output to contain {expected_snippet:?}, got: {}",
+            result.output
+        );
+    }
+
+    // A valid content must still store (the guard only rejects missing content).
+    let ok = dispatcher
+        .execute_with_context(
+            &ToolCall {
+                name: "memory_store".into(),
+                arguments: serde_json::json!({"content": "the spare key is under the mat"}),
+            },
+            ctx,
+        )
+        .await;
+    assert!(
+        ok.success,
+        "valid memory_store must succeed, got: {}",
+        ok.output
+    );
+
+    let events = read_jsonl(&paths.tool_audit);
+    assert_eq!(
+        events.len(),
+        expected_audit_count + 1,
+        "each rejected call plus the valid one must be tool-audited"
+    );
+    for event in &events[..expected_audit_count] {
+        assert_eq!(event["tool"], "memory_store");
+        assert_eq!(event["origin"], "dashboard");
+        assert_eq!(event["success"], false);
+    }
+    assert_eq!(events[expected_audit_count]["success"], true);
+}
+
+#[tokio::test]
 async fn calculate_rejects_invalid_arguments_and_audits() {
     let paths = TestAuditPaths::new();
     let dispatcher = paths.dispatcher(


### PR DESCRIPTION
## Summary

Completes typed-tool enforcement for `memory_store` (#416). `memory_forget` — the other half of #416 — already landed via #413.

On `main`, `memory_store` accepted missing/empty/whitespace/wrong-type `content` and returned a soft `Ok("Please specify what to remember.")` that the tool gate audited as `success: true` — breaking the M1 typed-tool contract (same class as #408 / #411 / #413).

- Add `parse_memory_store_content`, delegating to `normalize_memories_to_store` so every valid shape (the `content`/`fact`/`text`/`memory`/`note` aliases, the catch-all string, and the `name` path) still passes; only genuinely missing/empty/wrong-type content is rejected with `success: false` + a tool-audit failure.
- Validate at the top of `exec_memory_store`, before the memory lock — like `exec_memory_forget` / `exec_memory_recall`.

## Real Behavior Proof

- [x] `cargo test -p genie-core --test tool_gate_integration_test` → **20 passed, 0 failed**, including the new `memory_store_rejects_invalid_arguments_and_audits` (`{}` / `""` / `"   "` / `123` → `success: false` + audit) plus a positive case asserting a valid `{"content": ...}` still stores; `memory_forget_rejects` / `memory_recall_rejects` unchanged.
- [x] `cargo fmt --check` clean · `cargo clippy -p genie-core --tests` 0 warnings (x86_64 dev host).