### PR TITLE
fix(eval): keep BFCL canon_action from collapsing activate into turn_on

### DIFF
--- a/crates/genie-core/src/eval/bfcl.rs
+++ b/crates/genie-core/src/eval/bfcl.rs
@@ -1079,6 +1079,27 @@ mod tests {
     }
 
     #[test]
+    fn grounded_metric_credits_matching_activate() {
+        // Positive complement to grounded_metric_keeps_activate_distinct_from_turn_on:
+        // a correctly-predicted `activate` must still be credited — the fix passes
+        // `activate` through, it does not drop it.
+        let case = case(vec![expected(
+            "home_control",
+            serde_json::json!({"action": "activate", "entity": "kitchen lights"}),
+        )]);
+        let response = r#"{"tool":"home_control","arguments":{"action":"activate","entity":"kitchen lights"}}"#;
+        let score = score_response(&case, response);
+        assert!(
+            score.argument_match,
+            "exact activate match must be credited"
+        );
+        assert!(
+            score.grounded_argument_match,
+            "a matching activate must be credited by the grounded metric"
+        );
+    }
+
+    #[test]
     fn loads_jsonl_fixture_and_scores_report() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
         let cases = load_cases_jsonl(root.join("tests/bfcl/home_tool_cases.jsonl")).unwrap();

--- a/crates/genie-core/src/eval/bfcl.rs
+++ b/crates/genie-core/src/eval/bfcl.rs
@@ -599,14 +599,21 @@ fn canonicalize_entity_value(value: &Value, graph: &HomeGraph) -> Value {
 /// Canonicalize an action verb to a small set of stable forms, so the grounded
 /// metric credits synonyms the agent would execute identically. Unknown verbs
 /// pass through normalized (lowercase, separators -> `_`) so exact matches still
-/// hold. Mirrors the canonicalization the runtime tool dispatch should apply.
+/// hold. Mirrors the canonicalization the runtime tool dispatch applies in
+/// `tools::dispatch::canon_home_control_action`.
+///
+/// `activate` is intentionally *not* folded into `turn_on`: the runtime keeps it
+/// as a distinct `home_control` action for scenes/scripts (it appears separately
+/// in the action enum and `canon_home_control_action` leaves it as-is), so
+/// crediting `turn_on` for an expected `activate` would score a wrong actuation
+/// as correct and inflate the grounded metric.
 fn canon_action(text: &str) -> String {
     let normalized = text.trim().to_lowercase().replace([' ', '-'], "_");
     match normalized.as_str() {
         "deactivate" | "disable" | "switch_off" | "power_off" | "shut_off" | "turn_off" => {
             "turn_off".to_string()
         }
-        "activate" | "enable" | "switch_on" | "power_on" | "turn_on" => "turn_on".to_string(),
+        "enable" | "switch_on" | "power_on" | "turn_on" => "turn_on".to_string(),
         _ => normalized,
     }
 }
@@ -1000,6 +1007,38 @@ mod tests {
         let report = score_cases(&[case], &[prediction]);
         assert_eq!(report.argument_matches, 0);
         assert_eq!(report.grounded_strict_matches, 1);
+    }
+
+    #[test]
+    fn grounded_metric_keeps_activate_distinct_from_turn_on() {
+        // `activate` is a distinct runtime action for scenes/scripts: the
+        // dispatcher's canon_home_control_action leaves it as-is (covered by a
+        // "distinct action, must not remap" regression test), and `home_control`
+        // lists `activate` separately from `turn_on` in its action enum. The
+        // grounded metric must mirror runtime dispatch, so predicting `turn_on`
+        // for an expected `activate` is a *wrong actuation* (turn_on is a no-op
+        // for a scene) and must NOT be credited as a grounded match.
+        let case = case(vec![expected(
+            "home_control",
+            serde_json::json!({"action": "activate", "entity": "kitchen lights"}),
+        )]);
+        let prediction = BfclPrediction {
+            id: case.id.clone(),
+            response:
+                r#"{"tool":"home_control","arguments":{"action":"turn_on","entity":"kitchen lights"}}"#
+                    .to_string(),
+        };
+
+        let score = score_response(&case, &prediction.response);
+        assert!(
+            !score.argument_match,
+            "raw action strings differ, exact match must fail"
+        );
+        assert!(
+            !score.grounded_argument_match,
+            "predicting `turn_on` for an expected `activate` is a wrong actuation \
+             and must not be credited by the grounded metric"
+        );
     }
 
     #[test]

--- a/crates/genie-core/src/eval/bfcl.rs
+++ b/crates/genie-core/src/eval/bfcl.rs
@@ -1042,6 +1042,43 @@ mod tests {
     }
 
     #[test]
+    fn canon_action_contract() {
+        // Lock the scorer's action canonicalization so a future edit can't
+        // re-introduce the activate→turn_on collapse this fix removed (#458).
+        for s in ["turn_on", "enable", "switch_on", "power_on"] {
+            assert_eq!(canon_action(s), "turn_on", "{s} should fold to turn_on");
+        }
+        for s in [
+            "turn_off",
+            "deactivate",
+            "disable",
+            "switch_off",
+            "power_off",
+            "shut_off",
+        ] {
+            assert_eq!(canon_action(s), "turn_off", "{s} should fold to turn_off");
+        }
+        // activate stays distinct — it must NOT fold into turn_on.
+        assert_eq!(canon_action("activate"), "activate");
+        // Every other home_control action passes through unchanged (no cross-collapse).
+        for a in [
+            "toggle",
+            "open",
+            "close",
+            "lock",
+            "unlock",
+            "set_brightness",
+            "set_temperature",
+        ] {
+            assert_eq!(canon_action(a), a, "{a} must pass through unchanged");
+        }
+        // Normalization: case folding plus space/hyphen to underscore.
+        assert_eq!(canon_action(" Turn-On "), "turn_on");
+        assert_eq!(canon_action("ACTIVATE"), "activate");
+        assert_eq!(canon_action("set brightness"), "set_brightness");
+    }
+
+    #[test]
     fn loads_jsonl_fixture_and_scores_report() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
         let cases = load_cases_jsonl(root.join("tests/bfcl/home_tool_cases.jsonl")).unwrap();


### PR DESCRIPTION
## Summary

The BFCL grounded metric scored a wrong actuation as correct: predicting `home_control` `turn_on` for an expected `activate` counted as a grounded match. `eval::bfcl::canon_action` folded `activate` into `turn_on`, but the runtime dispatcher keeps `activate` a distinct action. This PR aligns the scorer with the runtime. Fixes #458.

## Changes

- `canon_action` no longer maps `activate` into `turn_on`; it passes through normalized, mirroring `tools::dispatch::canon_home_control_action` (which leaves `activate` as-is and is covered by a "must not remap" test).
- Updated the doc comment to state why `activate` stays distinct.
- Added regression test `grounded_metric_keeps_activate_distinct_from_turn_on` asserting the grounded metric does not credit `turn_on` for an expected `activate`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `laptop`

This change is to the BFCL scoring metric (host-side eval), not a runtime/hardware path, so a Jetson run is not applicable — the scorer is deterministic and produces identical results on any host. Verified on x86_64 Linux.

### What I ran

Built `genie-ctl` and scored a one-case fixture where the expected action is `activate` and the prediction emits `turn_on`:

```
# cases.jsonl
{"id":"scene-activate","category":"home","prompt":"Activate movie night scene","expected_tool_calls":[{"tool":"home_control","arguments":{"entity":"kitchen lights","action":"activate"}}]}
# preds.jsonl
{"id":"scene-activate","response":"{\"tool\":\"home_control\",\"arguments\":{\"entity\":\"kitchen lights\",\"action\":\"turn_on\"}}"}

genie-ctl bfcl-score --cases cases.jsonl --predictions preds.jsonl --json
```

Also ran the BFCL unit suite: `cargo test -p genie-core --lib eval::bfcl`.

### What I observed

`bfcl-score` before vs after:

| metric | before (main) | after |
|---|---|---|
| `grounded_argument_matches` | 1 | 0 |
| `grounded_strict_matches` | 1 | 0 |

Before the fix the wrong actuation was credited; after, it is correctly rejected with diagnostic `tool[0] argument mismatch: $.action expected "activate", got "turn_on"`. The non-grounded `argument_matches` was already `0` in both cases.

All 15 `eval::bfcl` tests pass, including the existing `grounded_metric_credits_action_synonym` (deactivate→turn_off still credited) and `loads_jsonl_fixture_and_scores_report` (21-case fixture unchanged).

## Test plan

1. `cargo test -p genie-core --lib eval::bfcl` — all green, new test included.
2. Reproduce the before/after with the fixture above via `genie-ctl bfcl-score`.