### PR TITLE
perf(memory): store embeddings as packed f32 BLOB instead of JSON text

### DIFF
--- a/crates/genie-core/src/memory/mod.rs
+++ b/crates/genie-core/src/memory/mod.rs
@@ -556,7 +556,7 @@ impl Memory {
                 memory_type      TEXT NOT NULL,
                 embedding_model  TEXT NOT NULL,
                 dimensions       INTEGER NOT NULL,
-                embedding        TEXT NOT NULL,
+                embedding        BLOB NOT NULL,
                 updated_ms       INTEGER NOT NULL
             );
 
@@ -1894,12 +1894,12 @@ impl Memory {
                 let entry = read_entry(row)?;
                 let embedding_model: String = row.get(11)?;
                 let dimensions: i64 = row.get(12)?;
-                let embedding_json: String = row.get(13)?;
-                Ok((entry, embedding_model, dimensions as usize, embedding_json))
+                let embedding_blob: Vec<u8> = row.get(13)?;
+                Ok((entry, embedding_model, dimensions as usize, embedding_blob))
             })?
             .filter_map(|row| row.ok())
-            .filter_map(|(entry, embedding_model, dimensions, embedding_json)| {
-                parse_embedding(&embedding_json, dimensions).map(|embedding| {
+            .filter_map(|(entry, embedding_model, dimensions, embedding_blob)| {
+                parse_embedding(&embedding_blob, dimensions).map(|embedding| {
                     let mut score = embedding::cosine_similarity(&query_embedding, &embedding);
                     if query_type.as_deref().is_some_and(|expected| {
                         expected == semantic_memory_type(&entry.kind, &entry.content)
@@ -3539,7 +3539,7 @@ fn upsert_embedded_memory_from_memory(
     let provider = LocalHashEmbeddingProvider;
     let embedding_text = embedding_text_for_memory(kind, content);
     let embedding = provider.embed(&embedding_text);
-    let embedding_json = serde_json::to_string(&embedding)?;
+    let embedding_blob: Vec<u8> = embedding.iter().flat_map(|f| f.to_le_bytes()).collect();
 
     conn.execute(
         "INSERT INTO embedded_memories (
@@ -3550,7 +3550,7 @@ fn upsert_embedded_memory_from_memory(
             semantic_memory_type(kind, content),
             provider.model_name(),
             provider.dimensions() as i64,
-            embedding_json,
+            embedding_blob,
             updated_ms
         ],
     )?;
@@ -7801,13 +7801,18 @@ fn semantic_query_type(query: &str) -> Option<String> {
     }
 }
 
-fn parse_embedding(value: &str, dimensions: usize) -> Option<Vec<f32>> {
-    let embedding = serde_json::from_str::<Vec<f32>>(value).ok()?;
-    if embedding.len() == dimensions {
-        Some(embedding)
-    } else {
-        None
+/// Decode a packed little-endian f32 embedding BLOB (4 bytes per dimension).
+/// Returns `None` if the byte length doesn't match `dimensions * 4`.
+fn parse_embedding(bytes: &[u8], dimensions: usize) -> Option<Vec<f32>> {
+    if bytes.len() != dimensions * 4 {
+        return None;
     }
+    Some(
+        bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+    )
 }
 
 fn family_calendar_events_from_memory(kind: &str, content: &str) -> Vec<FamilyCalendarEvent> {
@@ -16174,6 +16179,86 @@ mod tests {
         let hits = reopened.semantic_search("I'm feeling cold", 3).unwrap();
         assert_eq!(hits.len(), 1);
         assert!(hits[0].entry.content.contains("thermostat"));
+    }
+
+    #[test]
+    fn parse_embedding_blob_roundtrip_is_bit_identical() {
+        use crate::memory::embedding::{EmbeddingProvider, LocalHashEmbeddingProvider};
+        let provider = LocalHashEmbeddingProvider;
+        let original = provider.embed("the family keeps the thermostat warm in the evening");
+        let blob: Vec<u8> = original.iter().flat_map(|f| f.to_le_bytes()).collect();
+        let restored = parse_embedding(&blob, original.len()).expect("parse_embedding failed");
+        assert_eq!(
+            original, restored,
+            "packed f32 BLOB roundtrip must be bit-identical"
+        );
+    }
+
+    #[test]
+    fn parse_embedding_rejects_wrong_length() {
+        // Not a multiple of 4 → None.
+        assert!(parse_embedding(&[0u8; 3], 1).is_none());
+        // Right byte count but wrong declared dimensions.
+        let blob = vec![0u8; 64 * 4];
+        assert!(parse_embedding(&blob, 32).is_none());
+    }
+
+    #[test]
+    #[ignore = "benchmark; run with --release --ignored --nocapture"]
+    fn bench_embedding_decode_json_vs_blob() {
+        // Measures the per-row decode cost in `semantic_search`: the old TEXT
+        // column was decoded with serde_json per scanned row; the new BLOB with
+        // chunks_exact(4). Run on-device to capture the before→after.
+        use crate::memory::embedding::{EmbeddingProvider, LocalHashEmbeddingProvider};
+        use std::time::Instant;
+        let provider = LocalHashEmbeddingProvider;
+        let rows = 4000usize;
+        let embeds: Vec<Vec<f32>> = (0..rows)
+            .map(|i| {
+                provider.embed(&format!(
+                    "household memory {i}: routines, preferences, devices, people"
+                ))
+            })
+            .collect();
+        let dim = embeds[0].len();
+        let jsons: Vec<String> = embeds
+            .iter()
+            .map(|e| serde_json::to_string(e).unwrap())
+            .collect();
+        let blobs: Vec<Vec<u8>> = embeds
+            .iter()
+            .map(|e| e.iter().flat_map(|f| f.to_le_bytes()).collect())
+            .collect();
+
+        let mut sink = 0.0f32;
+        for j in &jsons {
+            sink += serde_json::from_str::<Vec<f32>>(j).unwrap()[0];
+        }
+        for b in &blobs {
+            sink += parse_embedding(b, dim).unwrap()[0];
+        }
+
+        let iters = 20u32;
+        let t = Instant::now();
+        for _ in 0..iters {
+            for j in &jsons {
+                sink += serde_json::from_str::<Vec<f32>>(j).unwrap()[0];
+            }
+        }
+        let json_ns = t.elapsed().as_nanos() as f64 / (iters as f64 * rows as f64);
+
+        let t = Instant::now();
+        for _ in 0..iters {
+            for b in &blobs {
+                sink += parse_embedding(b, dim).unwrap()[0];
+            }
+        }
+        let blob_ns = t.elapsed().as_nanos() as f64 / (iters as f64 * rows as f64);
+
+        eprintln!(
+            "BENCH embedding decode: dim={dim} rows={rows} | JSON {json_ns:.0} ns/row | BLOB {blob_ns:.0} ns/row | speedup {:.1}x (sink={sink})",
+            json_ns / blob_ns
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`embedded_memories.embedding` was stored as `TEXT` (a JSON array) and decoded with `serde_json::from_str::<Vec<f32>>()` on **every row scanned** during `semantic_search`. This stores it as a little-endian packed f32 **BLOB** (4 bytes/dim), decoded with a single `chunks_exact(4)` pass — no JSON tokenizer, no intermediate string allocation.

`rebuild_embedded_memories` clears and rewrites the whole table on every `Memory::open`, so no migration is needed.

Lands the optimization originally proposed in #466 (closed for missing on-device proof), now with a measured Jetson before→after.

## Changes

- `embedded_memories.embedding`: `TEXT` → `BLOB`.
- `upsert_embedded_memory_from_memory`: pack `Vec<f32>` via `to_le_bytes()` instead of `serde_json::to_string`.
- `semantic_search`: read the column as `Vec<u8>`.
- `parse_embedding`: decode with `chunks_exact(4)` + length validation, instead of a JSON parse.
- Tests: `parse_embedding_blob_roundtrip_is_bit_identical`, `parse_embedding_rejects_wrong_length`, and an `#[ignore]` decode benchmark.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware.
- [ ] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `jetson`

### What I ran

On the Jetson Orin Nano (aarch64, L4T R36): `cargo test -p genie-core --release --lib bench_embedding_decode -- --ignored --nocapture`, plus the `parse_embedding` and `semantic_search` suites.

### What I observed

```
BENCH embedding decode: dim=64 rows=4000 | JSON 6527 ns/row | BLOB 123 ns/row | speedup 52.9x
```

Decoding one embedding row drops from **6527 ns → 123 ns (~53× faster)** on-device — and `semantic_search` does this for every embedded row per query. Correctness on aarch64: `parse_embedding` roundtrip + wrong-length tests pass; the 20 `semantic_search` end-to-end tests (store → BLOB → decode → search) pass; `cargo fmt` / clippy clean.

## Test plan

`cargo test -p genie-core --lib memory::tests::semantic` and `...::parse_embedding`; reproduce the benchmark with `--release --lib bench_embedding_decode -- --ignored --nocapture`.