### PR TITLE
fix(actuation): persist undo_restore in audit hydrate for post-restart home_undo (#472)

### DIFF
--- a/crates/genie-core/src/tools/actuation.rs
+++ b/crates/genie-core/src/tools/actuation.rs
@@ -421,6 +421,8 @@ pub struct AuditEvent {
     pub action_id: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub undo_of: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub undo_restore: Option<UndoRestore>,
 }
 
 /// A failure while appending one JSON line to an audit log, tagged by the step
@@ -566,7 +568,7 @@ fn audit_event_to_recorded_action(event: AuditEvent) -> Option<RecordedAction> {
         action: event.action.clone(),
         value: event.value,
         inverse_action: inverse_action(&event.action).map(str::to_string),
-        undo_restore: None,
+        undo_restore: event.undo_restore,
         origin: event.origin,
         summary: event.reason,
         confidence: event.confidence,
@@ -899,6 +901,7 @@ mod tests {
             confidence: Some(0.9),
             action_id: Some(1),
             undo_of: None,
+            undo_restore: None,
         }
     }
 
@@ -980,6 +983,7 @@ mod tests {
                     confidence: None,
                     action_id: if idx % 2 == 0 { Some(idx) } else { None },
                     undo_of: None,
+                    undo_restore: None,
                 })
                 .expect("append audit event");
         }
@@ -1014,6 +1018,7 @@ mod tests {
                 confidence: Some(0.9),
                 action_id: Some(1),
                 undo_of: None,
+                undo_restore: None,
             })
             .expect("append executed event");
         logger
@@ -1029,12 +1034,80 @@ mod tests {
                 confidence: None,
                 action_id: None,
                 undo_of: None,
+                undo_restore: None,
             })
             .expect("append confirmation event");
 
         let actions = logger.read_recent_executed_actions(10);
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].entity, "kitchen light");
+        assert_eq!(actions[0].inverse_action.as_deref(), Some("turn_off"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn audit_logger_hydrates_undo_restore_from_executed_event() {
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-actuation-audit-undo-restore-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let logger = AuditLogger::new(&path);
+
+        logger
+            .append(AuditEvent {
+                ts_ms: 100,
+                status: AuditStatus::Executed,
+                origin: RequestOrigin::Dashboard,
+                entity: "kitchen light".into(),
+                action: "set_brightness".into(),
+                value: Some(30.0),
+                reason: "home action executed".into(),
+                token: None,
+                confidence: Some(0.95),
+                action_id: Some(7),
+                undo_of: None,
+                undo_restore: Some(UndoRestore {
+                    action: "set_brightness".into(),
+                    value: Some(100.0),
+                }),
+            })
+            .expect("append executed event");
+
+        let actions = logger.read_recent_executed_actions(10);
+        assert_eq!(actions.len(), 1);
+        let restore = actions[0].undo_restore.as_ref().unwrap();
+        assert_eq!(restore.action, "set_brightness");
+        assert_eq!(restore.value, Some(100.0));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn audit_logger_hydrates_legacy_lines_without_undo_restore_field() {
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-actuation-audit-legacy-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let line = serde_json::json!({
+            "ts_ms": 100,
+            "status": "executed",
+            "origin": "dashboard",
+            "entity": "kitchen light",
+            "action": "turn_on",
+            "value": null,
+            "reason": "home action executed",
+            "token": null,
+            "confidence": 0.9,
+            "action_id": 1,
+            "undo_of": null
+        });
+        std::fs::write(&path, format!("{line}\n")).unwrap();
+
+        let logger = AuditLogger::new(&path);
+        let actions = logger.read_recent_executed_actions(10);
+        assert_eq!(actions.len(), 1);
+        assert!(actions[0].undo_restore.is_none());
         assert_eq!(actions[0].inverse_action.as_deref(), Some("turn_off"));
         let _ = std::fs::remove_file(&path);
     }

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -1098,6 +1098,7 @@ impl ToolDispatcher {
                 confidence: None,
                 action_id: None,
                 undo_of: None,
+                undo_restore: None,
             });
             anyhow::bail!("Home action blocked by channel policy: {}", reason);
         }
@@ -1123,6 +1124,7 @@ impl ToolDispatcher {
                 confidence: None,
                 action_id: None,
                 undo_of: None,
+                undo_restore: None,
             });
             anyhow::bail!("Home action blocked by rate limit: {}", reason);
         }
@@ -1189,6 +1191,7 @@ impl ToolDispatcher {
                     confidence,
                     action_id: Some(recorded.id),
                     undo_of: recorded.undo_of,
+                    undo_restore: recorded.undo_restore.clone(),
                 });
                 Ok(output)
             }
@@ -1216,6 +1219,7 @@ impl ToolDispatcher {
                     confidence: None,
                     action_id: None,
                     undo_of: None,
+                    undo_restore: None,
                 });
                 // The token is a bearer secret: a leaked one is a reusable
                 // door-unlock credential for its full validity window. Keep it
@@ -1249,6 +1253,7 @@ impl ToolDispatcher {
                     confidence: None,
                     action_id: None,
                     undo_of: None,
+                    undo_restore: None,
                 });
                 Err(anyhow::anyhow!(error))
             }
@@ -3379,6 +3384,82 @@ mod tests {
         assert!(history.success);
         assert!(history.output.contains("turn_on kitchen light"));
         assert!(history.output.contains("undo: turn_off"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn home_undo_restores_brightness_after_audit_hydrate_restart() {
+        let path = std::env::temp_dir().join(format!(
+            "geniepod-dispatch-audit-undo-restart-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider = Arc::new(RecordingHomeProvider::new(executed.clone()));
+        let ctx = || ToolExecutionContext {
+            request_origin: RequestOrigin::Dashboard,
+            ..ToolExecutionContext::default()
+        };
+
+        let dispatcher = ToolDispatcher::new(Some(provider.clone()))
+            .with_actuation_audit_path(path.clone());
+
+        assert!(
+            dispatcher
+                .execute_with_context(
+                    &ToolCall {
+                        name: "home_control".into(),
+                        arguments: serde_json::json!({
+                            "entity": "kitchen light",
+                            "action": "turn_on"
+                        }),
+                    },
+                    ctx(),
+                )
+                .await
+                .success
+        );
+        assert!(
+            dispatcher
+                .execute_with_context(
+                    &ToolCall {
+                        name: "home_control".into(),
+                        arguments: serde_json::json!({
+                            "entity": "kitchen light",
+                            "action": "set_brightness",
+                            "value": 30
+                        }),
+                    },
+                    ctx(),
+                )
+                .await
+                .success
+        );
+        assert_eq!(provider.brightness(), Some(77));
+
+        let executed_restart = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider_restart = Arc::new(RecordingHomeProvider::new(executed_restart.clone()));
+        let restarted = ToolDispatcher::new(Some(provider_restart.clone()))
+            .with_actuation_audit_path(path.clone());
+
+        let undo = restarted
+            .execute_with_context(
+                &ToolCall {
+                    name: "home_undo".into(),
+                    arguments: serde_json::json!({}),
+                },
+                ctx(),
+            )
+            .await;
+
+        assert!(undo.success, "{}", undo.output);
+        assert!(undo.output.contains("Undid the last home action"));
+        assert_eq!(
+            *executed_restart.lock().unwrap(),
+            vec![HomeActionKind::SetBrightness]
+        );
+        assert_eq!(provider_restart.brightness(), Some(255));
         let _ = std::fs::remove_file(&path);
     }
 

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -3402,8 +3402,8 @@ mod tests {
             ..ToolExecutionContext::default()
         };
 
-        let dispatcher = ToolDispatcher::new(Some(provider.clone()))
-            .with_actuation_audit_path(path.clone());
+        let dispatcher =
+            ToolDispatcher::new(Some(provider.clone())).with_actuation_audit_path(path.clone());
 
         assert!(
             dispatcher


### PR DESCRIPTION
Fixes #472

## Summary

Persist `undo_restore` on executed actuation audit lines and hydrate it back into `RecordedAction` on startup. `home_undo` for value-changing actions (`set_brightness`, `set_temperature`, `toggle`) now works after a process restart within the audit retention window, not only for binary actions where `inverse_action` can be recomputed.

## Changes

- Add optional `undo_restore` field to `AuditEvent` (serde-defaulted for backward-compatible reads of legacy JSONL).
- Write `recorded.undo_restore` when appending executed audit events in `exec_home_control_inner`.
- `audit_event_to_recorded_action` copies `event.undo_restore` instead of hardcoding `None`.
- Unit tests: hydrate round-trip, legacy line without field, integration test simulating dispatcher restart → `home_undo` restores brightness.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Linux x86_64 dev host, no live Home Assistant (`RecordingHomeProvider` stub):

```bash
cd genie-claw
cargo test -p genie-core home_undo_restores_brightness_after_audit -- --nocapture
cargo test -p genie-core audit_logger_hydrates -- --nocapture
cargo clippy -p genie-core -- -D warnings
```

### What I observed

`home_undo_restores_brightness_after_audit_hydrate_restart` passes: first dispatcher turns on kitchen light and dims to 30%; a **new** `ToolDispatcher` loaded from the same audit JSONL successfully `home_undo`s and issues `set_brightness` restore to 100% (brightness 255 on stub). `audit_logger_hydrates_undo_restore_from_executed_event` and `audit_logger_hydrates_legacy_lines_without_undo_restore_field` pass — new field round-trips and old audit lines without `undo_restore` still hydrate with `inverse_action` only. Clippy clean.

**Validation gap:** Not run on Jetson or live HA. Restart path is exercised via `with_actuation_audit_path` + fresh dispatcher, matching production hydrate-on-startup. Real HA would use the same audit ledger fields.

## Test plan

- `cargo test -p genie-core home_undo_restores_brightness_after_audit`
- `cargo test -p genie-core audit_logger_hydrates`
- `cargo test -p genie-core action_history_hydrates_from_audit_log` (regression: `turn_on` still shows `undo: turn_off`)
- `cargo clippy -p genie-core -- -D warnings`

## Notes for reviewers

- `undo_restore` is omitted from JSONL when `None` (`skip_serializing_if`) — no size change for `turn_on`/`turn_off` lines.
- Complements #471 (action_history hints) and merged #434/#435; independent branch from `main`.
- Undo-of-undo (`undo_of` entries) still write `undo_restore: None` at execution time (unchanged).
