### PR TITLE
fix(home): require unanimous group undo_restore snapshot (#480)

### DIFF
--- a/crates/genie-core/src/tools/actuation.rs
+++ b/crates/genie-core/src/tools/actuation.rs
@@ -63,7 +63,7 @@ pub struct PendingConfirmation {
     pub expires_ms: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UndoRestore {
     pub action: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -337,9 +337,8 @@ fn inverse_action(action: &str) -> Option<&'static str> {
     }
 }
 
-/// Capture the `home_control` call that restores `prior` before `action` ran.
-pub fn undo_restore_from_prior(action: &str, prior: &HomeState) -> Option<UndoRestore> {
-    let entity = prior.entities.first()?;
+/// Capture the `home_control` call that restores one entity's pre-action state.
+fn undo_restore_from_entity(action: &str, entity: &crate::ha::Entity) -> Option<UndoRestore> {
     match action {
         "set_brightness" => {
             if entity.state == "off" {
@@ -380,6 +379,27 @@ pub fn undo_restore_from_prior(action: &str, prior: &HomeState) -> Option<UndoRe
         "toggle" => undo_restore_for_power_state(&entity.state),
         _ => None,
     }
+}
+
+/// Capture the `home_control` call that restores `prior` before `action` ran.
+///
+/// For group targets with multiple member entities, every member must agree on
+/// the same restore snapshot; heterogeneous member states return `None` so
+/// `home_undo` does not apply a single group-wide action derived from an
+/// arbitrary first entity (#480).
+pub fn undo_restore_from_prior(action: &str, prior: &HomeState) -> Option<UndoRestore> {
+    let first = prior.entities.first()?;
+    let baseline = undo_restore_from_entity(action, first)?;
+    if prior.entities.len() == 1 {
+        return Some(baseline);
+    }
+
+    prior
+        .entities
+        .iter()
+        .skip(1)
+        .all(|entity| undo_restore_from_entity(action, entity).as_ref() == Some(&baseline))
+        .then_some(baseline)
 }
 
 fn undo_restore_for_power_state(state: &str) -> Option<UndoRestore> {
@@ -1240,6 +1260,63 @@ mod tests {
         let restore = undo_restore_from_prior("set_temperature", &prior_on).unwrap();
         assert_eq!(restore.action, "set_temperature");
         assert_eq!(restore.value, Some(68.0));
+    }
+
+    #[test]
+    fn undo_restore_from_prior_mixed_group_brightness_returns_none() {
+        use crate::ha::Entity;
+
+        let prior = HomeState {
+            target_name: "living room lights".into(),
+            domain: Some("light".into()),
+            area: Some("Living Room".into()),
+            entities: vec![
+                Entity {
+                    entity_id: "light.a".into(),
+                    state: "off".into(),
+                    attributes: serde_json::json!({}),
+                },
+                Entity {
+                    entity_id: "light.b".into(),
+                    state: "on".into(),
+                    attributes: serde_json::json!({ "brightness": 204 }),
+                },
+            ],
+            available: true,
+            spoken_summary: "living room lights".into(),
+        };
+
+        assert!(undo_restore_from_prior("set_brightness", &prior).is_none());
+        assert!(undo_restore_from_prior("toggle", &prior).is_none());
+    }
+
+    #[test]
+    fn undo_restore_from_prior_unanimous_group_brightness_succeeds() {
+        use crate::ha::Entity;
+
+        let prior = HomeState {
+            target_name: "living room lights".into(),
+            domain: Some("light".into()),
+            area: Some("Living Room".into()),
+            entities: vec![
+                Entity {
+                    entity_id: "light.a".into(),
+                    state: "on".into(),
+                    attributes: serde_json::json!({ "brightness": 204 }),
+                },
+                Entity {
+                    entity_id: "light.b".into(),
+                    state: "on".into(),
+                    attributes: serde_json::json!({ "brightness": 204 }),
+                },
+            ],
+            available: true,
+            spoken_summary: "living room lights".into(),
+        };
+
+        let restore = undo_restore_from_prior("set_brightness", &prior).unwrap();
+        assert_eq!(restore.action, "set_brightness");
+        assert!((restore.value.unwrap() - 80.0).abs() < 0.1);
     }
 
     #[test]

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -2521,6 +2521,90 @@ mod tests {
         }
     }
 
+    /// Group target with heterogeneous member states for #480 regression tests.
+    struct MixedGroupHomeProvider {
+        executed: Arc<std::sync::Mutex<Vec<HomeActionKind>>>,
+    }
+
+    impl MixedGroupHomeProvider {
+        fn new(executed: Arc<std::sync::Mutex<Vec<HomeActionKind>>>) -> Self {
+            Self { executed }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl HomeAutomationProvider for MixedGroupHomeProvider {
+        async fn health(&self) -> IntegrationHealth {
+            IntegrationHealth {
+                connected: true,
+                cached_graph: true,
+                message: "ok".into(),
+            }
+        }
+
+        async fn sync_structure(&self) -> Result<HomeGraph> {
+            anyhow::bail!("not used in test")
+        }
+
+        async fn resolve_target(
+            &self,
+            query: &str,
+            _action_hint: Option<HomeActionKind>,
+        ) -> Result<HomeTarget> {
+            Ok(HomeTarget {
+                kind: HomeTargetKind::Group,
+                query: query.into(),
+                display_name: query.into(),
+                entity_ids: vec!["light.a".into(), "light.b".into()],
+                domain: Some("light".into()),
+                area: Some("Living Room".into()),
+                confidence: 0.96,
+                voice_safe: true,
+            })
+        }
+
+        async fn get_state(&self, target: &HomeTarget) -> Result<HomeState> {
+            Ok(HomeState {
+                target_name: target.display_name.clone(),
+                domain: target.domain.clone(),
+                area: target.area.clone(),
+                entities: vec![
+                    Entity {
+                        entity_id: "light.a".into(),
+                        state: "off".into(),
+                        attributes: serde_json::json!({}),
+                    },
+                    Entity {
+                        entity_id: "light.b".into(),
+                        state: "on".into(),
+                        attributes: serde_json::json!({ "brightness": 204 }),
+                    },
+                ],
+                available: true,
+                spoken_summary: format!("{} is mixed", target.display_name),
+            })
+        }
+
+        async fn execute(&self, action: HomeAction) -> Result<ActionResult> {
+            self.executed.lock().unwrap().push(action.kind);
+            Ok(ActionResult {
+                success: true,
+                spoken_summary: format!("Executed {:?}", action.kind),
+                affected_targets: vec![action.target.display_name],
+                state_snapshot: None,
+                confidence: Some(action.target.confidence),
+            })
+        }
+
+        async fn list_scenes(&self, _room: Option<&str>) -> Result<Vec<SceneRef>> {
+            Ok(Vec::new())
+        }
+
+        async fn list_devices(&self, _room: Option<&str>) -> Result<Vec<DeviceRef>> {
+            Ok(Vec::new())
+        }
+    }
+
     #[test]
     fn tool_defs_hide_home_tools_when_unavailable() {
         let dispatcher = ToolDispatcher::new(None);
@@ -3512,6 +3596,57 @@ mod tests {
         );
         assert_eq!(provider_restart.brightness(), Some(255));
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn home_undo_skips_heterogeneous_group_dim_without_wrong_turn_off() {
+        let executed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let dispatcher = ToolDispatcher::new(Some(Arc::new(MixedGroupHomeProvider::new(
+            executed.clone(),
+        ))));
+        let ctx = || ToolExecutionContext {
+            request_origin: RequestOrigin::Dashboard,
+            ..ToolExecutionContext::default()
+        };
+
+        let dim = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "home_control".into(),
+                    arguments: serde_json::json!({
+                        "entity": "living room lights",
+                        "action": "set_brightness",
+                        "value": 30
+                    }),
+                },
+                ctx(),
+            )
+            .await;
+        assert!(dim.success);
+
+        let history = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "action_history".into(),
+                    arguments: serde_json::json!({}),
+                },
+                ctx(),
+            )
+            .await;
+        assert!(history.output.contains("not undoable"));
+
+        let undo = dispatcher
+            .execute_with_context(
+                &ToolCall {
+                    name: "home_undo".into(),
+                    arguments: serde_json::json!({}),
+                },
+                ctx(),
+            )
+            .await;
+        assert!(!undo.success);
+        assert!(undo.output.contains("No recent reversible"));
+        assert_eq!(*executed.lock().unwrap(), vec![HomeActionKind::SetBrightness]);
     }
 
     #[test]

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -3646,7 +3646,10 @@ mod tests {
             .await;
         assert!(!undo.success);
         assert!(undo.output.contains("No recent reversible"));
-        assert_eq!(*executed.lock().unwrap(), vec![HomeActionKind::SetBrightness]);
+        assert_eq!(
+            *executed.lock().unwrap(),
+            vec![HomeActionKind::SetBrightness]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #480

## Summary

`undo_restore_from_prior` no longer derives group undo metadata from `prior.entities.first()` alone. For multi-entity group targets, every member must produce the same restore snapshot; heterogeneous member states skip `undo_restore` capture so `home_undo` cannot issue a wrong group-wide `turn_off` (or other action) based on arbitrary HA state ordering.

## Changes

- Extract per-entity restore logic into `undo_restore_from_entity`.
- `undo_restore_from_prior` requires unanimous restore across all group members; returns `None` when members disagree.
- Add `PartialEq` to `UndoRestore` for snapshot comparison.
- Unit tests: mixed group → `None`; unanimous group → shared `set_brightness` restore.
- Integration test: heterogeneous group dim is recorded as not undoable; `home_undo` fails safely instead of executing a bogus restore.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Linux x86_64 dev host, no live Home Assistant (`MixedGroupHomeProvider` stub with `HomeTargetKind::Group`):

```bash
cd genie-claw
cargo test -p genie-core --lib undo_restore_from_prior
cargo test -p genie-core --lib home_undo_skips_heterogeneous
cargo clippy -p genie-core -- -D warnings
```

### What I observed

- `undo_restore_from_prior_mixed_group_brightness_returns_none` — mixed off/on members → no `undo_restore` for `set_brightness` or `toggle`.
- `undo_restore_from_prior_unanimous_group_brightness_succeeds` — both members on @ 204 → `set_brightness ~80%` restore.
- `home_undo_skips_heterogeneous_group_dim_without_wrong_turn_off` — dim on heterogeneous group records `not undoable` in `action_history`; `home_undo` returns "No recent reversible" with only one `SetBrightness` executed (no erroneous `TurnOff`).
- Clippy clean.

**Validation gap:** Not run on Jetson or live HA area group. Stub exercises the same `get_state` → `undo_restore_from_prior` → ledger → `home_undo` path as production group targets.

## Test plan

- `cargo test -p genie-core --lib undo_restore_from_prior`
- `cargo test -p genie-core --lib home_undo_skips_heterogeneous`
- `cargo test -p genie-core --lib home_undo_restores_prior_brightness_after_dim` (regression: single entity unchanged)
- `cargo clippy -p genie-core -- -D warnings`

## Notes for reviewers

- Conservative fix: heterogeneous groups are not undoable via single `home_control` restore (same limitation as before, but no longer **wrong**). Per-member undo would need a follow-up schema change.
- Single-entity behavior unchanged.
