### PR TITLE
fix(tools): recover scalar single-key tool calls instead of dropping arguments (#438)

### DIFF
--- a/crates/genie-core/src/tools/parser.rs
+++ b/crates/genie-core/src/tools/parser.rs
@@ -88,15 +88,9 @@ fn normalize_single_key_tool_call(
         return None;
     }
 
-    let arguments = if nested.is_object() {
-        nested.clone()
-    } else {
-        serde_json::json!({})
-    };
-
     Some(ToolCall {
         name: tool_name.clone(),
-        arguments,
+        arguments: normalize_single_key_arguments(tool_name, nested),
     })
 }
 
@@ -151,15 +145,61 @@ fn normalize_single_key_tool_call_for_eval(value: serde_json::Value) -> Option<T
         return None;
     }
 
-    let arguments = if nested.is_object() {
-        nested.clone()
-    } else {
-        serde_json::json!({})
-    };
-
     Some(ToolCall {
         name: tool_name.clone(),
-        arguments,
+        arguments: normalize_single_key_arguments(tool_name, nested),
+    })
+}
+
+/// Map the nested value of a compact single-key tool call (`{tool: <value>}`)
+/// to a tool arguments object.
+///
+/// Small models emit two shapes: a nested **object**
+/// (`{"get_weather":{"location":"Denver"}}`) whose contents are the arguments
+/// verbatim, and a nested **scalar** (`{"get_weather":"Denver"}`) where the
+/// model inlined the tool's primary argument. The scalar shape previously
+/// collapsed to `{}`, silently dropping the value and forcing a misleading
+/// schema error or empty actuation (issue #438); route it to the tool's primary
+/// argument instead. Shapes that are neither object nor scalar (array/null) keep
+/// the previous empty-arguments behavior.
+fn normalize_single_key_arguments(
+    tool_name: &str,
+    nested: &serde_json::Value,
+) -> serde_json::Value {
+    if nested.is_object() {
+        return nested.clone();
+    }
+
+    if (nested.is_string() || nested.is_number() || nested.is_boolean())
+        && let Some(primary) = scalar_primary_arg(tool_name)
+    {
+        let mut arguments = serde_json::Map::new();
+        arguments.insert(primary.to_string(), nested.clone());
+        return serde_json::Value::Object(arguments);
+    }
+
+    serde_json::json!({})
+}
+
+/// The argument a scalar single-key tool call should populate, for tools whose
+/// schema has a single required scalar input (see `normalize_single_key_arguments`,
+/// issue #438). Each entry is the sole `required` field of that tool in
+/// `ToolDispatcher::tool_defs`; the `scalar_primary_arg_matches_tool_schema` test
+/// guards against drift. Tools with zero or multiple required fields (e.g.
+/// `home_control`, `get_time`) are intentionally absent — a lone scalar cannot
+/// unambiguously fill them, so they keep the empty-arguments fallback.
+fn scalar_primary_arg(tool_name: &str) -> Option<&'static str> {
+    Some(match tool_name {
+        "get_weather" => "location",
+        "web_search" => "query",
+        "calculate" => "expression",
+        "play_media" => "query",
+        "memory_recall" => "query",
+        "memory_store" => "content",
+        "memory_forget" => "query",
+        "home_status" => "entity",
+        "set_timer" => "seconds",
+        _ => return None,
     })
 }
 
@@ -430,6 +470,122 @@ mod tests {
         });
 
         assert!(normalize_single_key_tool_call(value, &dispatcher).is_none());
+    }
+
+    #[test]
+    fn single_key_scalar_value_maps_to_primary_arg() {
+        let dispatcher = ToolDispatcher::new(None);
+        for (json, tool, arg, expected) in [
+            (
+                r#"{"get_weather":"Denver"}"#,
+                "get_weather",
+                "location",
+                "Denver",
+            ),
+            (
+                r#"{"calculate":"2 + 2"}"#,
+                "calculate",
+                "expression",
+                "2 + 2",
+            ),
+            (
+                r#"{"memory_recall":"Maya"}"#,
+                "memory_recall",
+                "query",
+                "Maya",
+            ),
+            (r#"{"play_media":"jazz"}"#, "play_media", "query", "jazz"),
+        ] {
+            let value: serde_json::Value = serde_json::from_str(json).unwrap();
+            let call = normalize_single_key_tool_call(value, &dispatcher).unwrap();
+            assert_eq!(call.name, tool);
+            assert_eq!(call.arguments[arg], expected, "tool {tool}");
+        }
+    }
+
+    #[test]
+    fn single_key_scalar_number_maps_to_primary_arg() {
+        let dispatcher = ToolDispatcher::new(None);
+        let value = serde_json::json!({ "set_timer": 300 });
+        let call = normalize_single_key_tool_call(value, &dispatcher).unwrap();
+        assert_eq!(call.name, "set_timer");
+        assert_eq!(call.arguments["seconds"], 300);
+    }
+
+    #[test]
+    fn single_key_object_value_is_unchanged() {
+        // Regression: nested objects must still pass through verbatim.
+        let dispatcher = ToolDispatcher::new(None);
+        let value = serde_json::json!({ "get_weather": {"location": "Tokyo", "forecast": true} });
+        let call = normalize_single_key_tool_call(value, &dispatcher).unwrap();
+        assert_eq!(call.arguments["location"], "Tokyo");
+        assert_eq!(call.arguments["forecast"], true);
+    }
+
+    #[test]
+    fn single_key_scalar_without_primary_arg_stays_empty() {
+        // home_control has two required fields (entity, action): a lone scalar
+        // cannot fill it unambiguously, so arguments stay empty as before.
+        let dispatcher = ToolDispatcher::new(None);
+        if dispatcher
+            .tool_defs()
+            .iter()
+            .any(|t| t.name == "home_control")
+        {
+            let value = serde_json::json!({ "home_control": "kitchen light" });
+            let call = normalize_single_key_tool_call(value, &dispatcher).unwrap();
+            assert_eq!(call.name, "home_control");
+            assert_eq!(call.arguments, serde_json::json!({}));
+        }
+    }
+
+    #[test]
+    fn eval_parser_recovers_scalar_single_key_call() {
+        let calls = parse_tool_calls_for_eval(r#"{"web_search":"jetson power consumption"}"#);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "web_search");
+        assert_eq!(calls[0].arguments["query"], "jetson power consumption");
+    }
+
+    #[test]
+    fn scalar_primary_arg_matches_tool_schema() {
+        // Drift guard: every mapped primary arg must be the tool's sole required
+        // field in its actual schema, so the table cannot silently diverge.
+        let dispatcher = ToolDispatcher::new(None);
+        for def in dispatcher.tool_defs() {
+            if let Some(primary) = scalar_primary_arg(&def.name) {
+                let required: Vec<&str> = def
+                    .parameters
+                    .get("required")
+                    .and_then(|r| r.as_array())
+                    .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+                    .unwrap_or_default();
+                assert_eq!(
+                    required,
+                    vec![primary],
+                    "scalar_primary_arg({}) must equal the tool's sole required field",
+                    def.name
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn try_tool_call_recovers_scalar_single_key_calculate() {
+        // End-to-end: a compact scalar call now executes instead of failing
+        // schema validation with empty arguments (issue #438). `calculate` is
+        // always registered and needs no network or home automation.
+        let dispatcher = ToolDispatcher::new(None);
+        let result = try_tool_call(r#"{"calculate":"2 + 2"}"#, &dispatcher)
+            .await
+            .unwrap();
+        assert_eq!(result.tool, "calculate");
+        assert!(
+            result.success,
+            "scalar single-key calculate should execute, got: {}",
+            result.output
+        );
+        assert!(result.output.contains('4'), "output: {}", result.output);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #438. Compact single-key tool calls with a **scalar** nested value — `{"get_weather":"Denver"}` instead of `{"get_weather":{"location":"Denver"}}`, common from small local models — had their value silently dropped: the normalizer replaced every non-object nested value with `{}`. Execution then failed schema validation (`get_weather requires non-empty string argument 'location'`) or actuated with empty inputs, and the identical logic in the eval normalizer made BFCL scoring miss valid compact outputs.

This routes a scalar nested value to the tool's **primary argument** (the sole `required` field of its schema), preserving the model's intent.

## Changes

- New shared `normalize_single_key_arguments(tool_name, nested)` used by **both** the runtime (`normalize_single_key_tool_call`) and eval (`normalize_single_key_tool_call_for_eval`) paths:
  - nested **object** → arguments verbatim (unchanged behavior);
  - nested **scalar** (string/number/bool) → `{ <primary_arg>: <scalar> }`;
  - anything else (array/null) → `{}` (unchanged fallback).
- `scalar_primary_arg(tool_name)` maps each single-required-field tool to its primary arg (`get_weather`→`location`, `web_search`→`query`, `calculate`→`expression`, `memory_recall`/`memory_forget`/`play_media`→`query`, `memory_store`→`content`, `home_status`→`entity`, `set_timer`→`seconds`). Tools with zero or multiple required fields (`home_control`, `get_time`, …) are intentionally excluded — a lone scalar can't unambiguously fill them, so they keep the empty-arguments fallback.
- A drift-guard test asserts every mapped argument equals the tool's sole `required` field in its actual `tool_defs` schema, so the table cannot silently diverge from the schemas.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `laptop`

### What I ran

On an x86_64 Linux dev host (this is a hardware-independent parser/dispatch logic fix — issue #438 is filed as Non-Jetson x86_64, test plan = parser unit test):

- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p genie-core --all-targets --locked -- -D warnings` — clean (0 warnings).
- `cargo test -p genie-core --lib tools::parser` — **24 passed** (7 new), including the end-to-end `try_tool_call_recovers_scalar_single_key_calculate` and the `scalar_primary_arg_matches_tool_schema` drift guard.
- `cargo test -p genie-core --lib eval::bfcl` — **14 passed** (no regression on the eval path I touched).
- `cargo test -p genie-core --lib tools::dispatch::tests` — **54 passed**.

### What I observed

- **Before** (reproducing the issue): `{"get_weather":"Denver"}` normalized to `name="get_weather", arguments={}` → execution returned `success: false` ("requires non-empty string argument 'location'").
- **After**: `{"get_weather":"Denver"}` → `arguments={"location":"Denver"}`; `{"calculate":"2 + 2"}` executes end-to-end and returns a result containing `4` (asserted in `try_tool_call_recovers_scalar_single_key_calculate`); `{"web_search":"jetson power consumption"}` on the eval path yields `arguments={"query":"jetson power consumption"}`.
- **No behavior change** for the existing object shape (`{"get_weather":{"location":"Tokyo","forecast":true}}` passes through verbatim — regression test) or for ambiguous tools (`{"home_control":"kitchen light"}` stays `{}`).

This raises effective tool-call accuracy for small local models on the M1/BFCL path (the eval normalizer previously dropped the same valid outputs) without touching home actuation, so no live-HA run is required.

## Test plan

- `cargo test -p genie-core --lib tools::parser eval::bfcl`
- Send a small model the compact shapes `{"get_weather":"Denver"}`, `{"calculate":"2 + 2"}`, `{"memory_recall":"Maya"}`; each now dispatches with the value preserved instead of failing with empty arguments.

## Notes for reviewers

- Scoped to argument recovery; it does not change which tool names are recognized or the object-shape behavior.
- The eval-path change is a strict improvement to BFCL parsing (it recovers compact outputs that were previously discarded), matching the issue's note that `normalize_single_key_tool_call_for_eval` had the same defect.
- Chose issue Option A (map to primary arg) over Option B (reject) because M1's goal is recovering valid model intent for accuracy; the drift-guard test keeps the mapping honest against the schemas.
