### PR TITLE
perf(memory): store embeddings as packed f32 BLOB instead of JSON text

### DIFF
--- a/crates/genie-core/src/memory/mod.rs
+++ b/crates/genie-core/src/memory/mod.rs
@@ -554,7 +554,7 @@ impl Memory {
                 memory_type      TEXT NOT NULL,
                 embedding_model  TEXT NOT NULL,
                 dimensions       INTEGER NOT NULL,
-                embedding        TEXT NOT NULL,
+                embedding        BLOB NOT NULL,
                 updated_ms       INTEGER NOT NULL
             );
 
@@ -1886,12 +1886,12 @@ impl Memory {
                 let entry = read_entry(row)?;
                 let embedding_model: String = row.get(11)?;
                 let dimensions: i64 = row.get(12)?;
-                let embedding_json: String = row.get(13)?;
-                Ok((entry, embedding_model, dimensions as usize, embedding_json))
+                let embedding_blob: Vec<u8> = row.get(13)?;
+                Ok((entry, embedding_model, dimensions as usize, embedding_blob))
             })?
             .filter_map(|row| row.ok())
-            .filter_map(|(entry, embedding_model, dimensions, embedding_json)| {
-                parse_embedding(&embedding_json, dimensions).map(|embedding| {
+            .filter_map(|(entry, embedding_model, dimensions, embedding_blob)| {
+                parse_embedding(&embedding_blob, dimensions).map(|embedding| {
                     let mut score = embedding::cosine_similarity(&query_embedding, &embedding);
                     if query_type.as_deref().is_some_and(|expected| {
                         expected == semantic_memory_type(&entry.kind, &entry.content)
@@ -3531,7 +3531,7 @@ fn upsert_embedded_memory_from_memory(
     let provider = LocalHashEmbeddingProvider;
     let embedding_text = embedding_text_for_memory(kind, content);
     let embedding = provider.embed(&embedding_text);
-    let embedding_json = serde_json::to_string(&embedding)?;
+    let embedding_blob: Vec<u8> = embedding.iter().flat_map(|f| f.to_le_bytes()).collect();
 
     conn.execute(
         "INSERT INTO embedded_memories (
@@ -3542,7 +3542,7 @@ fn upsert_embedded_memory_from_memory(
             semantic_memory_type(kind, content),
             provider.model_name(),
             provider.dimensions() as i64,
-            embedding_json,
+            embedding_blob,
             updated_ms
         ],
     )?;
@@ -7793,13 +7793,16 @@ fn semantic_query_type(query: &str) -> Option<String> {
     }
 }
 
-fn parse_embedding(value: &str, dimensions: usize) -> Option<Vec<f32>> {
-    let embedding = serde_json::from_str::<Vec<f32>>(value).ok()?;
-    if embedding.len() == dimensions {
-        Some(embedding)
-    } else {
-        None
+fn parse_embedding(bytes: &[u8], dimensions: usize) -> Option<Vec<f32>> {
+    if bytes.len() != dimensions * 4 {
+        return None;
     }
+    Some(
+        bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+    )
 }
 
 fn family_calendar_events_from_memory(kind: &str, content: &str) -> Vec<FamilyCalendarEvent> {
@@ -16073,6 +16076,28 @@ mod tests {
                 "query {query:?} should recall {expected:?}"
             );
         }
+    }
+
+    #[test]
+    fn parse_embedding_blob_roundtrip_is_bit_identical() {
+        use crate::memory::embedding::{EmbeddingProvider, LocalHashEmbeddingProvider};
+        let provider = LocalHashEmbeddingProvider;
+        let original = provider.embed("the family keeps the thermostat warm in the evening");
+        let blob: Vec<u8> = original.iter().flat_map(|f| f.to_le_bytes()).collect();
+        let restored = parse_embedding(&blob, original.len()).expect("parse_embedding failed");
+        assert_eq!(
+            original, restored,
+            "packed f32 BLOB roundtrip must be bit-identical"
+        );
+    }
+
+    #[test]
+    fn parse_embedding_rejects_wrong_length() {
+        // 3 bytes is not a multiple of 4 — should return None.
+        assert!(parse_embedding(&[0u8; 3], 1).is_none());
+        // Right byte count but wrong declared dimensions.
+        let blob = vec![0u8; 64 * 4]; // 64 floats packed
+        assert!(parse_embedding(&blob, 32).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `embedded_memories.embedding` column was `TEXT`, decoded with `serde_json::from_str::<Vec<f32>>()` on every row scanned during `semantic_search`. Replace with a little-endian packed BLOB: 4 bytes per dimension, decoded by a single `chunks_exact(4)` pass — no JSON tokenizer, no intermediate string allocation.

Because `rebuild_embedded_memories` clears and rewrites the entire table on every `Memory::open`, no migration is needed.

## Changes

- `embedded_memories.embedding` schema: `TEXT` → `BLOB`
- `upsert_embedded_memory_from_memory`: pack `Vec<f32>` to `Vec<u8>` via `to_le_bytes()` instead of `serde_json::to_string`
- `semantic_search`: read column as `Vec<u8>` instead of `String`
- `parse_embedding`: decode bytes with `chunks_exact(4)` instead of JSON parse

## Tests

- `parse_embedding_blob_roundtrip_is_bit_identical` — embed → pack → unpack must produce the same `Vec<f32>`
- `parse_embedding_rejects_wrong_length` — truncated or dimension-mismatched byte slices return `None`
- All 748 existing unit tests pass