### PR TITLE
ci(auto-label): retire the community-contribution label

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -5,15 +5,15 @@
 #     "I have verified the change end-to-end on Jetson hardware." box.
 #   * performance  — title starts with `perf` without that box ticked.
 #   * bug          — title starts with `fix` or contains `[bug]`.
-# Author label — exactly one, by GitHub role (author_association):
-#   * maintainer             — OWNER / MEMBER / COLLABORATOR.
-#   * community-contribution — everyone else.
+# Author label — `maintainer` only, by GitHub role (author_association):
+#   * maintainer — OWNER / MEMBER / COLLABORATOR. Everyone else gets no author label.
 #
 # Ownership / reconciliation:
-#   * {optimization, performance} and {maintainer, community-contribution} are
-#     fully owned here: the workflow keeps exactly the computed label and removes
-#     its sibling, so edits re-label (ticking the Jetson box flips
-#     performance -> optimization; an empty box flips it back).
+#   * {optimization, performance} is fully owned here: the workflow keeps exactly
+#     the computed label and removes its sibling, so edits re-label (ticking the
+#     Jetson box flips performance -> optimization; an empty box flips it back).
+#   * `maintainer` is set for maintainer authors and removed otherwise; the
+#     retired `community-contribution` label is always removed.
 #   * `bug` is ADD-only — the issue forms ([bug]/[audio]/[voice]) and manual
 #     curation also apply it, so the workflow never removes it.
 #   * Every other label (enhancement, audio, voice, jetson, M1, ...) is untouched.
@@ -77,10 +77,10 @@ jobs:
 
           case "$ASSOC" in
             OWNER|MEMBER|COLLABORATOR) author_label="maintainer" ;;
-            *) author_label="community-contribution" ;;
+            *) author_label="" ;;
           esac
 
-          echo "::notice::#${NUMBER} assoc=${ASSOC} type=${type_label:-none} author=${author_label}"
+          echo "::notice::#${NUMBER} assoc=${ASSOC} type=${type_label:-none} author=${author_label:-none}"
 
           # Self-bootstrap the two labels this repo doesn't ship yet (no-op if present).
           gh label create performance --repo "$REPO" --color FEF2C0 \
@@ -91,12 +91,14 @@ jobs:
           add()    { gh api -X POST "repos/$REPO/issues/$NUMBER/labels" -f "labels[]=$1" >/dev/null 2>&1 || true; }
           remove() { gh api -X DELETE "repos/$REPO/issues/$NUMBER/labels/$1" >/dev/null 2>&1 || true; }
 
-          # Author label — exactly one.
+          # Author label — `maintainer` only. The retired `community-contribution`
+          # label is never added and is removed wherever a prior run set it.
           if [ "$author_label" = "maintainer" ]; then
-            add maintainer; remove community-contribution
+            add maintainer
           else
-            add community-contribution; remove maintainer
+            remove maintainer
           fi
+          remove community-contribution
 
           # Perf type — workflow fully owns {optimization, performance}.
           case "$type_label" in


### PR DESCRIPTION
## Summary

Removes the `community-contribution` author label from the auto-label workflow (added in #447). Non-maintainer authors no longer get an author label; `maintainer` is still applied to OWNER / MEMBER / COLLABORATOR. The workflow now always removes `community-contribution`, so any existing ones clear as PRs/issues are next opened or edited.

## Changes

- `*) author_label="community-contribution"` → `author_label=""` — no author label for non-maintainers.
- Author-apply block: `add maintainer` (or `remove maintainer`) plus an unconditional `remove community-contribution` cleanup.
- Updated the header docs and the `::notice::` line (`author=${author_label:-none}`).
- Type labels (optimization / performance / bug) and every other label are unchanged.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [ ] `laptop`
- [ ] `mac`
- [x] CI-only / docs-only
- [ ] Not run locally

### What I ran

GitHub Actions workflow-only change (`.github/workflows/auto-label.yml`) — no runtime, voice, audio, Home Assistant, or Jetson code is touched. Validated locally:

- `bash -n` on the extracted `run:` script — passes.
- `yaml.safe_load` of the workflow — parses clean.
- grep confirms the only remaining `community-contribution` references are the two doc comments and the intentional `remove community-contribution` cleanup line.

### What I observed

`bash -n` clean, YAML parses, diff is 14 insertions / 12 deletions confined to the author-label logic and its docs. The label-classification workflow itself ran green on this PR (the "Apply type + author labels" check). Type detection (perf → optimization/performance, fix/[bug] → bug) is unchanged.

## Test plan

After merge: opening/editing a PR from a non-maintainer applies no author label (and strips any prior `community-contribution`); a maintainer-authored PR still gets `maintainer`.