### PR TITLE
fix(home): restore off state on home_undo after set_temperature (#455)

### DIFF
--- a/crates/genie-core/src/tools/actuation.rs
+++ b/crates/genie-core/src/tools/actuation.rs
@@ -340,6 +340,12 @@ pub fn undo_restore_from_prior(action: &str, prior: &HomeState) -> Option<UndoRe
             })
         }
         "set_temperature" => {
+            if entity.state == "off" {
+                return Some(UndoRestore {
+                    action: "turn_off".into(),
+                    value: None,
+                });
+            }
             let temp = entity
                 .attributes
                 .get("temperature")
@@ -1111,6 +1117,40 @@ mod tests {
         };
         let restore = undo_restore_from_prior("toggle", &prior_off).unwrap();
         assert_eq!(restore.action, "turn_off");
+    }
+
+    #[test]
+    fn undo_restore_from_prior_set_temperature_when_off() {
+        use crate::ha::Entity;
+
+        let prior_off = HomeState {
+            target_name: "thermostat".into(),
+            domain: Some("climate".into()),
+            area: None,
+            entities: vec![Entity {
+                entity_id: "climate.heat".into(),
+                state: "off".into(),
+                attributes: serde_json::json!({}),
+            }],
+            available: true,
+            spoken_summary: "thermostat is off".into(),
+        };
+
+        let restore = undo_restore_from_prior("set_temperature", &prior_off).unwrap();
+        assert_eq!(restore.action, "turn_off");
+        assert!(restore.value.is_none());
+
+        let prior_on = HomeState {
+            entities: vec![Entity {
+                entity_id: "climate.heat".into(),
+                state: "heat".into(),
+                attributes: serde_json::json!({ "temperature": 68.0 }),
+            }],
+            ..prior_off.clone()
+        };
+        let restore = undo_restore_from_prior("set_temperature", &prior_on).unwrap();
+        assert_eq!(restore.action, "set_temperature");
+        assert_eq!(restore.value, Some(68.0));
     }
 
     #[test]

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -2274,17 +2274,11 @@ mod tests {
     struct RecordingHomeProvider {
         executed: Arc<std::sync::Mutex<Vec<HomeActionKind>>>,
         light: Arc<std::sync::Mutex<StubLightState>>,
-        climate: Arc<std::sync::Mutex<StubClimateState>>,
     }
 
     struct StubLightState {
         power: String,
         brightness: Option<u64>,
-    }
-
-    struct StubClimateState {
-        power: String,
-        temperature: Option<f64>,
     }
 
     impl StubLightState {
@@ -2296,21 +2290,11 @@ mod tests {
         }
     }
 
-    impl StubClimateState {
-        fn new() -> Self {
-            Self {
-                power: "off".into(),
-                temperature: None,
-            }
-        }
-    }
-
     impl RecordingHomeProvider {
         fn new(executed: Arc<std::sync::Mutex<Vec<HomeActionKind>>>) -> Self {
             Self {
                 executed,
                 light: Arc::new(std::sync::Mutex::new(StubLightState::new())),
-                climate: Arc::new(std::sync::Mutex::new(StubClimateState::new())),
             }
         }
 
@@ -2320,14 +2304,6 @@ mod tests {
 
         fn power(&self) -> String {
             self.light.lock().unwrap().power.clone()
-        }
-
-        fn climate_power(&self) -> String {
-            self.climate.lock().unwrap().power.clone()
-        }
-
-        fn climate_temperature(&self) -> Option<f64> {
-            self.climate.lock().unwrap().temperature
         }
     }
 
@@ -2458,19 +2434,6 @@ mod tests {
             query: &str,
             _action_hint: Option<HomeActionKind>,
         ) -> Result<HomeTarget> {
-            let lower = query.to_lowercase();
-            if lower.contains("thermostat") || lower.contains("climate") {
-                return Ok(HomeTarget {
-                    kind: HomeTargetKind::Entity,
-                    query: query.into(),
-                    display_name: query.into(),
-                    entity_ids: vec!["climate.test".into()],
-                    domain: Some("climate".into()),
-                    area: Some("Hall".into()),
-                    confidence: 0.96,
-                    voice_safe: true,
-                });
-            }
             Ok(HomeTarget {
                 kind: HomeTargetKind::Entity,
                 query: query.into(),
@@ -2484,25 +2447,6 @@ mod tests {
         }
 
         async fn get_state(&self, target: &HomeTarget) -> Result<HomeState> {
-            if target.domain.as_deref() == Some("climate") {
-                let climate = self.climate.lock().unwrap();
-                let mut attributes = serde_json::Map::new();
-                if let Some(temperature) = climate.temperature {
-                    attributes.insert("temperature".into(), serde_json::json!(temperature));
-                }
-                return Ok(HomeState {
-                    target_name: target.display_name.clone(),
-                    domain: target.domain.clone(),
-                    area: target.area.clone(),
-                    entities: vec![Entity {
-                        entity_id: target.entity_ids[0].clone(),
-                        state: climate.power.clone(),
-                        attributes: serde_json::Value::Object(attributes),
-                    }],
-                    available: true,
-                    spoken_summary: format!("{} is {}", target.display_name, climate.power),
-                });
-            }
             let light = self.light.lock().unwrap();
             let mut attributes = serde_json::Map::new();
             if let Some(brightness) = light.brightness {
@@ -2523,30 +2467,6 @@ mod tests {
         }
 
         async fn execute(&self, action: HomeAction) -> Result<ActionResult> {
-            if action.target.domain.as_deref() == Some("climate") {
-                {
-                    let mut climate = self.climate.lock().unwrap();
-                    match action.kind {
-                        HomeActionKind::TurnOff => {
-                            climate.power = "off".into();
-                            climate.temperature = None;
-                        }
-                        HomeActionKind::SetTemperature => {
-                            climate.power = "heat".into();
-                            climate.temperature = action.value;
-                        }
-                        other => anyhow::bail!("unsupported climate stub action: {other:?}"),
-                    }
-                }
-                self.executed.lock().unwrap().push(action.kind);
-                return Ok(ActionResult {
-                    success: true,
-                    spoken_summary: format!("Executed {:?}", action.kind),
-                    affected_targets: vec![action.target.display_name],
-                    state_snapshot: None,
-                    confidence: Some(action.target.confidence),
-                });
-            }
             {
                 let mut light = self.light.lock().unwrap();
                 match action.kind {
@@ -3412,57 +3332,6 @@ mod tests {
             ]
         );
         assert_eq!(provider.power(), "on");
-    }
-
-    #[tokio::test]
-    async fn home_undo_restores_off_state_after_set_temperature() {
-        let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let provider = Arc::new(RecordingHomeProvider::new(executed.clone()));
-        let dispatcher = ToolDispatcher::new(Some(provider.clone()));
-        let ctx = || ToolExecutionContext {
-            request_origin: RequestOrigin::Dashboard,
-            ..ToolExecutionContext::default()
-        };
-
-        assert_eq!(provider.climate_power(), "off");
-
-        assert!(
-            dispatcher
-                .execute_with_context(
-                    &ToolCall {
-                        name: "home_control".into(),
-                        arguments: serde_json::json!({
-                            "entity": "thermostat",
-                            "action": "set_temperature",
-                            "value": 72
-                        }),
-                    },
-                    ctx(),
-                )
-                .await
-                .success
-        );
-        assert_eq!(provider.climate_power(), "heat");
-        assert_eq!(provider.climate_temperature(), Some(72.0));
-
-        let undo = dispatcher
-            .execute_with_context(
-                &ToolCall {
-                    name: "home_undo".into(),
-                    arguments: serde_json::json!({}),
-                },
-                ctx(),
-            )
-            .await;
-
-        assert!(undo.success);
-        assert!(undo.output.contains("Undid the last home action"));
-        assert_eq!(
-            *executed.lock().unwrap(),
-            vec![HomeActionKind::SetTemperature, HomeActionKind::TurnOff,]
-        );
-        assert_eq!(provider.climate_power(), "off");
-        assert_eq!(provider.climate_temperature(), None);
     }
 
     #[tokio::test]

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -2275,11 +2275,17 @@ mod tests {
     struct RecordingHomeProvider {
         executed: Arc<std::sync::Mutex<Vec<HomeActionKind>>>,
         light: Arc<std::sync::Mutex<StubLightState>>,
+        climate: Arc<std::sync::Mutex<StubClimateState>>,
     }
 
     struct StubLightState {
         power: String,
         brightness: Option<u64>,
+    }
+
+    struct StubClimateState {
+        power: String,
+        temperature: Option<f64>,
     }
 
     impl StubLightState {
@@ -2291,11 +2297,21 @@ mod tests {
         }
     }
 
+    impl StubClimateState {
+        fn new() -> Self {
+            Self {
+                power: "off".into(),
+                temperature: None,
+            }
+        }
+    }
+
     impl RecordingHomeProvider {
         fn new(executed: Arc<std::sync::Mutex<Vec<HomeActionKind>>>) -> Self {
             Self {
                 executed,
                 light: Arc::new(std::sync::Mutex::new(StubLightState::new())),
+                climate: Arc::new(std::sync::Mutex::new(StubClimateState::new())),
             }
         }
 
@@ -2305,6 +2321,14 @@ mod tests {
 
         fn power(&self) -> String {
             self.light.lock().unwrap().power.clone()
+        }
+
+        fn climate_power(&self) -> String {
+            self.climate.lock().unwrap().power.clone()
+        }
+
+        fn climate_temperature(&self) -> Option<f64> {
+            self.climate.lock().unwrap().temperature
         }
     }
 
@@ -2435,6 +2459,19 @@ mod tests {
             query: &str,
             _action_hint: Option<HomeActionKind>,
         ) -> Result<HomeTarget> {
+            let lower = query.to_lowercase();
+            if lower.contains("thermostat") || lower.contains("climate") {
+                return Ok(HomeTarget {
+                    kind: HomeTargetKind::Entity,
+                    query: query.into(),
+                    display_name: query.into(),
+                    entity_ids: vec!["climate.test".into()],
+                    domain: Some("climate".into()),
+                    area: Some("Hall".into()),
+                    confidence: 0.96,
+                    voice_safe: true,
+                });
+            }
             Ok(HomeTarget {
                 kind: HomeTargetKind::Entity,
                 query: query.into(),
@@ -2448,6 +2485,25 @@ mod tests {
         }
 
         async fn get_state(&self, target: &HomeTarget) -> Result<HomeState> {
+            if target.domain.as_deref() == Some("climate") {
+                let climate = self.climate.lock().unwrap();
+                let mut attributes = serde_json::Map::new();
+                if let Some(temperature) = climate.temperature {
+                    attributes.insert("temperature".into(), serde_json::json!(temperature));
+                }
+                return Ok(HomeState {
+                    target_name: target.display_name.clone(),
+                    domain: target.domain.clone(),
+                    area: target.area.clone(),
+                    entities: vec![Entity {
+                        entity_id: target.entity_ids[0].clone(),
+                        state: climate.power.clone(),
+                        attributes: serde_json::Value::Object(attributes),
+                    }],
+                    available: true,
+                    spoken_summary: format!("{} is {}", target.display_name, climate.power),
+                });
+            }
             let light = self.light.lock().unwrap();
             let mut attributes = serde_json::Map::new();
             if let Some(brightness) = light.brightness {
@@ -2468,6 +2524,30 @@ mod tests {
         }
 
         async fn execute(&self, action: HomeAction) -> Result<ActionResult> {
+            if action.target.domain.as_deref() == Some("climate") {
+                {
+                    let mut climate = self.climate.lock().unwrap();
+                    match action.kind {
+                        HomeActionKind::TurnOff => {
+                            climate.power = "off".into();
+                            climate.temperature = None;
+                        }
+                        HomeActionKind::SetTemperature => {
+                            climate.power = "heat".into();
+                            climate.temperature = action.value;
+                        }
+                        other => anyhow::bail!("unsupported climate stub action: {other:?}"),
+                    }
+                }
+                self.executed.lock().unwrap().push(action.kind);
+                return Ok(ActionResult {
+                    success: true,
+                    spoken_summary: format!("Executed {:?}", action.kind),
+                    affected_targets: vec![action.target.display_name],
+                    state_snapshot: None,
+                    confidence: Some(action.target.confidence),
+                });
+            }
             {
                 let mut light = self.light.lock().unwrap();
                 match action.kind {
@@ -3333,6 +3413,57 @@ mod tests {
             ]
         );
         assert_eq!(provider.power(), "on");
+    }
+
+    #[tokio::test]
+    async fn home_undo_restores_off_state_after_set_temperature() {
+        let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider = Arc::new(RecordingHomeProvider::new(executed.clone()));
+        let dispatcher = ToolDispatcher::new(Some(provider.clone()));
+        let ctx = || ToolExecutionContext {
+            request_origin: RequestOrigin::Dashboard,
+            ..ToolExecutionContext::default()
+        };
+
+        assert_eq!(provider.climate_power(), "off");
+
+        assert!(
+            dispatcher
+                .execute_with_context(
+                    &ToolCall {
+                        name: "home_control".into(),
+                        arguments: serde_json::json!({
+                            "entity": "thermostat",
+                            "action": "set_temperature",
+                            "value": 72
+                        }),
+                    },
+                    ctx(),
+                )
+                .await
+                .success
+        );
+        assert_eq!(provider.climate_power(), "heat");
+        assert_eq!(provider.climate_temperature(), Some(72.0));
+
+        let undo = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "home_undo".into(),
+                    arguments: serde_json::json!({}),
+                },
+                ctx(),
+            )
+            .await;
+
+        assert!(undo.success);
+        assert!(undo.output.contains("Undid the last home action"));
+        assert_eq!(
+            *executed.lock().unwrap(),
+            vec![HomeActionKind::SetTemperature, HomeActionKind::TurnOff,]
+        );
+        assert_eq!(provider.climate_power(), "off");
+        assert_eq!(provider.climate_temperature(), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #455

## Summary

Mirror the `set_brightness` off-state handling in `undo_restore_from_prior` for `set_temperature`. When the HVAC was `off` before a setpoint change, `home_undo` now records `turn_off` as the restore action instead of leaving `undo_restore` empty (which skipped the thermostat change and reversed an unrelated earlier action).

## Changes

- `undo_restore_from_prior("set_temperature")`: prior `state == "off"` → `UndoRestore { action: "turn_off" }`.
- Unit test: off vs heating prior states.
- Dispatch test: off thermostat → `set_temperature(72)` → `home_undo` → `turn_off` (climate back off).
- Extend `RecordingHomeProvider` stub with climate domain for the integration test.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

```bash
cd genie-claw
git checkout fix/issue-455-home-undo-set-temperature-off

cargo fmt
cargo test -p genie-core undo_restore_from_prior_set_temperature
cargo test -p genie-core home_undo_restores_off_state_after_set_temperature
cargo test -p genie-core home_undo
cargo clippy -p genie-core -- -D warnings
```

Environment: x86_64 Linux dev host (`laptop` profile). Stub provider test + unit tests; optional live HA repro below.

Optional live HA repro:

```bash
docker compose -f deploy/homeassistant/docker-compose.yml up -d
# Ensure climate entity is off with no active setpoint exposed
genie-ctl chat "set the thermostat to 72"
genie-ctl chat "undo the last home action"
# Expect: HVAC returns to off, not an unrelated earlier action
```

### What I observed

**Before (`main`):**

- `undo_restore_from_prior("set_temperature", prior_off)` → `None`.
- `home_undo` after heating an off thermostat could skip the temperature change.

**After (this PR):**

```text
$ cargo test -p genie-core undo_restore_from_prior_set_temperature
test tools::actuation::tests::undo_restore_from_prior_set_temperature_when_off ... ok

$ cargo test -p genie-core home_undo_restores_off_state_after_set_temperature
test tools::dispatch::tests::home_undo_restores_off_state_after_set_temperature ... ok

$ cargo clippy -p genie-core -- -D warnings
(clean)
```

- Off prior → undo issues `turn_off`; heating prior with `temperature: 68` → undo restores `set_temperature(68)`.

**Repro caveat:** Some HA climate entities expose `temperature` while `state` is `off`; this fix targets the `state == "off"` path aligned with #435 brightness handling.

## Test plan

- [x] `cargo test -p genie-core undo_restore_from_prior_set_temperature`
- [x] `cargo test -p genie-core home_undo_restores_off_state_after_set_temperature`
- [x] `cargo test -p genie-core home_undo`
- [x] `cargo clippy -p genie-core -- -D warnings`
- [ ] Live HA: off climate → set temp → undo → off (optional)

## Notes for reviewers

- Follow-up to [#435](https://github.com/GeniePod/genie-claw/pull/435) / closed [#434](https://github.com/GeniePod/genie-claw/issues/434).
- Parent epic: [#402](https://github.com/GeniePod/genie-claw/issues/402).
