### PR TITLE
fix(dispatch): action_history shows undo_restore hints for value-changing actions (#471)

### DIFF
--- a/crates/genie-core/src/tools/actuation.rs
+++ b/crates/genie-core/src/tools/actuation.rs
@@ -87,6 +87,22 @@ pub struct RecordedAction {
     pub executed_ms: u64,
 }
 
+impl RecordedAction {
+    /// Undo suffix for `action_history` lines — mirrors [`ActionLedger::last_undoable`].
+    pub fn action_history_undo_hint(&self) -> String {
+        if let Some(inverse) = self.inverse_action.as_deref() {
+            format!(" undo: {inverse}")
+        } else if let Some(restore) = &self.undo_restore {
+            match restore.value {
+                Some(value) => format!(" undo: {} {value}", restore.action),
+                None => format!(" undo: {}", restore.action),
+            }
+        } else {
+            " not undoable".into()
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct ConfirmationManager {
     inner: Mutex<ConfirmationState>,
@@ -1183,5 +1199,48 @@ mod tests {
         let args = ActionLedger::undo_home_control_args(&undo).unwrap();
         assert_eq!(args["action"], "set_brightness");
         assert_eq!(args["value"], 100.0);
+    }
+
+    #[test]
+    fn action_history_undo_hint_uses_restore_when_no_inverse() {
+        let action = RecordedAction {
+            id: 1,
+            undo_of: None,
+            entity: "kitchen light".into(),
+            action: "set_brightness".into(),
+            value: Some(30.0),
+            inverse_action: None,
+            undo_restore: Some(UndoRestore {
+                action: "set_brightness".into(),
+                value: Some(100.0),
+            }),
+            origin: RequestOrigin::Dashboard,
+            summary: "dimmed".into(),
+            confidence: None,
+            executed_ms: 0,
+        };
+        assert_eq!(
+            action.action_history_undo_hint(),
+            " undo: set_brightness 100"
+        );
+        assert!(!action.action_history_undo_hint().contains("not undoable"));
+    }
+
+    #[test]
+    fn action_history_undo_hint_prefers_inverse_action() {
+        let action = RecordedAction {
+            id: 1,
+            undo_of: None,
+            entity: "kitchen light".into(),
+            action: "turn_on".into(),
+            value: None,
+            inverse_action: Some("turn_off".into()),
+            undo_restore: None,
+            origin: RequestOrigin::Dashboard,
+            summary: "on".into(),
+            confidence: None,
+            executed_ms: 0,
+        };
+        assert_eq!(action.action_history_undo_hint(), " undo: turn_off");
     }
 }

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -1283,11 +1283,7 @@ impl ToolDispatcher {
         if !actions.is_empty() {
             lines.push("Recent home actions:".to_string());
             for action in actions.iter().take(5) {
-                let undo = action
-                    .inverse_action
-                    .as_deref()
-                    .map(|inverse| format!(" undo: {inverse}"))
-                    .unwrap_or_else(|| " not undoable".into());
+                let undo = action.action_history_undo_hint();
                 lines.push(format!(
                     "- {} {} via {:?};{}",
                     action.action, action.entity, action.origin, undo
@@ -3265,6 +3261,61 @@ mod tests {
         );
         assert_eq!(provider.power(), "on");
         assert_eq!(provider.brightness(), Some(255));
+    }
+
+    #[tokio::test]
+    async fn action_history_shows_undo_restore_hint_after_dim() {
+        let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let dispatcher =
+            ToolDispatcher::new(Some(Arc::new(RecordingHomeProvider::new(executed.clone()))));
+        let ctx = || ToolExecutionContext {
+            request_origin: RequestOrigin::Dashboard,
+            ..ToolExecutionContext::default()
+        };
+
+        assert!(
+            dispatcher
+                .execute_with_context(
+                    &ToolCall {
+                        name: "home_control".into(),
+                        arguments: serde_json::json!({
+                            "entity": "kitchen light",
+                            "action": "turn_on"
+                        }),
+                    },
+                    ctx(),
+                )
+                .await
+                .success
+        );
+        assert!(
+            dispatcher
+                .execute_with_context(
+                    &ToolCall {
+                        name: "home_control".into(),
+                        arguments: serde_json::json!({
+                            "entity": "kitchen light",
+                            "action": "set_brightness",
+                            "value": 30
+                        }),
+                    },
+                    ctx(),
+                )
+                .await
+                .success
+        );
+
+        let history = dispatcher
+            .execute(&ToolCall {
+                name: "action_history".into(),
+                arguments: serde_json::json!({}),
+            })
+            .await;
+
+        assert!(history.success);
+        assert!(history.output.contains("set_brightness kitchen light"));
+        assert!(history.output.contains("undo: set_brightness 100"));
+        assert!(!history.output.contains("not undoable"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #471

## Summary

`action_history` now mirrors `last_undoable`: value-changing home actions (`set_brightness`, `set_temperature`, `toggle`) show an `undo:` hint derived from `undo_restore` instead of **not undoable** when `inverse_action` is absent. Closes the UX gap left after #434 / #435 where `home_undo` worked in-session but history misled the model and dashboard users.

## Changes

- Add `RecordedAction::action_history_undo_hint()` in `actuation.rs` — prefers `inverse_action`, then formats `undo_restore` (e.g. `undo: set_brightness 100`, `undo: turn_off`).
- `exec_action_history` delegates to that helper instead of only checking `inverse_action`.
- Unit tests for hint formatting plus `action_history_shows_undo_restore_hint_after_dim` integration test (`RecordingHomeProvider` stub).

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Linux x86_64 dev host (`main` base + this branch), no live Home Assistant:

```bash
cd genie-claw
cargo test -p genie-core action_history -- --nocapture
cargo clippy -p genie-core -- -D warnings
```

### What I observed

All `action_history`-related tests pass. The new integration test exercises the full dispatch path: `home_control` turn_on → `set_brightness` 30 → `action_history`. Output includes `set_brightness kitchen light` with `undo: set_brightness 100` (prior brightness 255 → 100%) and does **not** contain `not undoable` for that entry. Existing `turn_on` hydrate test still shows `undo: turn_off`. Clippy clean.

**Validation gap:** Not exercised on Jetson or against a live HA instance. This change is display-only in `exec_action_history`; undo execution logic is unchanged and already covered by `home_undo_restores_prior_brightness_after_dim`. Real HA would surface the same ledger fields; restart/hydrate undo hints remain #472.

## Test plan

- `cargo test -p genie-core action_history`
- `cargo clippy -p genie-core -- -D warnings`
- Optional on hardware with HA: dim a light, ask "what did you do?" / call `action_history`, confirm undo hint matches what `home_undo` would restore.

## Notes for reviewers

- Scoped to in-session ledger entries that already carry `undo_restore`. Audit-hydrated actions after restart still lack `undo_restore` (#472) — out of scope here.
- Hint format mirrors `undo_home_control_args` args (`action` + optional `value`), not a new schema.
