### PR TITLE
fix(ctl): restore indentation of `health` in `--help` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **`genie-ctl --help` alignment** (#445): the `health` command no longer
+  prints flush-left. A trailing `\` line-continuation after the voice-gated
+  `speaker` block was stripping the four-space indent off the following line
+  in both `voice`-on and `voice`-off builds. Rendering moved into a pure
+  `usage_text()` helper with a regression test that fails if any command line
+  loses its indent.
+
 ## 1.0.0-alpha.11 - 2026-06-20
 
 Alpha 11 is the **typed-tool contract + grounded BFCL** release. The single

--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -231,6 +231,10 @@ async fn main() -> Result<()> {
 }
 
 fn print_usage() {
+    println!("{}", usage_text());
+}
+
+fn usage_text() -> String {
     // Gated per issue #41: `speaker` is only listed when this build includes
     // the `voice` feature, so the help text matches what the binary can do.
     #[cfg(feature = "voice")]
@@ -238,7 +242,7 @@ fn print_usage() {
     #[cfg(not(feature = "voice"))]
     const SPEAKER_HELP_LINE: &str = "";
 
-    println!(
+    format!(
         "\
 GeniePod CLI v{version}
 
@@ -265,8 +269,7 @@ COMMANDS:
                         Convert Home Assistant Intents into attributed BFCL cases
     connectivity        Inspect ESP32-C6 Thread/Matter sidecar status
     skill <SUBCOMMAND>  Manage loadable skill modules
-{speaker}\
-    health              Service health check
+{speaker}    health              Service health check
     conversations       List all conversations
     update-check        Check for OTA updates
     diag                Full system diagnostics report
@@ -275,7 +278,7 @@ COMMANDS:
     help                Show this help",
         version = env!("CARGO_PKG_VERSION"),
         speaker = SPEAKER_HELP_LINE,
-    );
+    )
 }
 
 #[cfg(feature = "voice")]
@@ -2824,6 +2827,32 @@ mod tests {
         let version = env!("CARGO_PKG_VERSION");
         assert!(!version.is_empty());
         assert!(version.contains('.')); // Semver: x.y.z
+    }
+
+    #[test]
+    fn usage_command_lines_are_indented() {
+        // Regression: a `\` line-continuation after the `{speaker}` block used to
+        // strip the four-space indent off the `health` line, leaving it flush-left
+        // while every other command stayed indented.
+        let usage = usage_text();
+        assert!(
+            usage.contains("\n    health              Service health check"),
+            "`health` command should keep its four-space indent:\n{usage}"
+        );
+
+        let in_commands = usage
+            .split_once("COMMANDS:\n")
+            .map(|(_, rest)| rest)
+            .unwrap_or(&usage);
+        for line in in_commands.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            assert!(
+                line.starts_with("    "),
+                "every command/continuation line must be indented, got: {line:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`genie-ctl --help` / `genie-ctl help` printed the `health` command flush-left while every other command was indented by four spaces. A trailing `\` line-continuation after the voice-gated `{speaker}` block was eating the indent. This restores the alignment and adds a regression test.

## Changes

- Drop the `\` line-continuation after `{speaker}` in `print_usage` so the `health` line keeps its four-space indent. In a Rust string literal a line-ending `\` strips the next line's newline **and leading whitespace**, which consumed the indent in both `voice`-on and `voice`-off builds.
- Extract the help rendering into a pure `usage_text()` helper.
- Add `usage_command_lines_are_indented` regression test asserting every command/continuation line under `COMMANDS:` stays indented.
- CHANGELOG entry under `## Unreleased`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `laptop`

This is a platform-independent change to a CLI help string — it has no Jetson-, audio-, voice-, or hardware-specific behavior, so an x86_64 Linux dev box exercises exactly the same code path that runs on the device.

### What I ran

On x86_64 Linux (Ubuntu, kernel 6.8), rustc 1.96.0:

```
cargo run -q --bin genie-ctl -- help                                  # voice on (default)
cargo run -q -p genie-ctl --no-default-features --bin genie-ctl -- help  # voice off
cargo test -p genie-ctl
cargo test -p genie-ctl --no-default-features
cargo clippy -p genie-ctl --all-targets
```

I also temporarily reintroduced the `\` to confirm the new regression test fails (catches the bug), then reverted.

### What I observed

Before — `health` flush-left:

```
    skill <SUBCOMMAND>  Manage loadable skill modules
    speaker <SUBCOMMAND>
                        Manage local speaker identity profiles
health              Service health check
    conversations       List all conversations
```

After — `health` aligned with the rest:

```
    skill <SUBCOMMAND>  Manage loadable skill modules
    speaker <SUBCOMMAND>
                        Manage local speaker identity profiles
    health              Service health check
    conversations       List all conversations
```

- `cargo test -p genie-ctl` — 44 passed (incl. new `usage_command_lines_are_indented`)
- `cargo test -p genie-ctl --no-default-features` — 42 passed
- `cargo clippy -p genie-ctl --all-targets` — clean
- With the `\` reintroduced, `usage_command_lines_are_indented` fails as expected.

## Test plan

1. `cargo run --bin genie-ctl -- help` and confirm `health` lines up under `COMMANDS:` with every other entry.
2. Repeat with `--no-default-features` (voice off) — `health` is still indented and the `speaker` line is absent.
3. `cargo test -p genie-ctl` passes including `usage_command_lines_are_indented`.
