### PR TITLE
perf(memory): batch open-time derived-table rebuilds into one transaction

### DIFF
--- a/crates/genie-core/src/memory/mod.rs
+++ b/crates/genie-core/src/memory/mod.rs
@@ -670,6 +670,17 @@ impl Memory {
         );
 
         backfill_policy_columns(&conn)?;
+
+        // Every derived table (profiles, aliases, rules, calendar, shopping,
+        // inventory, embeddings, …) is re-derived from the canonical `memories`
+        // rows on every open. Each rebuild_* issues many per-row writes; left as
+        // individual auto-commit statements that is one WAL transaction per row
+        // across the whole set. Run the rebuild pass inside a single transaction
+        // so startup re-derivation commits once instead of thousands of times —
+        // the writes are identical, just batched (the per-recall version of this
+        // is `record_recalls`, PR #431). On a `?` failure `rebuild_tx` is dropped
+        // and the partial rebuild rolls back atomically.
+        let rebuild_tx = conn.unchecked_transaction()?;
         rebuild_household_profiles(&conn)?;
         rebuild_device_aliases(&conn)?;
         rebuild_household_profile_attributes(&conn)?;
@@ -685,6 +696,7 @@ impl Memory {
         rebuild_household_schedule_items(&conn)?;
         rebuild_household_event_logs(&conn)?;
         rebuild_embedded_memories(&conn)?;
+        rebuild_tx.commit()?;
 
         // Older databases may predate the FTS update trigger or may have been
         // edited by a recovery tool. Rebuild once at open so recall and forget

--- a/crates/genie-core/tests/memory_open_bench.rs
+++ b/crates/genie-core/tests/memory_open_bench.rs
@@ -1,0 +1,65 @@
+//! Benchmark for `Memory::open`, which re-derives every derived table (profiles,
+//! aliases, rules, calendar, shopping, inventory, embeddings, …) from the
+//! canonical `memories` rows on each open.
+//!
+//! Ignored by default — a timing harness, not a pass/fail test. Run on-device to
+//! reproduce the before→after numbers for batching the rebuild pass into one
+//! transaction:
+//!
+//! ```text
+//! cargo test -p genie-core --release --test memory_open_bench -- --ignored --nocapture
+//! ```
+//!
+//! The same file runs unchanged on `main` (per-row auto-commit rebuilds) and on
+//! the perf branch (single rebuild transaction), so the delta isolates that cost.
+
+use genie_core::Memory;
+
+#[test]
+#[ignore = "benchmark; run with --release --ignored --nocapture"]
+fn bench_memory_open_rebuild() {
+    // Own subdirectory so the per-db canonical "memory" dir is fresh and owned
+    // by this run.
+    let dir = std::env::temp_dir().join(format!("genie-open-bench-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let path = dir.join("mem.db");
+
+    // Seed a household-sized memory store once (not timed). store() maintains the
+    // derived tables incrementally; the full re-derivation happens on open().
+    let memories = 2_000usize;
+    {
+        let mem = Memory::open(&path).expect("seed open");
+        for i in 0..memories {
+            mem.store(
+                "fact",
+                &format!(
+                    "Household note {i}: the family keeps the room {} thermostat warm in the \
+                     evening and restocks grocery and lunchbox snacks for school.",
+                    i % 12
+                ),
+            )
+            .expect("store");
+        }
+    }
+
+    // Warm the OS page cache for the db file.
+    {
+        let _m = Memory::open(&path).expect("warm open");
+    }
+
+    let iterations = 10usize;
+    let start = std::time::Instant::now();
+    for _ in 0..iterations {
+        let m = Memory::open(&path).expect("open");
+        std::hint::black_box(&m);
+    }
+    let elapsed = start.elapsed();
+
+    let _ = std::fs::remove_dir_all(&dir);
+    eprintln!(
+        "BENCH memory_open_rebuild: {memories} memories, {iterations} opens, total {elapsed:?}, \
+         per-open {:?}",
+        elapsed / iterations as u32,
+    );
+}


### PR DESCRIPTION
## Summary

`Memory::open` re-derives every derived table — household profiles, device aliases, rules, notes, secret references, media items, calendar events, shopping list, inventory, access permissions, task logs, schedule items, event logs, and embeddings — from the canonical `memories` rows on **every open**. Each `rebuild_*` issued its per-row writes as individual auto-commit statements, so a single open ran one WAL transaction per row across the whole re-derivation. Wrapping the rebuild pass in a **single transaction** collapses thousands of commits into one. The writes are identical (same rebuilt tables), so behavior is unchanged. Measured **~2.5× faster `Memory::open` (median 3.50 s → 1.36 s with 2000 memories)** on the Jetson Orin Nano. Contributes under #402 (performance bucket).

## Changes

- `crates/genie-core/src/memory/mod.rs`: in `open_with_half_life`, run the 15 `rebuild_*` calls inside one `conn.unchecked_transaction()` and `commit()` instead of letting each rebuild auto-commit per row. Same writes, committed once; a mid-rebuild `?` failure now drops the transaction and rolls back atomically instead of leaving a half-rebuilt set. (This is the open-time analogue of the per-recall batching in `record_recalls`, PR #431.)
- `crates/genie-core/tests/memory_open_bench.rs`: ignored standalone benchmark over `Memory::open` for reproducible before→after timing.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware.
- [ ] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On the target **Jetson Orin Nano** (Engineering Reference Developer Kit Super, 8 GB), L4T R36.4.7, `Linux 5.15.148-tegra aarch64`, `rustc 1.95.0`, **release** profile (`opt-level="z"`, LTO disabled only to speed the build). Applied the change and the benchmark onto a fresh upstream-`main` clone, built in a tmpfs target dir. The benchmark seeds a 2000-memory store once (not timed), then times `Memory::open` (the full re-derivation) over 10 opens; the database lives on the SD card so real storage cost is measured. Ran 3× per side:

```
# before = main (per-row auto-commit rebuilds); after = this change (one transaction)
cargo test -p genie-core --release --test memory_open_bench -- --ignored --nocapture
```

Also on an x86_64 dev box (`rustc 1.95.0`): same benchmark showed 1.356 s → 0.740 s per open (~1.83×); full `memory::` test suite (161 tests) green; `cargo fmt -p genie-core -- --check` and `cargo clippy -p genie-core --tests` (and `--no-default-features --tests`) clean.

### What I observed

`Memory::open`, 2000 memories, 10 opens per run:

| run | before (per-row auto-commit) | after (one transaction) |
| --- | --- | --- |
| 1 | 3.65 s/open | 1.36 s/open |
| 2 | 3.50 s/open | 1.59 s/open |
| 3 | 2.97 s/open | 1.26 s/open |
| **median** | **3.50 s** | **1.36 s** |

- **~2.5× faster** open at the median; the "before" runs swing 2.97–3.65 s (per-row commit overhead on SD storage) while "after" is tighter.
- Behavior unchanged: the rebuilt derived tables are identical, only the commit boundary moved. The full `memory::` suite — recall, injection, semantic search, household structured queries — passes on x86_64 and aarch64.

### Test plan

- `cargo test -p genie-core --lib memory::` (derived-table behavior unchanged)
- `cargo test -p genie-core --release --test memory_open_bench -- --ignored --nocapture` on `main` vs this branch to reproduce the table above.

### Notes for reviewers

- `Memory::open` runs at process start (and on governor-driven service restarts), so this is startup latency; the win scales with stored-memory count.
- The schema creation / `CREATE INDEX` migrations stay outside the transaction (DDL, run once); only the per-open derived-table re-derivation is wrapped.