### PR TITLE
fix(tools): runtime parser accepts OpenAI tool_calls wrapper (#479)

### DIFF
--- a/crates/genie-core/src/tools/parser.rs
+++ b/crates/genie-core/src/tools/parser.rs
@@ -7,6 +7,8 @@ use super::dispatch::{ToolCall, ToolDispatcher, ToolExecutionContext, ToolResult
 /// 2. Markdown code block: ````json\n{"tool": "get_time"}\n````
 /// 3. Embedded in text: `I'll check that. {"tool": "get_weather", "arguments": {"location": "Denver"}}`
 /// 4. With extra fields: `{"tool": "set_timer", "arguments": {"seconds": 300}, "reasoning": "..."}`
+/// 5. OpenAI-compatible wrappers: `{"tool_calls": [...]}` or `{"function_call": {...}}` (#479)
+/// 6. Top-level JSON arrays of tool calls (first call only at runtime)
 pub async fn try_tool_call(response: &str, tools: &ToolDispatcher) -> Option<ToolResult> {
     try_tool_call_with_context(response, tools, ToolExecutionContext::default()).await
 }
@@ -41,11 +43,33 @@ pub const UNPARSED_TOOL_CALL_FALLBACK: &str =
 /// therefore handled by `try_tool_call_with_context`), returns false.
 pub fn is_unparsed_tool_call(response: &str) -> bool {
     let trimmed = response.trim();
-    let looks_toolish = (trimmed.starts_with('{') || trimmed.starts_with("```"))
+    let looks_toolish = (trimmed.starts_with('{')
+        || trimmed.starts_with('[')
+        || trimmed.starts_with("```"))
         && (trimmed.contains("\"tool\"")
             || trimmed.contains("\"arguments\"")
-            || trimmed.contains("\"name\""));
-    looks_toolish && extract_json(response).is_none()
+            || trimmed.contains("\"name\"")
+            || trimmed.contains("\"tool_calls\"")
+            || trimmed.contains("\"function_call\""));
+
+    let Some(json_str) = extract_json(response) else {
+        return looks_toolish;
+    };
+
+    if serde_json::from_str::<serde_json::Value>(&json_str).is_err() {
+        return looks_toolish;
+    }
+
+    // Malformed OpenAI / array wrappers that still parse as JSON (#479).
+    if (trimmed.contains("\"tool_calls\"")
+        || trimmed.contains("\"function_call\"")
+        || trimmed.starts_with('['))
+        && parse_tool_calls_for_eval(response).is_empty()
+    {
+        return true;
+    }
+
+    false
 }
 
 /// Parse tool calls from model output without executing them.
@@ -66,11 +90,19 @@ pub fn parse_tool_calls_for_eval(response: &str) -> Vec<ToolCall> {
 }
 
 fn parse_tool_call_value(value: serde_json::Value, tools: &ToolDispatcher) -> Option<ToolCall> {
-    if let Ok(call) = serde_json::from_value::<ToolCall>(value.clone()) {
+    if let Ok(call) = serde_json::from_value::<ToolCall>(value.clone())
+        && !call.name.is_empty()
+    {
         return Some(call);
     }
 
-    normalize_single_key_tool_call(value, tools)
+    if let Some(call) = normalize_single_key_tool_call(value.clone(), tools) {
+        return Some(call);
+    }
+
+    // OpenAI `tool_calls` / `function_call` wrappers and JSON arrays — runtime
+    // dispatches the first call only, matching BFCL eval parsing (#479).
+    parse_tool_call_value_for_eval(value).into_iter().next()
 }
 
 fn normalize_single_key_tool_call(
@@ -650,6 +682,39 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "home_control");
         assert_eq!(calls[0].arguments["entity"], "kitchen light");
+    }
+
+    #[tokio::test]
+    async fn try_tool_call_accepts_openai_tool_calls_wrapper() {
+        let dispatcher = ToolDispatcher::new(None);
+        let input = r#"{"tool_calls":[{"type":"function","function":{"name":"calculate","arguments":"{\"expression\":\"2+2\"}"}}]}"#;
+
+        let result = try_tool_call(input, &dispatcher).await.unwrap();
+        assert_eq!(result.tool, "calculate");
+        assert!(result.success);
+        assert!(result.output.contains('4'), "output: {}", result.output);
+    }
+
+    #[tokio::test]
+    async fn try_tool_call_accepts_json_array_first_call_only() {
+        let dispatcher = ToolDispatcher::new(None);
+        let input = r#"[{"tool": "get_time", "arguments": {}}, {"tool": "set_timer", "arguments": {"seconds": 60}}]"#;
+
+        let result = try_tool_call(input, &dispatcher).await.unwrap();
+        assert_eq!(result.tool, "get_time");
+        assert!(result.success);
+    }
+
+    #[test]
+    fn openai_tool_calls_wrapper_is_not_flagged_as_unparsed() {
+        let ok = r#"{"tool_calls":[{"type":"function","function":{"name":"calculate","arguments":"{\"expression\":\"1+1\"}"}}]}"#;
+        assert!(!is_unparsed_tool_call(ok));
+    }
+
+    #[test]
+    fn malformed_openai_tool_calls_wrapper_is_unparsed() {
+        let broken = r#"{"tool_calls":[{"type":"function","function":{"name":"","arguments":"{}"}}]}"#;
+        assert!(is_unparsed_tool_call(broken));
     }
 
     #[test]

--- a/crates/genie-core/src/tools/parser.rs
+++ b/crates/genie-core/src/tools/parser.rs
@@ -43,14 +43,13 @@ pub const UNPARSED_TOOL_CALL_FALLBACK: &str =
 /// therefore handled by `try_tool_call_with_context`), returns false.
 pub fn is_unparsed_tool_call(response: &str) -> bool {
     let trimmed = response.trim();
-    let looks_toolish = (trimmed.starts_with('{')
-        || trimmed.starts_with('[')
-        || trimmed.starts_with("```"))
-        && (trimmed.contains("\"tool\"")
-            || trimmed.contains("\"arguments\"")
-            || trimmed.contains("\"name\"")
-            || trimmed.contains("\"tool_calls\"")
-            || trimmed.contains("\"function_call\""));
+    let looks_toolish =
+        (trimmed.starts_with('{') || trimmed.starts_with('[') || trimmed.starts_with("```"))
+            && (trimmed.contains("\"tool\"")
+                || trimmed.contains("\"arguments\"")
+                || trimmed.contains("\"name\"")
+                || trimmed.contains("\"tool_calls\"")
+                || trimmed.contains("\"function_call\""));
 
     let Some(json_str) = extract_json(response) else {
         return looks_toolish;
@@ -713,7 +712,8 @@ mod tests {
 
     #[test]
     fn malformed_openai_tool_calls_wrapper_is_unparsed() {
-        let broken = r#"{"tool_calls":[{"type":"function","function":{"name":"","arguments":"{}"}}]}"#;
+        let broken =
+            r#"{"tool_calls":[{"type":"function","function":{"name":"","arguments":"{}"}}]}"#;
         assert!(is_unparsed_tool_call(broken));
     }
 


### PR DESCRIPTION
Fixes #479

## Summary

Runtime tool dispatch (`try_tool_call_with_context` → `parse_tool_call_value`) now accepts the same OpenAI-compatible `tool_calls` / `function_call` wrappers and top-level JSON arrays that BFCL eval parsing already handled. The first call is dispatched at runtime; malformed wrappers fall through to the `#378` unparsed fallback instead of leaking raw JSON to the user.

## Changes

- `parse_tool_call_value` delegates to `parse_tool_call_value_for_eval` after native and single-key compact shapes.
- `is_unparsed_tool_call` recognizes `tool_calls` / `function_call` / array wrappers; flags malformed wrappers that parse as JSON but yield no tool call.
- Runtime tests mirror eval coverage for OpenAI wrapper and JSON-array first-call dispatch.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Linux x86_64 dev host, stub `ToolDispatcher` (no HA / network):

```bash
cd genie-claw
cargo test -p genie-core --lib openai_tool_calls
cargo test -p genie-core --lib try_tool_call_accepts
cargo test -p genie-core --lib unparsed_tool_call
cargo clippy -p genie-core -- -D warnings
```

### What I observed

- `try_tool_call_accepts_openai_tool_calls_wrapper` — `{"tool_calls":[...calculate...]}` executes `calculate` and returns `4` for `2+2`.
- `try_tool_call_accepts_json_array_first_call_only` — array dispatches first `get_time` call.
- `openai_tool_calls_wrapper_is_not_flagged_as_unparsed` — valid wrapper no longer treated as normal assistant text path.
- `malformed_openai_tool_calls_wrapper_is_unparsed` — empty tool name triggers `#378` fallback class.
- Existing `#378` unparsed tests still pass. Clippy clean.

**Validation gap:** Not run on Jetson or through live chat/voice loop. Same `try_tool_call_with_context` entry point as `server.rs` / `voice_loop.rs`.

## Test plan

- `cargo test -p genie-core --lib openai_tool_calls`
- `cargo test -p genie-core --lib try_tool_call_accepts`
- `cargo test -p genie-core --lib unparsed_tool_call`
- `cargo test -p genie-core --lib try_tool_call_recovers_scalar_single_key_calculate` (regression: compact shape unchanged)
- `cargo clippy -p genie-core -- -D warnings`

## Notes for reviewers

- Runtime still dispatches **first** call only from arrays / `tool_calls` (same as eval's first-element semantics for BFCL).
- Single-key compact path still validates against `tool_defs` before eval fallback, preserving unknown-tool rejection for `{"unknown_tool": ...}`.
