### PR TITLE
test: use unique temp DB paths to fix "readonly database" test failures

### DIFF
--- a/crates/genie-core/src/prompt.rs
+++ b/crates/genie-core/src/prompt.rs
@@ -312,6 +312,23 @@ fn format_memories(memory: &Memory) -> String {
 mod tests {
     use super::*;
 
+    /// A unique on-disk SQLite path per call. A fixed shared name in the
+    /// world-writable temp dir collides across repeated runs and across users:
+    /// leftover `-wal`/`-shm` sidecars owned by another user (or a crashed
+    /// earlier run) make the reopened database read-only ("attempt to write a
+    /// readonly database"). Mirror the per-process + counter convention already
+    /// used elsewhere in this crate (see the `memory::recall` tests).
+    fn unique_test_db(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static CTR: AtomicU32 = AtomicU32::new(0);
+        let id = CTR.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "prompt-test-{tag}-{}-{}.db",
+            std::process::id(),
+            id
+        ))
+    }
+
     #[test]
     fn detect_nemotron() {
         assert!(matches!(
@@ -369,7 +386,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-qwen3-4b.db");
+        let mem_path = unique_test_db("qwen3-4b");
         let _ = std::fs::remove_file(&mem_path);
         let memory = Memory::open(&mem_path).unwrap();
 
@@ -403,7 +420,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test.db");
+        let mem_path = unique_test_db("default");
         let _ = std::fs::remove_file(&mem_path);
         let memory = Memory::open(&mem_path).unwrap();
 
@@ -420,7 +437,7 @@ mod tests {
             description: "Get system status".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-system-info.db");
+        let mem_path = unique_test_db("system-info");
         let _ = std::fs::remove_file(&mem_path);
         let memory = Memory::open(&mem_path).unwrap();
 
@@ -444,7 +461,7 @@ mod tests {
                 parameters: serde_json::json!({"type": "object", "properties": {"query": {"type": "string"}}}),
             },
         ];
-        let mem_path = std::env::temp_dir().join("prompt-test-small.db");
+        let mem_path = unique_test_db("small");
         let _ = std::fs::remove_file(&mem_path);
         let memory = Memory::open(&mem_path).unwrap();
 
@@ -466,7 +483,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-no-home.db");
+        let mem_path = unique_test_db("no-home");
         let _ = std::fs::remove_file(&mem_path);
         let memory = Memory::open(&mem_path).unwrap();
 
@@ -483,7 +500,7 @@ mod tests {
             description: "Demo greeting skill".into(),
             parameters: serde_json::json!({"type": "object", "properties": {"name": {"type": "string"}}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-hello-world.db");
+        let mem_path = unique_test_db("hello-world");
         let _ = std::fs::remove_file(&mem_path);
         let memory = Memory::open(&mem_path).unwrap();
 
@@ -515,7 +532,7 @@ mod tests {
                 parameters: serde_json::json!({"type": "object", "properties": {"content": {"type": "string"}}}),
             },
         ];
-        let mem_path = std::env::temp_dir().join("prompt-test-memory-tools.db");
+        let mem_path = unique_test_db("memory-tools");
         let _ = std::fs::remove_file(&mem_path);
         let memory = Memory::open(&mem_path).unwrap();
 
@@ -537,7 +554,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-phi.db");
+        let mem_path = unique_test_db("phi");
         let _ = std::fs::remove_file(&mem_path);
         let memory = Memory::open(&mem_path).unwrap();
 
@@ -555,7 +572,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-policy-filter.db");
+        let mem_path = unique_test_db("policy-filter");
         let _ = std::fs::remove_file(&mem_path);
         let memory = Memory::open(&mem_path).unwrap();
         memory

--- a/crates/genie-governor/src/governor.rs
+++ b/crates/genie-governor/src/governor.rs
@@ -587,7 +587,16 @@ mod tests {
     fn night_model_swap_config() {
         let mut config = test_config();
         config.governor.night_model_swap = true;
-        let db_path = std::env::temp_dir().join("geniepod-test-gov2.db");
+        // Unique per-process DB path; a fixed shared name collides across runs
+        // and users (leftover `-wal`/`-shm` sidecars owned by another user make
+        // the reopened database read-only).
+        let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let db_path = std::env::temp_dir().join(format!(
+            "geniepod-test-gov-{}-{}.db",
+            std::process::id(),
+            id
+        ));
+        let _ = std::fs::remove_file(&db_path);
         let store = Store::open(&db_path).unwrap();
         let mut gov = Governor::new(config, store);
         gov.config.governor.night_start_hour = 0;
@@ -628,7 +637,16 @@ mod tests {
     fn resolves_llm_alias_to_configured_service_unit() {
         let mut config = test_config();
         config.services.llm.systemd_unit = "genie-ai-runtime.service".into();
-        let db_path = std::env::temp_dir().join("geniepod-test-gov-llm-unit.db");
+        // Unique per-process DB path; a fixed shared name collides across runs
+        // and users (leftover `-wal`/`-shm` sidecars owned by another user make
+        // the reopened database read-only).
+        let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let db_path = std::env::temp_dir().join(format!(
+            "geniepod-test-gov-{}-{}.db",
+            std::process::id(),
+            id
+        ));
+        let _ = std::fs::remove_file(&db_path);
         let store = Store::open(&db_path).unwrap();
         let gov = Governor::new(config, store);
 


### PR DESCRIPTION
## Summary

Several unit tests opened a SQLite database at a fixed filename in the shared temp dir and only removed the main `.db` file, leaving the `-wal`/`-shm` sidecars. When those sidecars exist owned by another user (shared host, multi-user Jetson) or a crashed prior run, the reopened DB is read-only and the test panics with `attempt to write a readonly database`. This gives every affected test a unique per-process path. Fixes #463.

## Changes

- `crates/genie-core/src/prompt.rs`: add a `unique_test_db(tag)` test helper (`process::id()` + atomic counter) and use it for all 9 fixed-path tests.
- `crates/genie-governor/src/governor.rs`: give `night_model_swap_config` and `resolves_llm_alias_to_configured_service_unit` unique per-process DB paths, matching the existing `make_governor` helper.
- Tests-only; no production code changes. Mirrors the convention already used by the `memory::recall` tests and `make_governor`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `laptop`

This is a host-side test-isolation fix (no runtime/hardware path), so it is environment-reproducible on any host; a Jetson run is not applicable.

### What I ran

On x86_64 Linux, with a foreign-owned (`orin`-owned, read-only to my user) leftover sidecar present at the old fixed path `/tmp/prompt-test-memory-tools.db-wal` / `-shm`:

```
# before the change, on this host:
cargo test -p genie-core --lib prompt::tests::prompt_guides_memory_recall_and_store_correctly
# after the change:
cargo test -p genie-core --lib            # full crate
cargo test -p genie-governor             # governor unit tests
```

### What I observed

Before (clean `main`, foreign sidecar present):

```
thread '...prompt_guides_memory_recall_and_store_correctly' panicked at crates/genie-core/src/prompt.rs:520:
called `Result::unwrap()` on an `Err` value: attempt to write a readonly database
test result: FAILED. 736 passed; 1 failed
```

After (this branch, same foreign sidecar still present at the old path):

```
prompt module:      test result: ok. 16 passed; 0 failed
genie-core lib:     test result: ok. 737 passed; 0 failed
genie-governor:     test result: ok. 18 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy` are clean.

## Test plan

1. `cargo test -p genie-core --lib` and `cargo test -p genie-governor` — both green.
2. To reproduce the original failure on `main`: create `/tmp/prompt-test-memory-tools.db-wal` and `-shm` owned by a different user (or `chmod 000` them), then run the test — it panics with `attempt to write a readonly database`. With this branch it passes regardless.