### PR TITLE
fix(quick-router): parse compound spoken durations like "forty five minutes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   in both `voice`-on and `voice`-off builds. Rendering moved into a pure
   `usage_text()` helper with a regression test that fails if any command line
   loses its indent.
+- **Quick-router compound spoken durations** (#449): "set a timer for forty
+  five minutes" now sets a 45-minute timer instead of 5. The deterministic
+  router only ever saw single tokens, so its `"forty five"` number arm was dead
+  code and the trailing "five" bound to the unit. `parse_duration` now stitches
+  a tens word (`twenty`..`ninety`) to a following ones digit, and the missing
+  `fifty`..`ninety` tens words parse on their own.
 
 ## 1.0.0-alpha.11 - 2026-06-20
 

--- a/crates/genie-core/src/tools/quick.rs
+++ b/crates/genie-core/src/tools/quick.rs
@@ -2393,16 +2393,40 @@ fn parse_duration(tokens: &[&str]) -> Option<(u64, usize)> {
         let Some(amount) = parse_number(token) else {
             continue;
         };
-        let unit = tokens.get(idx + 1)?;
+        // Combine a spoken compound cardinal like "forty five" (45) into a
+        // single amount. Worded numbers arrive as separate whitespace tokens,
+        // so the tens word and the ones word must be stitched here.
+        let (amount, unit_index) = match tokens.get(idx + 1).and_then(|next| ones_digit(next)) {
+            Some(ones) if is_tens_word(token) => (amount + ones, idx + 2),
+            _ => (amount, idx + 1),
+        };
+        let unit = tokens.get(unit_index)?;
         let multiplier = match *unit {
             "second" | "seconds" | "sec" | "secs" => 1,
             "minute" | "minutes" | "min" | "mins" => 60,
             "hour" | "hours" | "hr" | "hrs" => 3600,
             _ => continue,
         };
-        return Some((amount * multiplier, idx + 1));
+        return Some((amount * multiplier, unit_index));
     }
     None
+}
+
+/// True when `token` is a spoken tens word that can lead a compound cardinal
+/// such as "forty five".
+fn is_tens_word(token: &str) -> bool {
+    matches!(
+        token,
+        "twenty" | "thirty" | "forty" | "fifty" | "sixty" | "seventy" | "eighty" | "ninety"
+    )
+}
+
+/// The trailing ones digit of a compound cardinal ("forty *five*"), 1-9.
+fn ones_digit(token: &str) -> Option<u64> {
+    match parse_number(token) {
+        Some(value @ 1..=9) => Some(value),
+        _ => None,
+    }
 }
 
 fn parse_number(token: &str) -> Option<u64> {
@@ -2427,7 +2451,11 @@ fn parse_number(token: &str) -> Option<u64> {
         "twenty" => Some(20),
         "thirty" => Some(30),
         "forty" => Some(40),
-        "forty five" => Some(45),
+        "fifty" => Some(50),
+        "sixty" => Some(60),
+        "seventy" => Some(70),
+        "eighty" => Some(80),
+        "ninety" => Some(90),
         _ => None,
     }
 }
@@ -4136,6 +4164,28 @@ mod tests {
         let call = route("set a timer for 15 minutes").unwrap();
         assert_eq!(call.name, "set_timer");
         assert_eq!(call.arguments["seconds"], 900);
+    }
+
+    #[test]
+    fn routes_compound_worded_timer() {
+        // Regression: "forty five" used to parse as the trailing "five" (5 min)
+        // because the compound cardinal was never stitched from its two tokens.
+        let call = route("set a timer for forty five minutes").unwrap();
+        assert_eq!(call.name, "set_timer");
+        assert_eq!(call.arguments["seconds"], 2700);
+
+        // Other tens+ones compounds work the same way.
+        let call = route("set a timer for twenty five seconds").unwrap();
+        assert_eq!(call.arguments["seconds"], 25);
+
+        // A bare tens word (no trailing ones) is still parsed on its own.
+        let call = route("set a timer for fifty minutes").unwrap();
+        assert_eq!(call.arguments["seconds"], 3000);
+
+        // The compound amount is carried into the reminder label boundary too.
+        let call = route("remind me in forty five minutes to check the oven").unwrap();
+        assert_eq!(call.arguments["seconds"], 2700);
+        assert_eq!(call.arguments["label"], "check the oven");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The deterministic quick-router (the no-LLM tool-call path on the Jetson) mis-parsed compound spoken durations: "set a timer for **forty five** minutes" set a **5-minute** timer instead of 45. This fixes the parse and the related dead code, keeping the M1 quick-router accurate without touching the LLM path.

## Changes

- `parse_number` only ever received single whitespace tokens, so its `"forty five" => Some(45)` arm was **unreachable dead code**. "forty five minutes" scanned token-by-token, matched the trailing "five" against "minutes", and produced 5 minutes.
- Stitch a leading tens word (`twenty`..`ninety`) to a following ones digit (1-9) inside `parse_duration`, so compound cardinals resolve to a single amount; the returned unit index advances past the compound so reminder-label extraction still lines up.
- Add the missing `fifty`..`ninety` tens words to `parse_number` (bare "fifty minutes" previously failed to parse at all), and drop the dead `"forty five"` arm.
- Add a regression test covering the compound timer, a second compound, a bare tens word, and a compound inside a labelled reminder.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `laptop`

This is a deterministic, hardware-independent parser change in `tools/quick.rs` — no Jetson, audio, model, or network dependency, so an x86_64 Linux dev box exercises the exact code path that runs on-device.

### What I ran

On x86_64 Linux (Ubuntu, kernel 6.8), rustc 1.96.0:

```
cargo test -p genie-core            # full crate
cargo test -p genie-core timer      # timer routing incl. new regression test
cargo clippy -p genie-core --all-targets
cargo fmt -p genie-core -- --check
```

I also temporarily removed the new compound-stitching branch to confirm the regression test actually catches the bug, then restored it.

### What I observed

- `cargo test -p genie-core` — **730 passed, 0 failed** (plus the integration/doc suites green).
- New `routes_compound_worded_timer` passes: "set a timer for forty five minutes" → `seconds = 2700`; "twenty five seconds" → `25`; "fifty minutes" → `3000`; "remind me in forty five minutes to check the oven" → `seconds = 2700`, `label = "check the oven"`.
- Bug-proof: with the compound branch removed, the test fails with `left: Number(300)` vs `right: 2700` — i.e. the old 5-minute behavior. Restoring the branch makes it pass.
- `cargo clippy` clean; `cargo fmt --check` clean.

## Test plan

1. `cargo test -p genie-core timer` — all timer tests pass including `routes_compound_worded_timer`.
2. Manually: route "set a timer for forty five minutes" through the quick-router and confirm `set_timer` with `seconds = 2700`.
