### PR TITLE
fix(parser): recover tool calls that have a trailing comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
   code and the trailing "five" bound to the unit. `parse_duration` now stitches
   a tens word (`twenty`..`ninety`) to a following ones digit, and the missing
   `fifty`..`ninety` tens words parse on their own.
+- **Tool-call parser tolerates trailing commas** (#469): a trailing comma (a
+  common local-model JSON quirk) made the embedded-JSON scanner return an inner
+  fragment of the call — `{"tool":"set_timer","arguments":{"seconds":300},}`
+  parsed as a phantom `"seconds"` tool, and array forms dropped every call after
+  the first. A balanced candidate that fails to parse is now retried once with a
+  string-aware trailing-comma strip, recovering the correct call for both the
+  runtime and BFCL eval paths.
 
 ## 1.0.0-alpha.11 - 2026-06-20
 

--- a/crates/genie-core/src/tools/parser.rs
+++ b/crates/genie-core/src/tools/parser.rs
@@ -341,6 +341,12 @@ fn extract_balanced_json_candidate(
                     if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
                         return Some(candidate.to_string());
                     }
+                    let repaired = strip_trailing_commas(candidate);
+                    if repaired != candidate
+                        && serde_json::from_str::<serde_json::Value>(&repaired).is_ok()
+                    {
+                        return Some(repaired);
+                    }
                     return None;
                 }
             }
@@ -349,6 +355,44 @@ fn extract_balanced_json_candidate(
     }
 
     None
+}
+
+fn strip_trailing_commas(json: &str) -> String {
+    let chars: Vec<char> = json.chars().collect();
+    let mut out = String::with_capacity(json.len());
+    let mut in_string = false;
+    let mut escape = false;
+
+    for (index, &current) in chars.iter().enumerate() {
+        if escape {
+            out.push(current);
+            escape = false;
+            continue;
+        }
+
+        match current {
+            '\\' if in_string => {
+                out.push(current);
+                escape = true;
+            }
+            '"' => {
+                in_string = !in_string;
+                out.push(current);
+            }
+            ',' if !in_string => {
+                let mut next = index + 1;
+                while next < chars.len() && chars[next].is_whitespace() {
+                    next += 1;
+                }
+                if !(next < chars.len() && matches!(chars[next], '}' | ']')) {
+                    out.push(current);
+                }
+            }
+            _ => out.push(current),
+        }
+    }
+
+    out
 }
 
 #[cfg(test)]
@@ -613,6 +657,44 @@ mod tests {
         let calls = parse_tool_calls_for_eval(r#"{"answer":"hello"}"#);
 
         assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn extract_recovers_trailing_comma_object() {
+        let input = r#"{"tool":"set_timer","arguments":{"seconds":300},}"#;
+        let calls = parse_tool_calls_for_eval(input);
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "set_timer");
+        assert_eq!(calls[0].arguments["seconds"], 300);
+    }
+
+    #[test]
+    fn extract_recovers_trailing_comma_array() {
+        let input = r#"[{"tool":"get_time","arguments":{}},{"tool":"set_timer","arguments":{"seconds":60}},]"#;
+        let calls = parse_tool_calls_for_eval(input);
+
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].name, "get_time");
+        assert_eq!(calls[1].name, "set_timer");
+        assert_eq!(calls[1].arguments["seconds"], 60);
+    }
+
+    #[test]
+    fn extract_trailing_comma_recovery_preserves_string_commas() {
+        let input = r#"{"tool":"web_search","arguments":{"query":"a, b,}","limit":3},}"#;
+        let json = extract_json(input).unwrap();
+        let call: ToolCall = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(call.name, "web_search");
+        assert_eq!(call.arguments["query"], "a, b,}");
+        assert_eq!(call.arguments["limit"], 3);
+    }
+
+    #[test]
+    fn extract_leaves_valid_json_untouched() {
+        let input = r#"{"tool":"get_time","arguments":{}}"#;
+        assert_eq!(extract_json(input).unwrap(), input);
     }
 
     // The `system_info` tool reads /proc/meminfo (via tegrastats), /proc/uptime,


### PR DESCRIPTION
## Summary

The tool-call parser mis-handled a **trailing comma** — one of the most common malformed-JSON quirks local models emit. `{"tool":"set_timer","arguments":{"seconds":300},}` was parsed as a phantom tool named `"seconds"`, and a trailing comma in an array dropped every call after the first. This recovers the correct call instead.

## Changes

- `extract_embedded_json` advanced by a single byte after a balanced candidate failed `serde_json` validation, so it resumed scanning **inside** the object it had just rejected — and returned an inner fragment of the real call.
- When a balanced top-level candidate fails to parse, `extract_balanced_json_candidate` now retries once after stripping trailing commas via a string-aware pass (`strip_trailing_commas`), so commas inside string values are preserved. Valid JSON still returns unchanged on the first attempt; genuinely-invalid JSON (e.g. `{"seconds":60*60*12}`, issue #380) still returns `None` and is caught by `is_unparsed_tool_call`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `laptop`

This is a deterministic, hardware-independent change to `tools/parser.rs` (the shared tool-call extraction used by both the runtime path and the BFCL eval path). No Jetson, audio, model, or network dependency — an x86_64 Linux dev box exercises the exact code path that runs on-device. Because the same parser backs `parse_tool_calls_for_eval`, this directly affects BFCL scoring fidelity: a trailing-comma response that previously scored as a wrong/missing call now scores as the correct call.

### What I ran

On x86_64 Linux (Ubuntu, kernel 6.8), rustc 1.96.0:

```
cargo test -p genie-core
cargo test -p genie-core --lib tools::parser
cargo clippy -p genie-core --tests
cargo clippy -p genie-core --no-default-features --tests
cargo fmt -p genie-core -- --check
```

I added the four regression tests first and confirmed three of them **fail on the current code** (proving the bug) before applying the fix.

### What I observed

- Before the fix, the new tests failed exactly as the bug predicts:
  - `extract_recovers_trailing_comma_object`: `left: "seconds"` vs `right: "set_timer"`.
  - `extract_recovers_trailing_comma_array`: `left: 1` vs `right: 2` (second call dropped).
  - `extract_trailing_comma_recovery_preserves_string_commas`: panicked (no JSON extracted).
- After the fix: `cargo test -p genie-core` — **734 passed, 0 failed** (plus integration/doc suites green). The parser module: 21 passed.
- `extract_leaves_valid_json_untouched` confirms valid JSON is returned byte-for-byte unchanged (no behavior change on the happy path).
- `clippy` clean in both default and `--no-default-features`; `cargo fmt --check` clean.

## Test plan

1. `cargo test -p genie-core --lib tools::parser` — all 21 pass, including the four new `extract_*` tests.
2. Feed `{"tool":"set_timer","arguments":{"seconds":300},}` through `parse_tool_calls_for_eval` and confirm one `set_timer` call with `seconds = 300` (not a `"seconds"` tool).
