### PR TITLE
fix(ha): infer entity domain by whole word, not substring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
   the first. A balanced candidate that fails to parse is now retried once with a
   string-aware trailing-comma strip, recovering the correct call for both the
   runtime and BFCL eval paths.
+- **Entity-domain inference matches whole words** (#477): `infer_domain` used
+  substring matching, so the climate term `"ac"` matched inside "b**ac**k" —
+  "open the back blinds" and "lock the back door" mis-routed to the climate
+  domain. It now classifies query tokens through the shared whole-word
+  `entity_fidelity::domain_of_word`, aligning runtime routing with the fidelity
+  guard and BFCL grounding.
 
 ## 1.0.0-alpha.11 - 2026-06-20
 

--- a/crates/genie-core/src/ha/provider.rs
+++ b/crates/genie-core/src/ha/provider.rs
@@ -974,33 +974,13 @@ fn domain_synonyms(domain: &str) -> Vec<String> {
 }
 
 fn infer_domain(query: &str) -> Option<String> {
-    let query = normalize(query);
-    let checks: [(&str, &[&str]); 6] = [
-        ("light", &["light", "lights", "lamp", "lamps"]),
-        ("switch", &["switch", "switches", "plug", "outlet"]),
-        ("fan", &["fan", "fans"]),
-        (
-            "climate",
-            &[
-                "thermostat",
-                "temperature",
-                "warmer",
-                "cooler",
-                "heat",
-                "ac",
-            ],
-        ),
-        (
-            "cover",
-            &[
-                "cover", "covers", "blind", "blinds", "shade", "shades", "curtain", "garage",
-            ],
-        ),
-        ("lock", &["lock", "locks", "unlock", "door lock"]),
-    ];
-
-    for (domain, terms) in checks {
-        if terms.iter().any(|term| query.contains(term)) {
+    let tokens = entity_fidelity::query_tokens(query);
+    for domain in ["light", "switch", "fan", "climate", "cover", "lock"] {
+        let matched = tokens.iter().any(|token| {
+            entity_fidelity::domain_of_word(token) == Some(domain)
+                || (domain == "climate" && matches!(token.as_str(), "warmer" | "cooler"))
+        });
+        if matched {
             return Some(domain.to_string());
         }
     }
@@ -1347,6 +1327,17 @@ mod tests {
             infer_domain("turn off the living room lamps").as_deref(),
             Some("light")
         );
+    }
+
+    #[test]
+    fn infer_domain_matches_whole_words_not_substrings() {
+        assert_eq!(
+            infer_domain("open the back blinds").as_deref(),
+            Some("cover")
+        );
+        assert_eq!(infer_domain("lock the back door").as_deref(), Some("lock"));
+        assert_eq!(infer_domain("set the ac to 70").as_deref(), Some("climate"));
+        assert_eq!(infer_domain("track the package").as_deref(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`infer_domain` (the Home Assistant entity-domain guesser used by `resolve_target_in_graph`) matched its keywords with naked substring containment, so the two-letter climate term `"ac"` matched inside ordinary words. "open the back blinds" and "lock the back door" both inferred the **climate** domain because "b**ac**k" contains "ac" — and since climate is checked before cover and lock, those requests were mis-routed to climate (then failing the domain check at execution).

## Changes

- Replace the substring scan in `infer_domain` with whole-word classification through the shared `entity_fidelity::domain_of_word`, which already does whole-word matching and which `infer_domain`'s sibling is documented to mirror ("mirroring the runtime `infer_domain`").
- Domain priority order (`light, switch, fan, climate, cover, lock`) is preserved, and the two climate synonyms the runtime carried that the shared map lacks (`"warmer"`, `"cooler"`) are kept so existing household phrasing still resolves.
- Net effect: runtime routing is now consistent with the fidelity guard and BFCL grounding, which already classify tokens through the same `domain_of_word`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `laptop`

This is a deterministic, hardware-independent change to the HA resolver's pure `infer_domain` function. No Jetson, audio, model, or network dependency — an x86_64 Linux dev box exercises the same logic that runs on-device. The resolver also backs the BFCL grounded metric, so I ran the full BFCL suite to confirm no scoring regression.

### What I ran

On x86_64 Linux (Ubuntu, kernel 6.8), rustc 1.96.0:

```
cargo test -p genie-core
cargo test -p genie-core --lib infer_domain
cargo clippy -p genie-core --tests
cargo clippy -p genie-core --no-default-features --tests
cargo fmt -p genie-core -- --check
```

I added the regression test first and confirmed it **fails on the current code** before applying the fix.

### What I observed

- Before the fix, `infer_domain("open the back blinds")` returned `Some("climate")` (the test failed: `left: Some("climate")`, `right: Some("cover")`).
- After the fix:
  - `infer_domain("open the back blinds")` → `cover`
  - `infer_domain("lock the back door")` → `lock`
  - `infer_domain("set the ac to 70")` → `climate` (genuine "ac" command still works)
  - `infer_domain("track the package")` → `None` (no false climate match)
  - `infer_domain("make the bedroom warmer")` → `climate`, `infer_domain("turn off the living room lamps")` → `light` (existing test unchanged)
- `cargo test -p genie-core` — **774 passed, 0 failed**, including the full BFCL grounded-metric suite and the resolver tests, so the change is regression-free.
- `clippy` clean in both default and `--no-default-features`; `cargo fmt --check` clean.

## Test plan

1. `cargo test -p genie-core --lib infer_domain` — both tests pass, including `infer_domain_matches_whole_words_not_substrings`.
2. Resolve "open the back blinds" / "lock the back door" against a home that has a `Back` area with cover/lock entities and confirm they no longer resolve to a climate entity.

## Notes for reviewers

`infer_domain` previously carried its own term lists that duplicated (and diverged from) `domain_of_word`. This delegates to the shared classifier, so the lists stay in one place. The only terms `infer_domain` had that `domain_of_word` lacks are `"warmer"`/`"cooler"`, kept inline to preserve current behavior; folding those into `domain_of_word` would be a separate change since it also feeds the fidelity guard.
