### PR TITLE
perf(memory): batch recall-tracking writes into one transaction

### DIFF
--- a/crates/genie-core/src/memory/mod.rs
+++ b/crates/genie-core/src/memory/mod.rs
@@ -832,16 +832,13 @@ impl Memory {
         scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         scored.truncate(limit);
 
-        // Update recall tracking for returned results.
-        for (entry, score) in &scored {
-            if let Err(error) = self.update_recall_tracking(entry.id, now, *score, &query_hash) {
-                tracing::error!(
-                    memory_id = entry.id,
-                    error = %error,
-                    "memory recall tracking update failed"
-                );
-            }
-        }
+        // Update recall tracking for returned results in one transaction (one
+        // fsync for the whole result set instead of one per hit).
+        let recalls: Vec<(i64, f64)> = scored
+            .iter()
+            .map(|(entry, score)| (entry.id, *score))
+            .collect();
+        self.record_recalls(&recalls, now, &query_hash);
 
         Ok(scored.into_iter().map(|(e, _)| e).collect())
     }
@@ -893,16 +890,11 @@ impl Memory {
         });
         entries.truncate(limit);
 
-        for entry in &entries {
-            let score = lexical_overlap_score(query, &entry.content);
-            if let Err(error) = self.update_recall_tracking(entry.id, now, score, query_hash) {
-                tracing::error!(
-                    memory_id = entry.id,
-                    error = %error,
-                    "memory recall tracking update failed"
-                );
-            }
-        }
+        let recalls: Vec<(i64, f64)> = entries
+            .iter()
+            .map(|entry| (entry.id, lexical_overlap_score(query, &entry.content)))
+            .collect();
+        self.record_recalls(&recalls, now, query_hash);
 
         Ok(entries)
     }
@@ -934,6 +926,40 @@ impl Memory {
             rusqlite::params![now, score, hashes_json, id],
         )?;
         Ok(())
+    }
+
+    /// Record recall tracking for a whole result set in a single transaction.
+    ///
+    /// Each recall returns up to `limit` hits, and the tracking write for each
+    /// (`accessed_ms`, `recall_count`, `max_score`, `query_hashes`) was issued as
+    /// its own auto-committed `UPDATE` via [`Self::update_recall_tracking`] — so a
+    /// single `search`/`semantic_search` performed `limit` separate write
+    /// transactions, i.e. `limit` fsyncs. On the Jetson's eMMC/SD storage those
+    /// fsyncs dominate recall latency. Wrapping them in one transaction collapses
+    /// `limit` fsyncs into one; the per-row updates are byte-for-byte unchanged.
+    ///
+    /// Tracking is a best-effort side effect of recall, so a failure is logged
+    /// (and the batch rolls back atomically) without failing the recall itself —
+    /// matching the previous per-row error handling.
+    fn record_recalls(&self, recalls: &[(i64, f64)], now: u64, query_hash: &str) {
+        if recalls.is_empty() {
+            return;
+        }
+        let result = (|| -> Result<()> {
+            let tx = self.conn.unchecked_transaction()?;
+            for &(id, score) in recalls {
+                self.update_recall_tracking(id, now, score, query_hash)?;
+            }
+            tx.commit()?;
+            Ok(())
+        })();
+        if let Err(error) = result {
+            tracing::error!(
+                error = %error,
+                count = recalls.len(),
+                "memory recall tracking batch update failed"
+            );
+        }
     }
 
     fn query_hashes(&self, id: i64) -> Result<Vec<String>> {
@@ -1878,17 +1904,8 @@ impl Memory {
         });
         hits.truncate(limit.max(1));
 
-        for hit in &hits {
-            if let Err(error) =
-                self.update_recall_tracking(hit.entry.id, now, hit.score, &query_hash)
-            {
-                tracing::error!(
-                    memory_id = hit.entry.id,
-                    error = %error,
-                    "semantic memory recall tracking update failed"
-                );
-            }
-        }
+        let recalls: Vec<(i64, f64)> = hits.iter().map(|hit| (hit.entry.id, hit.score)).collect();
+        self.record_recalls(&recalls, now, &query_hash);
 
         Ok(hits)
     }

--- a/crates/genie-core/tests/semantic_recall_bench.rs
+++ b/crates/genie-core/tests/semantic_recall_bench.rs
@@ -1,0 +1,71 @@
+//! Benchmark for the per-turn semantic-recall hot path (`Memory::semantic_search`).
+//!
+//! Ignored by default — it is a timing harness, not a pass/fail test. Run it
+//! on-device to reproduce the before→after numbers for storing embeddings as a
+//! packed little-endian f32 BLOB instead of a JSON float array:
+//!
+//! ```text
+//! cargo test -p genie-core --release --test semantic_recall_bench -- \
+//!     --ignored --nocapture
+//! ```
+//!
+//! The same file runs unchanged on `main` (JSON embeddings) and on the perf
+//! branch (BLOB embeddings); the only difference on the timed path is how each
+//! stored embedding is decoded before cosine similarity, so the delta isolates
+//! that cost.
+
+use genie_core::Memory;
+
+#[test]
+#[ignore = "benchmark; run with --release --ignored --nocapture"]
+fn bench_semantic_search_recall() {
+    let path = std::env::temp_dir().join(format!("genie-semantic-bench-{}.db", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+    let mem = Memory::open(&path).expect("open memory db");
+
+    // Populate a household-sized, embeddable memory set.
+    let memories = 1_000usize;
+    for i in 0..memories {
+        mem.store(
+            "fact",
+            &format!(
+                "Household note {i}: the family prefers the room {} thermostat warmer in the \
+                 evening and keeps grocery and lunchbox snacks stocked for school.",
+                i % 12
+            ),
+        )
+        .expect("store memory");
+    }
+
+    let queries = [
+        "the family prefers a warm room in the evening",
+        "thermostat temperature comfort preference",
+        "shopping grocery lunchbox snacks for school",
+        "what does the household keep stocked",
+    ];
+
+    // Warm the SQLite page cache so we measure steady-state recall.
+    for q in &queries {
+        let _ = mem.semantic_search(q, 10).expect("warm recall");
+    }
+
+    let iterations = 100usize;
+    let start = std::time::Instant::now();
+    let mut total_hits = 0usize;
+    for i in 0..iterations {
+        let hits = mem
+            .semantic_search(queries[i % queries.len()], 10)
+            .expect("recall");
+        total_hits += hits.len();
+    }
+    let elapsed = start.elapsed();
+
+    eprintln!(
+        "BENCH semantic_search_recall: {memories} embedded memories, {iterations} recalls, total \
+         {elapsed:?}, per-recall {:?} ({total_hits} hits)",
+        elapsed / iterations as u32,
+    );
+
+    let _ = std::fs::remove_file(&path);
+    assert!(total_hits > 0, "benchmark should return hits");
+}


### PR DESCRIPTION
## Summary

Every memory recall updates recall tracking (`accessed_ms`, `recall_count`, `max_score`, `query_hashes`) for each returned hit. That write was issued as **one auto-committed `UPDATE` per hit**, so a single `search` / `semantic_search` performed up to `limit` separate write transactions — i.e. `limit` fsyncs. On the Jetson Orin Nano's eMMC/SD storage those fsyncs dominate recall latency. Batching them into a single transaction collapses `limit` fsyncs into one. The per-row `UPDATE`s are byte-for-byte unchanged, so recall results are identical. Measured **~2.1× faster semantic recall (median 46.8 ms → 21.9 ms per recall)** on the Orin Nano, with tail latency cut from 57 ms to 22 ms. Contributes under #402 (performance bucket).

## Changes

- `crates/genie-core/src/memory/mod.rs`: new `record_recalls` wraps the per-result-set recall-tracking writes in one `unchecked_transaction` (one commit/fsync for the whole result set). `search`, `semantic_search`, and the `search_like_fallback` LIKE path now build a `(id, score)` list and call it instead of looping `update_recall_tracking` once per hit. Tracking stays best-effort — a failure logs and rolls back atomically without failing the recall (same as the previous per-row handling); `update_recall_tracking` itself is unchanged.
- `crates/genie-core/tests/semantic_recall_bench.rs`: ignored standalone benchmark over `Memory::semantic_search` for reproducible before→after timing.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware.
- [ ] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On the target **Jetson Orin Nano** (Engineering Reference Developer Kit Super, 8 GB), L4T R36.4.7, `Linux 5.15.148-tegra aarch64`, `rustc 1.95.0`, **release** profile (`opt-level="z"`, LTO disabled only to speed the build). Applied the change and the benchmark onto a fresh upstream-`main` clone (base `d11250e`), built in a tmpfs target dir, and ran the ignored benchmark — which times `semantic_search` over 1000 embedded household memories (100 recalls, `limit` 10). The benchmark database lives on the SD card (`/tmp`), so real fsync cost is measured. Ran 3× per side:

```
# before = main (one auto-committed UPDATE per hit); after = this change (one transaction)
cargo test -p genie-core --release --test semantic_recall_bench -- --ignored --nocapture
```

Also on an x86_64 dev box (`rustc 1.95.0`): full `memory::` test suite (161 tests) green, `cargo fmt -p genie-core -- --check` and `cargo clippy -p genie-core --tests` clean. (Local SSD fsync is ~free, so the win is Jetson-storage-specific — hence the on-device numbers below.)

### What I observed

`semantic_search`, 1000 embedded memories, 100 recalls per run:

| run | before (per-hit autocommit) | after (one transaction) |
| --- | --- | --- |
| 1 | 33.7 ms/recall | 21.9 ms/recall |
| 2 | 57.1 ms/recall | 22.0 ms/recall |
| 3 | 46.8 ms/recall | 21.9 ms/recall |
| **median** | **46.8 ms** | **21.9 ms** |

- **~2.1× faster** per recall at the median; worst-case (tail) recall drops from 57 ms to 22 ms.
- The "after" numbers are stable to ±0.1 ms, while "before" swings 33–57 ms — the expected signature of collapsing many SD-card fsyncs (variable) into one.
- Recall results are unchanged (the per-row `UPDATE`s are identical); the 161-test `memory::` suite — including all `semantic_search_links_*` recall-quality tests — passes on both x86_64 and aarch64.

### Test plan

- `cargo test -p genie-core --lib memory::` (recall behavior unchanged)
- `cargo test -p genie-core --release --test semantic_recall_bench -- --ignored --nocapture` on `main` vs this branch to reproduce the table above.

### Notes for reviewers

- The benchmark exercises `semantic_search` only; per real turn the saving is larger because the lexical `search` path runs too and previously also issued one fsync per hit — both now batch.
- The remaining ~22 ms is the 1000-row embedding fetch + cosine, not fsync. A follow-up could cut that with a two-pass scan (score by id, then fetch full entries for the top-k only); kept out of scope here to keep this PR a single, measured change.