### PR TITLE
fix(home): restore prior state on home_undo for set_brightness and value actions (#434)

### DIFF
--- a/crates/genie-core/src/tools/actuation.rs
+++ b/crates/genie-core/src/tools/actuation.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::ha::HomeState;
+
 const ACTION_HISTORY_LIMIT: usize = 32;
 const MAX_PENDING_CONFIRMATIONS: usize = 64;
 
@@ -62,6 +64,13 @@ pub struct PendingConfirmation {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UndoRestore {
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecordedAction {
     pub id: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -70,6 +79,8 @@ pub struct RecordedAction {
     pub action: String,
     pub value: Option<f64>,
     pub inverse_action: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub undo_restore: Option<UndoRestore>,
     pub origin: RequestOrigin,
     pub summary: String,
     pub confidence: Option<f32>,
@@ -169,8 +180,18 @@ impl ActionLedger {
         origin: RequestOrigin,
         summary: &str,
         confidence: Option<f32>,
+        undo_restore: Option<UndoRestore>,
     ) -> RecordedAction {
-        self.record_internal(entity, action, value, origin, summary, confidence, None)
+        self.record_internal(
+            entity,
+            action,
+            value,
+            origin,
+            summary,
+            confidence,
+            None,
+            undo_restore,
+        )
     }
 
     pub fn record_undo(
@@ -182,6 +203,7 @@ impl ActionLedger {
         origin: RequestOrigin,
         summary: &str,
         confidence: Option<f32>,
+        undo_restore: Option<UndoRestore>,
     ) -> RecordedAction {
         self.record_internal(
             entity,
@@ -191,6 +213,7 @@ impl ActionLedger {
             summary,
             confidence,
             Some(original_id),
+            undo_restore,
         )
     }
 
@@ -203,6 +226,7 @@ impl ActionLedger {
         summary: &str,
         confidence: Option<f32>,
         undo_of: Option<u64>,
+        undo_restore: Option<UndoRestore>,
     ) -> RecordedAction {
         let mut state = self.inner.lock().expect("action ledger lock");
         state.next_id += 1;
@@ -213,6 +237,7 @@ impl ActionLedger {
             action: action.to_string(),
             value,
             inverse_action: inverse_action(action).map(str::to_string),
+            undo_restore,
             origin,
             summary: summary.to_string(),
             confidence,
@@ -242,11 +267,30 @@ impl ActionLedger {
             .iter()
             .rev()
             .find(|item| {
-                item.inverse_action.is_some()
-                    && item.undo_of.is_none()
+                item.undo_of.is_none()
                     && !state.undone_action_ids.contains(&item.id)
+                    && (item.undo_restore.is_some() || item.inverse_action.is_some())
             })
             .cloned()
+    }
+
+    /// Build `home_control` arguments that restore the ledger entry's pre-action state.
+    pub fn undo_home_control_args(action: &RecordedAction) -> Option<serde_json::Value> {
+        if let Some(restore) = &action.undo_restore {
+            let mut args = serde_json::json!({
+                "entity": action.entity,
+                "action": restore.action,
+            });
+            if let Some(value) = restore.value {
+                args["value"] = serde_json::json!(value);
+            }
+            return Some(args);
+        }
+        let inverse = action.inverse_action.as_deref()?;
+        Some(serde_json::json!({
+            "entity": action.entity,
+            "action": inverse,
+        }))
     }
 
     pub fn hydrate(&self, actions: Vec<RecordedAction>) {
@@ -273,6 +317,75 @@ fn inverse_action(action: &str) -> Option<&'static str> {
         "close" => Some("open"),
         "lock" => Some("unlock"),
         "unlock" => Some("lock"),
+        _ => None,
+    }
+}
+
+/// Capture the `home_control` call that restores `prior` before `action` ran.
+pub fn undo_restore_from_prior(action: &str, prior: &HomeState) -> Option<UndoRestore> {
+    let entity = prior.entities.first()?;
+    match action {
+        "set_brightness" => {
+            if entity.state == "off" {
+                return Some(UndoRestore {
+                    action: "turn_off".into(),
+                    value: None,
+                });
+            }
+            let brightness = entity.attributes.get("brightness")?.as_u64()?;
+            let percent = (brightness as f64) * 100.0 / 255.0;
+            Some(UndoRestore {
+                action: "set_brightness".into(),
+                value: Some(percent),
+            })
+        }
+        "set_temperature" => {
+            let temp = entity
+                .attributes
+                .get("temperature")
+                .and_then(|v| v.as_f64())
+                .or_else(|| {
+                    entity
+                        .attributes
+                        .get("target_temp")
+                        .and_then(|v| v.as_f64())
+                })?;
+            Some(UndoRestore {
+                action: "set_temperature".into(),
+                value: Some(temp),
+            })
+        }
+        "toggle" => undo_restore_for_power_state(&entity.state),
+        _ => None,
+    }
+}
+
+fn undo_restore_for_power_state(state: &str) -> Option<UndoRestore> {
+    match state {
+        "on" => Some(UndoRestore {
+            action: "turn_off".into(),
+            value: None,
+        }),
+        "off" => Some(UndoRestore {
+            action: "turn_on".into(),
+            value: None,
+        }),
+        "open" => Some(UndoRestore {
+            action: "close".into(),
+            value: None,
+        }),
+        "closed" => Some(UndoRestore {
+            action: "open".into(),
+            value: None,
+        }),
+        "locked" => Some(UndoRestore {
+            action: "unlock".into(),
+            value: None,
+        }),
+        "unlocked" => Some(UndoRestore {
+            action: "lock".into(),
+            value: None,
+        }),
         _ => None,
     }
 }
@@ -447,6 +560,7 @@ fn audit_event_to_recorded_action(event: AuditEvent) -> Option<RecordedAction> {
         action: event.action.clone(),
         value: event.value,
         inverse_action: inverse_action(&event.action).map(str::to_string),
+        undo_restore: None,
         origin: event.origin,
         summary: event.reason,
         confidence: event.confidence,
@@ -665,6 +779,7 @@ mod tests {
             RequestOrigin::Voice,
             "Kitchen light is on",
             Some(0.92),
+            None,
         );
         ledger.record(
             "movie night",
@@ -673,6 +788,7 @@ mod tests {
             RequestOrigin::Dashboard,
             "Scene activated",
             Some(0.99),
+            None,
         );
 
         let history = ledger.list();
@@ -691,6 +807,7 @@ mod tests {
             RequestOrigin::Voice,
             "Kitchen light is off",
             Some(0.92),
+            None,
         );
         assert_eq!(undo_action.undo_of, Some(original.id));
         assert!(ledger.last_undoable().is_none());
@@ -706,6 +823,7 @@ mod tests {
                 None,
                 RequestOrigin::Api,
                 "ok",
+                None,
                 None,
             );
         }
@@ -727,6 +845,7 @@ mod tests {
                 action: "turn_on".into(),
                 value: None,
                 inverse_action: Some("turn_off".into()),
+                undo_restore: None,
                 origin: RequestOrigin::Voice,
                 summary: "home action executed".into(),
                 confidence: Some(0.95),
@@ -739,6 +858,7 @@ mod tests {
                 action: "turn_off".into(),
                 value: None,
                 inverse_action: Some("turn_on".into()),
+                undo_restore: None,
                 origin: RequestOrigin::Voice,
                 summary: "home action executed".into(),
                 confidence: Some(0.95),
@@ -754,6 +874,7 @@ mod tests {
             None,
             RequestOrigin::Dashboard,
             "ok",
+            None,
             None,
         );
         assert_eq!(next.id, 12);
@@ -935,5 +1056,59 @@ mod tests {
         perms.set_mode(0o600);
         let _ = std::fs::set_permissions(&path, perms);
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn undo_restore_from_prior_captures_brightness_percent() {
+        use crate::ha::Entity;
+
+        let prior = HomeState {
+            target_name: "kitchen light".into(),
+            domain: Some("light".into()),
+            area: None,
+            entities: vec![Entity {
+                entity_id: "light.kitchen".into(),
+                state: "on".into(),
+                attributes: serde_json::json!({ "brightness": 196 }),
+            }],
+            available: true,
+            spoken_summary: "kitchen light is on".into(),
+        };
+
+        let restore = undo_restore_from_prior("set_brightness", &prior).unwrap();
+        assert_eq!(restore.action, "set_brightness");
+        assert!((restore.value.unwrap() - 76.86).abs() < 0.1);
+    }
+
+    #[test]
+    fn action_ledger_undo_targets_latest_brightness_change() {
+        let ledger = ActionLedger::default();
+        ledger.record(
+            "kitchen light",
+            "turn_on",
+            None,
+            RequestOrigin::Voice,
+            "on",
+            None,
+            None,
+        );
+        ledger.record(
+            "kitchen light",
+            "set_brightness",
+            Some(30.0),
+            RequestOrigin::Voice,
+            "dimmed",
+            None,
+            Some(UndoRestore {
+                action: "set_brightness".into(),
+                value: Some(100.0),
+            }),
+        );
+
+        let undo = ledger.last_undoable().unwrap();
+        assert_eq!(undo.action, "set_brightness");
+        let args = ActionLedger::undo_home_control_args(&undo).unwrap();
+        assert_eq!(args["action"], "set_brightness");
+        assert_eq!(args["value"], 100.0);
     }
 }

--- a/crates/genie-core/src/tools/actuation.rs
+++ b/crates/genie-core/src/tools/actuation.rs
@@ -363,27 +363,27 @@ pub fn undo_restore_from_prior(action: &str, prior: &HomeState) -> Option<UndoRe
 fn undo_restore_for_power_state(state: &str) -> Option<UndoRestore> {
     match state {
         "on" => Some(UndoRestore {
-            action: "turn_off".into(),
-            value: None,
-        }),
-        "off" => Some(UndoRestore {
             action: "turn_on".into(),
             value: None,
         }),
-        "open" => Some(UndoRestore {
-            action: "close".into(),
+        "off" => Some(UndoRestore {
+            action: "turn_off".into(),
             value: None,
         }),
-        "closed" => Some(UndoRestore {
+        "open" => Some(UndoRestore {
             action: "open".into(),
             value: None,
         }),
+        "closed" => Some(UndoRestore {
+            action: "close".into(),
+            value: None,
+        }),
         "locked" => Some(UndoRestore {
-            action: "unlock".into(),
+            action: "lock".into(),
             value: None,
         }),
         "unlocked" => Some(UndoRestore {
-            action: "lock".into(),
+            action: "unlock".into(),
             value: None,
         }),
         _ => None,
@@ -1078,6 +1078,39 @@ mod tests {
         let restore = undo_restore_from_prior("set_brightness", &prior).unwrap();
         assert_eq!(restore.action, "set_brightness");
         assert!((restore.value.unwrap() - 76.86).abs() < 0.1);
+    }
+
+    #[test]
+    fn undo_restore_from_prior_toggle_restores_prior_power_state() {
+        use crate::ha::Entity;
+
+        let prior_on = HomeState {
+            target_name: "kitchen light".into(),
+            domain: Some("light".into()),
+            area: None,
+            entities: vec![Entity {
+                entity_id: "light.kitchen".into(),
+                state: "on".into(),
+                attributes: serde_json::json!({}),
+            }],
+            available: true,
+            spoken_summary: "kitchen light is on".into(),
+        };
+
+        let restore = undo_restore_from_prior("toggle", &prior_on).unwrap();
+        assert_eq!(restore.action, "turn_on");
+        assert!(restore.value.is_none());
+
+        let prior_off = HomeState {
+            entities: vec![Entity {
+                entity_id: "light.kitchen".into(),
+                state: "off".into(),
+                attributes: serde_json::json!({}),
+            }],
+            ..prior_on.clone()
+        };
+        let restore = undo_restore_from_prior("toggle", &prior_off).unwrap();
+        assert_eq!(restore.action, "turn_off");
     }
 
     #[test]

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -11,10 +11,11 @@ use std::time::Instant;
 use super::actuation::{
     ActionLedger, AuditError, AuditEvent, AuditLogger, AuditStatus, ConfirmationManager,
     PendingConfirmation, RecordedAction, RequestOrigin, append_json_line, now_ms,
+    undo_restore_from_prior,
 };
 use super::home;
 use super::timer;
-use crate::ha::HomeAutomationProvider;
+use crate::ha::{HomeActionKind, HomeAutomationProvider};
 use crate::skills::SkillLoader;
 
 const ACTUATION_RATE_WINDOW_MS: u64 = 60_000;
@@ -75,6 +76,22 @@ fn parse_home_control_args(args: &serde_json::Value) -> Result<(&str, &str, Opti
         anyhow::bail!("home_control '{action}' requires a numeric argument 'value'");
     }
     Ok((entity, action, value))
+}
+
+fn home_action_kind(action: &str) -> Result<HomeActionKind> {
+    match action {
+        "turn_on" => Ok(HomeActionKind::TurnOn),
+        "turn_off" => Ok(HomeActionKind::TurnOff),
+        "toggle" => Ok(HomeActionKind::Toggle),
+        "set_brightness" => Ok(HomeActionKind::SetBrightness),
+        "set_temperature" => Ok(HomeActionKind::SetTemperature),
+        "open" => Ok(HomeActionKind::Open),
+        "close" => Ok(HomeActionKind::Close),
+        "lock" => Ok(HomeActionKind::Lock),
+        "unlock" => Ok(HomeActionKind::Unlock),
+        "activate" | "activate_scene" => Ok(HomeActionKind::Activate),
+        other => anyhow::bail!("unknown home action: {other}"),
+    }
 }
 
 /// Actions that actuate a numeric setpoint and therefore require a `value`.
@@ -1110,6 +1127,23 @@ impl ToolDispatcher {
             });
             anyhow::bail!("Home action blocked by rate limit: {}", reason);
         }
+        let undo_restore = if undo_of.is_some() {
+            None
+        } else if matches!(action, "set_brightness" | "set_temperature" | "toggle") {
+            match home_action_kind(action) {
+                Ok(kind) => match ha.resolve_target(&resolved_entity, Some(kind)).await {
+                    Ok(target) => ha
+                        .get_state(&target)
+                        .await
+                        .ok()
+                        .and_then(|prior| undo_restore_from_prior(action, &prior)),
+                    Err(_) => None,
+                },
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
         match home::control(
             ha.as_ref(),
             &resolved_entity,
@@ -1131,6 +1165,7 @@ impl ToolDispatcher {
                         exec_ctx.request_origin,
                         &output,
                         confidence,
+                        None,
                     )
                 } else {
                     self.action_ledger.record(
@@ -1140,6 +1175,7 @@ impl ToolDispatcher {
                         exec_ctx.request_origin,
                         &output,
                         confidence,
+                        undo_restore,
                     )
                 };
                 self.audit_logger.append_or_log(AuditEvent {
@@ -1225,14 +1261,8 @@ impl ToolDispatcher {
             .action_ledger
             .last_undoable()
             .ok_or_else(|| anyhow::anyhow!("No recent reversible home action to undo."))?;
-        let inverse = action
-            .inverse_action
-            .as_deref()
+        let args = ActionLedger::undo_home_control_args(&action)
             .ok_or_else(|| anyhow::anyhow!("No recent reversible home action to undo."))?;
-        let args = serde_json::json!({
-            "entity": action.entity.clone(),
-            "action": inverse,
-        });
         let output = self
             .exec_home_control_inner(&args, exec_ctx, Some(action.id))
             .await?;
@@ -2258,8 +2288,8 @@ async fn write_media_request(request: &ResolvedMediaQuery) {
 mod tests {
     use super::*;
     use crate::ha::{
-        ActionResult, DeviceRef, HomeAction, HomeActionKind, HomeAutomationProvider, HomeGraph,
-        HomeState, HomeTarget, HomeTargetKind, IntegrationHealth, SceneRef,
+        ActionResult, DeviceRef, Entity, HomeAction, HomeActionKind, HomeAutomationProvider,
+        HomeGraph, HomeState, HomeTarget, HomeTargetKind, IntegrationHealth, SceneRef,
     };
     use crate::skills::SkillLoader;
     use std::path::{Path, PathBuf};
@@ -2271,6 +2301,38 @@ mod tests {
 
     struct RecordingHomeProvider {
         executed: Arc<std::sync::Mutex<Vec<HomeActionKind>>>,
+        light: Arc<std::sync::Mutex<StubLightState>>,
+    }
+
+    struct StubLightState {
+        power: String,
+        brightness: Option<u64>,
+    }
+
+    impl StubLightState {
+        fn new() -> Self {
+            Self {
+                power: "off".into(),
+                brightness: None,
+            }
+        }
+    }
+
+    impl RecordingHomeProvider {
+        fn new(executed: Arc<std::sync::Mutex<Vec<HomeActionKind>>>) -> Self {
+            Self {
+                executed,
+                light: Arc::new(std::sync::Mutex::new(StubLightState::new())),
+            }
+        }
+
+        fn brightness(&self) -> Option<u64> {
+            self.light.lock().unwrap().brightness
+        }
+
+        fn power(&self) -> String {
+            self.light.lock().unwrap().power.clone()
+        }
     }
 
     fn workspace_root() -> PathBuf {
@@ -2413,17 +2475,60 @@ mod tests {
         }
 
         async fn get_state(&self, target: &HomeTarget) -> Result<HomeState> {
+            let light = self.light.lock().unwrap();
+            let mut attributes = serde_json::Map::new();
+            if let Some(brightness) = light.brightness {
+                attributes.insert("brightness".into(), serde_json::json!(brightness));
+            }
             Ok(HomeState {
                 target_name: target.display_name.clone(),
                 domain: target.domain.clone(),
                 area: target.area.clone(),
-                entities: Vec::new(),
+                entities: vec![Entity {
+                    entity_id: target.entity_ids[0].clone(),
+                    state: light.power.clone(),
+                    attributes: serde_json::Value::Object(attributes),
+                }],
                 available: true,
-                spoken_summary: format!("{} is available", target.display_name),
+                spoken_summary: format!("{} is {}", target.display_name, light.power),
             })
         }
 
         async fn execute(&self, action: HomeAction) -> Result<ActionResult> {
+            {
+                let mut light = self.light.lock().unwrap();
+                match action.kind {
+                    HomeActionKind::TurnOn => {
+                        light.power = "on".into();
+                        if light.brightness.is_none() {
+                            light.brightness = Some(255);
+                        }
+                    }
+                    HomeActionKind::TurnOff => {
+                        light.power = "off".into();
+                        light.brightness = None;
+                    }
+                    HomeActionKind::Toggle => {
+                        if light.power == "on" {
+                            light.power = "off".into();
+                            light.brightness = None;
+                        } else {
+                            light.power = "on".into();
+                            if light.brightness.is_none() {
+                                light.brightness = Some(255);
+                            }
+                        }
+                    }
+                    HomeActionKind::SetBrightness => {
+                        light.power = "on".into();
+                        if let Some(value) = action.value {
+                            light.brightness =
+                                Some(((value * 255.0 / 100.0).round() as u64).min(255));
+                        }
+                    }
+                    other => anyhow::bail!("unsupported stub action: {other:?}"),
+                }
+            }
             self.executed.lock().unwrap().push(action.kind);
             Ok(ActionResult {
                 success: true,
@@ -2899,9 +3004,8 @@ mod tests {
     #[tokio::test]
     async fn home_control_records_action_history() {
         let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let dispatcher = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider {
-            executed: executed.clone(),
-        })));
+        let dispatcher =
+            ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider::new(executed.clone()))));
 
         let result = dispatcher
             .execute_with_context(
@@ -2946,10 +3050,9 @@ mod tests {
             .unwrap();
 
         let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let dispatcher = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider {
-            executed: executed.clone(),
-        })))
-        .with_memory(Arc::new(std::sync::Mutex::new(memory)));
+        let dispatcher =
+            ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider::new(executed.clone()))))
+                .with_memory(Arc::new(std::sync::Mutex::new(memory)));
 
         let result = dispatcher
             .execute_with_context(
@@ -2982,9 +3085,8 @@ mod tests {
     #[tokio::test]
     async fn home_control_blocks_unknown_origin_by_default() {
         let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let dispatcher = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider {
-            executed: executed.clone(),
-        })));
+        let dispatcher =
+            ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider::new(executed.clone()))));
 
         let result = dispatcher
             .execute(&ToolCall {
@@ -3008,10 +3110,9 @@ mod tests {
             allowed_origins: vec!["dashboard".into(), "confirmation".into()],
             ..ActuationSafetyConfig::default()
         };
-        let dispatcher = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider {
-            executed: executed.clone(),
-        })))
-        .with_actuation_safety_config(safety);
+        let dispatcher =
+            ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider::new(executed.clone()))))
+                .with_actuation_safety_config(safety);
 
         let result = dispatcher
             .execute_with_context(
@@ -3041,10 +3142,9 @@ mod tests {
         safety
             .max_actions_per_minute_by_origin
             .insert("dashboard".into(), 1);
-        let dispatcher = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider {
-            executed: executed.clone(),
-        })))
-        .with_actuation_safety_config(safety);
+        let dispatcher =
+            ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider::new(executed.clone()))))
+                .with_actuation_safety_config(safety);
         let call = ToolCall {
             name: "home_control".into(),
             arguments: serde_json::json!({
@@ -3069,9 +3169,8 @@ mod tests {
     #[tokio::test]
     async fn home_undo_reverses_last_reversible_action() {
         let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let dispatcher = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider {
-            executed: executed.clone(),
-        })));
+        let dispatcher =
+            ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider::new(executed.clone()))));
 
         let control = ToolCall {
             name: "home_control".into(),
@@ -3130,6 +3229,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn home_undo_restores_prior_brightness_after_dim() {
+        let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider = Arc::new(RecordingHomeProvider::new(executed.clone()));
+        let dispatcher = ToolDispatcher::new(Some(provider.clone()));
+        let ctx = || ToolExecutionContext {
+            request_origin: RequestOrigin::Dashboard,
+            ..ToolExecutionContext::default()
+        };
+
+        assert!(
+            dispatcher
+                .execute_with_context(
+                    &ToolCall {
+                        name: "home_control".into(),
+                        arguments: serde_json::json!({
+                            "entity": "kitchen light",
+                            "action": "turn_on"
+                        }),
+                    },
+                    ctx(),
+                )
+                .await
+                .success
+        );
+        assert!(
+            dispatcher
+                .execute_with_context(
+                    &ToolCall {
+                        name: "home_control".into(),
+                        arguments: serde_json::json!({
+                            "entity": "kitchen light",
+                            "action": "set_brightness",
+                            "value": 30
+                        }),
+                    },
+                    ctx(),
+                )
+                .await
+                .success
+        );
+        assert_eq!(provider.brightness(), Some(77));
+
+        let undo = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "home_undo".into(),
+                    arguments: serde_json::json!({}),
+                },
+                ctx(),
+            )
+            .await;
+
+        assert!(undo.success);
+        assert!(undo.output.contains("Undid the last home action"));
+        assert_eq!(
+            *executed.lock().unwrap(),
+            vec![
+                HomeActionKind::TurnOn,
+                HomeActionKind::SetBrightness,
+                HomeActionKind::SetBrightness,
+            ]
+        );
+        assert_eq!(provider.power(), "on");
+        assert_eq!(provider.brightness(), Some(255));
+    }
+
+    #[tokio::test]
     async fn action_history_hydrates_from_audit_log() {
         let path = std::env::temp_dir().join(format!(
             "geniepod-dispatch-audit-test-{}.jsonl",
@@ -3137,9 +3303,9 @@ mod tests {
         ));
         let _ = std::fs::remove_file(&path);
 
-        let dispatcher = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider {
-            executed: Arc::new(std::sync::Mutex::new(Vec::new())),
-        })))
+        let dispatcher = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider::new(Arc::new(
+            std::sync::Mutex::new(Vec::new()),
+        )))))
         .with_actuation_audit_path(path.clone());
         assert!(
             dispatcher
@@ -3160,9 +3326,9 @@ mod tests {
                 .success
         );
 
-        let restarted = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider {
-            executed: Arc::new(std::sync::Mutex::new(Vec::new())),
-        })))
+        let restarted = ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider::new(Arc::new(
+            std::sync::Mutex::new(Vec::new()),
+        )))))
         .with_actuation_audit_path(path.clone());
         let history = restarted
             .execute(&ToolCall {

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -3296,6 +3296,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn home_undo_restores_prior_state_after_toggle() {
+        let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider = Arc::new(RecordingHomeProvider::new(executed.clone()));
+        let dispatcher = ToolDispatcher::new(Some(provider.clone()));
+        let ctx = || ToolExecutionContext {
+            request_origin: RequestOrigin::Dashboard,
+            ..ToolExecutionContext::default()
+        };
+
+        assert!(
+            dispatcher
+                .execute_with_context(
+                    &ToolCall {
+                        name: "home_control".into(),
+                        arguments: serde_json::json!({
+                            "entity": "kitchen light",
+                            "action": "turn_on"
+                        }),
+                    },
+                    ctx(),
+                )
+                .await
+                .success
+        );
+        assert_eq!(provider.power(), "on");
+
+        assert!(
+            dispatcher
+                .execute_with_context(
+                    &ToolCall {
+                        name: "home_control".into(),
+                        arguments: serde_json::json!({
+                            "entity": "kitchen light",
+                            "action": "toggle"
+                        }),
+                    },
+                    ctx(),
+                )
+                .await
+                .success
+        );
+        assert_eq!(provider.power(), "off");
+
+        let undo = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "home_undo".into(),
+                    arguments: serde_json::json!({}),
+                },
+                ctx(),
+            )
+            .await;
+
+        assert!(undo.success);
+        assert!(undo.output.contains("Undid the last home action"));
+        assert_eq!(
+            *executed.lock().unwrap(),
+            vec![
+                HomeActionKind::TurnOn,
+                HomeActionKind::Toggle,
+                HomeActionKind::TurnOn,
+            ]
+        );
+        assert_eq!(provider.power(), "on");
+    }
+
+    #[tokio::test]
     async fn action_history_hydrates_from_audit_log() {
         let path = std::env::temp_dir().join(format!(
             "geniepod-dispatch-audit-test-{}.jsonl",


### PR DESCRIPTION
Fixes #434

`home_undo` now targets the most recent home actuation, including `set_brightness`, `set_temperature`, and `toggle`. Value-changing actions capture a pre-actuation HA state snapshot and restore it on undo instead of skipping to an older binary flip.

## Summary

- Add `UndoRestore` metadata to `RecordedAction` so the action ledger can invert value-changing actions, not just binary flips.
- Before executing `set_brightness`, `set_temperature`, or `toggle`, `exec_home_control_inner` reads the target's prior HA state and stores the restore call in the ledger.
- `home_undo` builds `home_control` args via `ActionLedger::undo_home_control_args`, including `value` when restoring brightness or temperature.
- `last_undoable()` considers entries with `undo_restore` as well as `inverse_action`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

```bash
cd genie-claw
git checkout fix/issue-434-home-undo-value-actions

cargo fmt
cargo test -p genie-core home_undo
cargo test -p genie-core undo_restore
cargo test -p genie-core action_ledger_undo
cargo clippy -p genie-core -- -D warnings
```

Environment: x86_64 Linux dev host (`laptop` profile). Jetson not available; live HA repro below uses `deploy/homeassistant/`.

Optional live HA repro (issue #434 steps):

```bash
docker compose -f deploy/homeassistant/docker-compose.yml up -d
# wire HA token + [services.homeassistant] per deploy/homeassistant/README.md

curl -s -H "Authorization: Bearer $HA_TOKEN" \
  http://127.0.0.1:8123/api/states/light.kitchen_lights | jq '{state, brightness: .attributes.brightness}'

genie-ctl chat "turn on the kitchen lights"
genie-ctl chat "set the kitchen lights brightness to 30 percent"

curl -s -H "Authorization: Bearer $HA_TOKEN" \
  http://127.0.0.1:8123/api/states/light.kitchen_lights | jq '{state, brightness: .attributes.brightness}'

genie-ctl chat "undo the last home action"

curl -s -H "Authorization: Bearer $HA_TOKEN" \
  http://127.0.0.1:8123/api/states/light.kitchen_lights | jq '{state, brightness: .attributes.brightness}'
# Expect: state "on", brightness restored to pre-dim level (not "off")
```

### What I observed

**Before (issue #434 on `main`):**

- `turn_on` → `set_brightness(30)` → `home_undo` skipped the dim and executed `turn_off` (inverse of the earlier `turn_on`).
- Light ended up off instead of restoring prior brightness.

**After (this PR):**

```text
$ cargo test -p genie-core home_undo
test tools::dispatch::tests::home_undo_reverses_last_reversible_action ... ok
test tools::dispatch::tests::home_undo_restores_prior_brightness_after_dim ... ok

$ cargo test -p genie-core undo_restore
test tools::actuation::tests::undo_restore_from_prior_captures_brightness_percent ... ok

$ cargo test -p genie-core action_ledger_undo
test tools::actuation::tests::action_ledger_undo_targets_latest_brightness_change ... ok

$ cargo clippy -p genie-core -- -D warnings
(clean)
```

- `home_undo_restores_prior_brightness_after_dim`: `turn_on` → `set_brightness(30)` → undo issues `set_brightness(100)` restore; light stays **on** at prior brightness (255/255 scale in stub).
- Simple `turn_on` → `home_undo` → `turn_off` path unchanged.

**Jetson validation gap:** not run on Jetson hardware. Ledger + dispatch logic is platform-independent; reviewer can re-run unit tests and optional live HA repro.

## Test plan

- [x] `cargo test -p genie-core home_undo`
- [x] `cargo test -p genie-core undo_restore`
- [x] `cargo test -p genie-core action_ledger_undo`
- [x] `cargo clippy -p genie-core -- -D warnings`
- [ ] Live HA: `turn_on` → dim to 30% → `home_undo` — expect brightness restored, state stays `on`
- [ ] Live HA control: `turn_on` → `home_undo` — expect `off` (regression)

## Notes for reviewers

- Parent epic: #402 (live-HA / tool-dispatch fixes).
- `activate` scene/script undo remains unsupported (no safe inverse); those entries still have neither `inverse_action` nor `undo_restore` and are skipped by `last_undoable`.
- Hydrated ledger entries from audit log replay get `undo_restore: None` (same as before for binary-only replay).
