### PR TITLE
perf(memory): gate open-time schema-ensure + migrations on PRAGMA user_version

### DIFF
--- a/crates/genie-core/src/memory/mod.rs
+++ b/crates/genie-core/src/memory/mod.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 const MAX_QUERY_HASHES: usize = 16;
 
 const DERIVATION_VERSION: i64 = 1;
+const SCHEMA_VERSION: i64 = 1;
 
 /// Persistent conversational memory with dreaming-inspired consolidation.
 ///
@@ -302,12 +303,19 @@ impl Memory {
         )?;
         conn.busy_timeout(Duration::from_secs(5))?;
         conn.execute_batch(
-            "
-            PRAGMA journal_mode = WAL;
-            PRAGMA synchronous = NORMAL;
-            PRAGMA temp_store = MEMORY;
-            PRAGMA foreign_keys = ON;
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA temp_store = MEMORY;
+             PRAGMA foreign_keys = ON;",
+        )?;
 
+        let mut migration_degraded = false;
+        let schema_version: i64 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap_or(0);
+        if schema_version < SCHEMA_VERSION {
+            conn.execute_batch(
+                "
             CREATE TABLE IF NOT EXISTS memories (
                 id            INTEGER PRIMARY KEY,
                 kind          TEXT NOT NULL,
@@ -589,94 +597,97 @@ impl Memory {
             ",
         )?;
 
-        // Migrate: add columns if they don't exist (idempotent).
-        let mut migration_degraded = false;
-        run_open_migration(
-            &conn,
-            "ALTER TABLE memories ADD COLUMN recall_count INTEGER NOT NULL DEFAULT 0",
-            "add recall_count",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "ALTER TABLE memories ADD COLUMN max_score REAL NOT NULL DEFAULT 0.0",
-            "add max_score",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "ALTER TABLE memories ADD COLUMN promoted INTEGER NOT NULL DEFAULT 0",
-            "add promoted",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "ALTER TABLE memories ADD COLUMN query_hashes TEXT NOT NULL DEFAULT '[]'",
-            "add query_hashes",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "ALTER TABLE memories ADD COLUMN evergreen INTEGER NOT NULL DEFAULT 0",
-            "add evergreen",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "ALTER TABLE memories ADD COLUMN scope TEXT NOT NULL DEFAULT 'household'",
-            "add scope",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "ALTER TABLE memories ADD COLUMN sensitivity TEXT NOT NULL DEFAULT 'normal'",
-            "add sensitivity",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "ALTER TABLE memories ADD COLUMN spoken_policy TEXT NOT NULL DEFAULT 'allow'",
-            "add spoken_policy",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "ALTER TABLE memories ADD COLUMN display_order INTEGER NOT NULL DEFAULT 2147483647",
-            "add display_order",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "CREATE INDEX IF NOT EXISTS idx_memories_kind_accessed ON memories(kind, accessed_ms DESC)",
-            "create idx_memories_kind_accessed",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "CREATE INDEX IF NOT EXISTS idx_memories_promotion ON memories(promoted, recall_count, max_score)",
-            "create idx_memories_promotion",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "CREATE INDEX IF NOT EXISTS idx_memories_prune ON memories(evergreen, promoted, accessed_ms)",
-            "create idx_memories_prune",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "CREATE INDEX IF NOT EXISTS idx_memories_scope_sensitivity ON memories(scope, sensitivity, spoken_policy)",
-            "create idx_memories_scope_sensitivity",
-            &mut migration_degraded,
-        );
-        run_open_migration(
-            &conn,
-            "CREATE INDEX IF NOT EXISTS idx_memories_display_order ON memories(display_order, accessed_ms DESC, id DESC)",
-            "create idx_memories_display_order",
-            &mut migration_degraded,
-        );
+            // Migrate: add columns if they don't exist (idempotent).
+            run_open_migration(
+                &conn,
+                "ALTER TABLE memories ADD COLUMN recall_count INTEGER NOT NULL DEFAULT 0",
+                "add recall_count",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "ALTER TABLE memories ADD COLUMN max_score REAL NOT NULL DEFAULT 0.0",
+                "add max_score",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "ALTER TABLE memories ADD COLUMN promoted INTEGER NOT NULL DEFAULT 0",
+                "add promoted",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "ALTER TABLE memories ADD COLUMN query_hashes TEXT NOT NULL DEFAULT '[]'",
+                "add query_hashes",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "ALTER TABLE memories ADD COLUMN evergreen INTEGER NOT NULL DEFAULT 0",
+                "add evergreen",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "ALTER TABLE memories ADD COLUMN scope TEXT NOT NULL DEFAULT 'household'",
+                "add scope",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "ALTER TABLE memories ADD COLUMN sensitivity TEXT NOT NULL DEFAULT 'normal'",
+                "add sensitivity",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "ALTER TABLE memories ADD COLUMN spoken_policy TEXT NOT NULL DEFAULT 'allow'",
+                "add spoken_policy",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "ALTER TABLE memories ADD COLUMN display_order INTEGER NOT NULL DEFAULT 2147483647",
+                "add display_order",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "CREATE INDEX IF NOT EXISTS idx_memories_kind_accessed ON memories(kind, accessed_ms DESC)",
+                "create idx_memories_kind_accessed",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "CREATE INDEX IF NOT EXISTS idx_memories_promotion ON memories(promoted, recall_count, max_score)",
+                "create idx_memories_promotion",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "CREATE INDEX IF NOT EXISTS idx_memories_prune ON memories(evergreen, promoted, accessed_ms)",
+                "create idx_memories_prune",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "CREATE INDEX IF NOT EXISTS idx_memories_scope_sensitivity ON memories(scope, sensitivity, spoken_policy)",
+                "create idx_memories_scope_sensitivity",
+                &mut migration_degraded,
+            );
+            run_open_migration(
+                &conn,
+                "CREATE INDEX IF NOT EXISTS idx_memories_display_order ON memories(display_order, accessed_ms DESC, id DESC)",
+                "create idx_memories_display_order",
+                &mut migration_degraded,
+            );
 
-        backfill_policy_columns(&conn)?;
+            backfill_policy_columns(&conn)?;
+            if !migration_degraded {
+                conn.execute_batch(&format!("PRAGMA user_version = {SCHEMA_VERSION};"))?;
+            }
+        }
 
         let stored_derivation: Option<i64> = conn
             .query_row(
@@ -16159,6 +16170,56 @@ mod tests {
             "version mismatch must rebuild household_profiles from memories"
         );
         assert_eq!(profiles[0].name, "Jared");
+    }
+
+    #[test]
+    fn stale_schema_version_reopen_reensures_and_restamps() {
+        let path = temp_memory_path("schema-version-reensure");
+        {
+            let mem = Memory::open(&path).unwrap();
+            mem.store("fact", "the kitchen light is warm white")
+                .unwrap();
+        }
+        {
+            let raw = rusqlite::Connection::open(&path).unwrap();
+            let stamped: i64 = raw
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(
+                stamped, SCHEMA_VERSION,
+                "a successful open must stamp user_version"
+            );
+            raw.execute_batch("DROP INDEX idx_memories_display_order; PRAGMA user_version = 0;")
+                .unwrap();
+            let present: i64 = raw
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_memories_display_order'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(present, 0, "precondition: index dropped, version reset");
+        }
+        let _reopened = Memory::open(&path).unwrap();
+        let raw = rusqlite::Connection::open(&path).unwrap();
+        let present: i64 = raw
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_memories_display_order'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            present, 1,
+            "stale version must re-run schema-ensure and recreate the index"
+        );
+        let restamped: i64 = raw
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            restamped, SCHEMA_VERSION,
+            "ensure pass must restamp user_version"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Memory::open` re-ran the **entire schema-ensure pass on every open** — the big `CREATE TABLE/INDEX/TRIGGER IF NOT EXISTS` batch, the 14 `ALTER`/`CREATE INDEX` `run_open_migration` calls, and the policy-column backfill — even when the on-disk schema was already current. With the derived-table rebuild already gated by #464, that ensure pass is the **entire remaining steady-state reopen cost** (~99.8% of it on Jetson). This change gates it on SQLite's built-in `PRAGMA user_version`: run the ensure pass only when the stored version is below `SCHEMA_VERSION`, then stamp the version; skip it otherwise. The result is **~575× faster `Memory::open`** on steady-state restarts on the Jetson Orin Nano (483 ms → 0.84 ms). Contributes under #402 (performance bucket).

## Changes

- `crates/genie-core/src/memory/mod.rs` (`open_with_half_life`):
  - Split the **per-connection PRAGMAs** (`journal_mode`/`synchronous`/`temp_store`/`foreign_keys`) out of the big schema batch into their own `execute_batch` that still runs on **every** open — they are connection state, not persisted schema.
  - Gate the schema-ensure pass (the `CREATE … IF NOT EXISTS` batch + the 14 `run_open_migration` calls + `backfill_policy_columns`) behind `if schema_version < SCHEMA_VERSION { … }`, reading `PRAGMA user_version` (defaulting to `0`).
  - Stamp `PRAGMA user_version = SCHEMA_VERSION` after the pass, **only when `!migration_degraded`** — so a transient migration failure is not locked in and self-heals on the next open.
  - New `const SCHEMA_VERSION: i64 = 1;` next to `DERIVATION_VERSION`.
  - The separate #464 `derivation_version` rebuild gate is unchanged and still runs afterward.
- `crates/genie-core/src/memory/mod.rs` (tests): `stale_schema_version_reopen_reensures_and_restamps` — opens a DB, asserts a successful open stamps `user_version`, then drops a migration-created index and resets `user_version`, and asserts the reopen re-runs the ensure pass (recreates the index) and re-stamps the version.

The line count of the diff is inflated by re-indentation: the existing schema-ensure statements are now nested in the version-gate `if`, so `rustfmt` shifts them. `git diff --ignore-all-space` shows the real change is the gate + the PRAGMA split + the stamp guard.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware.
- [ ] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On the target **Jetson Orin Nano** (Engineering Reference Developer Kit Super, 8 GB), L4T R36.4.7, `Linux 5.15.148-tegra aarch64`, `rustc 1.95.0`, **release** profile (`opt-level="z"`, LTO disabled only to speed the build), DB on the SD card. Cloned current `main` into a tmpfs target dir, ran the existing `memory_open_bench` (added in #464 — seeds 2000 memories, then times 10 reopens of the same DB), then applied this change and reran (3× each):

```
cargo test -p genie-core --release --test memory_open_bench -- --ignored --nocapture
```

Also on an x86_64 dev box (`rustc 1.95.0`): the same bench (median 209 ms → 1.35 ms/open, ~155×); `cargo test -p genie-core --lib memory::` → **174 tests green** (incl. the new regression test); `cargo fmt -p genie-core -- --check`, `cargo clippy -p genie-core --tests`, and `cargo clippy -p genie-core --no-default-features --tests` all clean.

### What I observed

`Memory::open` steady-state reopen, 2000 memories, 10 opens/run (the rebuild is already skipped by #464, so this isolates the schema-ensure cost):

| run | before (schema-ensure every open) | after (gated on user_version) |
| --- | --- | --- |
| 1 | 468.95 ms/open | 0.842 ms/open |
| 2 | 483.26 ms/open | 0.840 ms/open |
| 3 | 493.45 ms/open | 0.837 ms/open |
| **median** | **483 ms** | **0.84 ms** |

- **~575× faster** `Memory::open` on the Jetson at the median; ~155× on x86_64. The schema-ensure pass was ~99.8% of steady-state reopen cost on the Jetson.
- Behavior unchanged on the paths that matter: fresh DBs (`user_version` defaults to `0`) and legacy/upgraded DBs run the full idempotent ensure exactly as before, then skip on subsequent opens. Verified by the existing suite — `recall_works_after_reopen_skips_rebuild`, `version_mismatch_reopen_rebuilds_derived_tables`, `open_backfills_policy_columns_for_existing_rows`, `open_marks_migration_degraded_when_fts_rebuild_fails` — plus the new `stale_schema_version_reopen_reensures_and_restamps`.

### Test plan

- `cargo test -p genie-core --lib memory::` (open/reopen/migration/backfill behavior unchanged; 174 green)
- `cargo test -p genie-core --release --test memory_open_bench -- --ignored --nocapture` on `main` vs this branch to reproduce the table.

## Notes for reviewers

- **Self-healing preserved.** `run_open_migration` swallows non-duplicate failures (disk full, lock, corrupt page) into the in-memory `migration_degraded` flag. The version is stamped **only when `!migration_degraded`**, so a degraded open leaves `user_version` below `SCHEMA_VERSION` and the next open re-runs the idempotent ensure — the same self-healing the per-open ensure gave, without re-running it in the steady state.
- **Monotonic gate.** The check is `schema_version < SCHEMA_VERSION` (not `!=`), so an older binary opening a DB written by a newer binary will not downgrade the stamp.
- **Maintenance contract:** bump `SCHEMA_VERSION` whenever the schema DDL or any `run_open_migration` call changes, otherwise already-stamped DBs will skip the new schema. This mirrors the existing `DERIVATION_VERSION` discipline from #464.
- Per-connection PRAGMAs (`foreign_keys`, `synchronous`, `temp_store`, `journal_mode`) still run on every open — they were moved out of the gated batch, not gated.
- Out of scope (hardening, needs out-of-band schema tampering to hit): the FTS table/triggers are `CREATE … IF NOT EXISTS` inside the gated pass, so they are no longer re-asserted on every open; `health().fts_consistent` still surfaces row-count drift.
- No new behavior, config, or data migration; no schema content change.
