### PR TITLE
perf(memory): score the LIKE fallback once per row instead of recomputing in sort + recalls

### DIFF
--- a/crates/genie-core/src/memory/mod.rs
+++ b/crates/genie-core/src/memory/mod.rs
@@ -888,27 +888,25 @@ impl Memory {
         values.push((limit * 3).to_string());
 
         let mut stmt = self.conn.prepare(&sql)?;
-        let mut entries = stmt
+        let mut scored: Vec<(MemoryEntry, f64)> = stmt
             .query_map(params_from_iter(values.iter()), read_entry)?
             .filter_map(|r| r.ok())
-            .collect::<Vec<_>>();
+            .map(|entry| {
+                let score = lexical_overlap_score(query, &entry.content);
+                (entry, score)
+            })
+            .collect();
 
-        entries.sort_by(|a, b| {
-            let a_score = lexical_overlap_score(query, &a.content);
-            let b_score = lexical_overlap_score(query, &b.content);
-            b_score
-                .partial_cmp(&a_score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        entries.truncate(limit);
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(limit);
 
-        let recalls: Vec<(i64, f64)> = entries
+        let recalls: Vec<(i64, f64)> = scored
             .iter()
-            .map(|entry| (entry.id, lexical_overlap_score(query, &entry.content)))
+            .map(|(entry, score)| (entry.id, *score))
             .collect();
         self.record_recalls(&recalls, now, query_hash);
 
-        Ok(entries)
+        Ok(scored.into_iter().map(|(entry, _)| entry).collect())
     }
 
     fn update_recall_tracking(

--- a/crates/genie-core/tests/memory_fallback_bench.rs
+++ b/crates/genie-core/tests/memory_fallback_bench.rs
@@ -1,0 +1,50 @@
+use genie_core::Memory;
+
+#[test]
+#[ignore = "benchmark; run with --release --ignored --nocapture"]
+fn bench_search_like_fallback() {
+    let dir = std::env::temp_dir().join(format!("genie-fallback-bench-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let path = dir.join("mem.db");
+
+    let mem = Memory::open(&path).expect("open");
+
+    let n = 300usize;
+    for i in 0..n {
+        mem.store(
+            "fact",
+            &format!(
+                "Household qwxzytoken note {i}: the family prefers warm rooms in the evening and \
+                 keeps grocery and lunchbox snacks stocked for school day {}.",
+                i % 30
+            ),
+        )
+        .expect("store");
+    }
+
+    // "wxzyto" is an infix of "qwxzytoken": no FTS token/prefix match, so search()
+    // routes to the LIKE fallback; LIKE %wxzyto% matches every row.
+    let query = "wxzyto";
+    let limit = 50usize;
+
+    for _ in 0..3 {
+        let _ = mem.search(query, limit).expect("warm");
+    }
+
+    let iterations = 200usize;
+    let start = std::time::Instant::now();
+    let mut total_hits = 0usize;
+    for _ in 0..iterations {
+        total_hits += mem.search(query, limit).expect("search").len();
+    }
+    let elapsed = start.elapsed();
+
+    let _ = std::fs::remove_dir_all(&dir);
+    eprintln!(
+        "BENCH search_like_fallback: {n} memories, {iterations} searches (limit {limit}), total \
+         {elapsed:?}, per-search {:?} ({total_hits} total hits)",
+        elapsed / iterations as u32,
+    );
+    assert!(total_hits > 0, "fallback path must return hits");
+}


### PR DESCRIPTION
## Summary

`search_like_fallback` (the substring/`LIKE` recall path used when FTS returns nothing) computed `lexical_overlap_score` **inside the sort comparator** — twice per comparison, each call re-lowercasing the query and re-tokenizing the entry content into two `String`s + two `HashSet`s — and then **once more per kept entry** to build recall tracking. This decorate-sort-undecorate change computes the score **exactly once per row**, mirroring the existing FTS `search()` path. It is behavior-preserving: identical ordering (same `partial_cmp` + `Ordering::Equal` tie-break) and identical recall scores. Measured **~1.2× (~18%) faster on the fallback path** on the Jetson Orin Nano. Contributes under #402 (performance bucket).

**Scope (honest):** the `LIKE` fallback only runs when the FTS query matches nothing, so this is a correctness-neutral efficiency cleanup on a **cold path**, not a headline end-to-end latency win. It removes real redundant CPU work (O(N·logN) score recomputations → O(N)) and keeps the two recall paths consistent.

## Changes

- `crates/genie-core/src/memory/mod.rs` (`search_like_fallback`): build a `Vec<(MemoryEntry, f64)>` scoring each row once, sort by the precomputed score, truncate, and derive recall tracking from the same precomputed scores — instead of recomputing `lexical_overlap_score` in the comparator and again in the recalls map. Matches the structure of the FTS `search()` path.
- `crates/genie-core/tests/memory_fallback_bench.rs`: ignored standalone benchmark that forces the `LIKE` fallback (an infix query FTS can't match) and times it, for reproducible before→after.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware.
- [ ] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On the target **Jetson Orin Nano** (Engineering Reference Developer Kit Super, 8 GB), L4T R36.4.7, `Linux 5.15.148-tegra aarch64`, `rustc 1.95.0`, **release** profile (`opt-level="z"`, LTO disabled only to speed the build). Cloned current `main` into a tmpfs target dir; the benchmark seeds 300 memories, then issues 200 `search()` calls with an infix query (`wxzyto`, an infix of `qwxzytoken`) that FTS cannot token/prefix-match — so `search()` routes to `search_like_fallback`, whose `LIKE %wxzyto%` matches every row. `limit=50` makes the SQL return 150 rows into the scored sort. Ran the bench on `main`, then applied this change and reran (3× each):

```
cargo test -p genie-core --release --test memory_fallback_bench -- --ignored --nocapture
```

Also on an x86_64 dev box (`rustc 1.95.0`): the same bench (5.41 → 4.53 ms/search, ~1.2×); full `memory::` suite (168 tests) green; `cargo fmt -p genie-core -- --check`, `cargo clippy -p genie-core --tests`, and `cargo clippy -p genie-core --no-default-features --tests` all clean.

### What I observed

`search_like_fallback` via `search()`, 300 memories, 200 searches/run, `limit=50` (150 rows scored), 50 hits/search (confirms the fallback path ran):

| run | before (recompute in sort + recalls) | after (score once per row) |
| --- | --- | --- |
| 1 | 5.78 ms/search | 4.76 ms/search |
| 2 | 7.38 ms/search | 4.77 ms/search |
| 3 | 5.85 ms/search | 4.78 ms/search |
| **median** | **5.85 ms** | **4.77 ms** |

- **~1.23× (~18%) faster** on the fallback path at the median. "after" is stable to ±0.01 ms; "before" is noisier (5.78–7.38 ms) — the redundant per-comparison scoring amplifies variance.
- Behavior unchanged: ordering and recall scores are identical (`lexical_overlap_score` is pure; same comparator). The 168-test `memory::` suite passes on x86_64 and aarch64.

### Test plan

- `cargo test -p genie-core --lib memory::` (recall behavior unchanged)
- `cargo test -p genie-core --release --test memory_fallback_bench -- --ignored --nocapture` on `main` vs this branch to reproduce the table.

### Notes for reviewers

- Cold-path scope is intentional and stated plainly: the win only applies when FTS misses and the `LIKE` fallback runs. The change is a clean correctness-neutral consistency fix (the FTS `search()` path already scores once), with a real, measurable per-call delta on that path.
- No new behavior, no new config, no schema change.