### PR TITLE
perf(voice): single-pass TTS text cleanup in for_voice

### DIFF
--- a/crates/genie-core/src/voice/format.rs
+++ b/crates/genie-core/src/voice/format.rs
@@ -132,20 +132,26 @@ fn strip_links(text: &str) -> String {
 }
 
 fn strip_raw_urls(text: &str) -> String {
-    text.split_whitespace()
-        .filter(|token| {
-            let trimmed = token.trim_matches(|c: char| {
-                matches!(
-                    c,
-                    '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';' | ':' | '"' | '\''
-                )
-            });
-            !(trimmed.starts_with("http://")
-                || trimmed.starts_with("https://")
-                || trimmed.starts_with("www."))
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+    let mut result = String::with_capacity(text.len());
+    for token in text.split_whitespace() {
+        let trimmed = token.trim_matches(|c: char| {
+            matches!(
+                c,
+                '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';' | ':' | '"' | '\''
+            )
+        });
+        if trimmed.starts_with("http://")
+            || trimmed.starts_with("https://")
+            || trimmed.starts_with("www.")
+        {
+            continue;
+        }
+        if !result.is_empty() {
+            result.push(' ');
+        }
+        result.push_str(token);
+    }
+    result
 }
 
 /// Normalize whitespace: collapse multiple spaces, trim.
@@ -200,7 +206,8 @@ fn truncate_for_voice(text: &str, max_sentences: usize) -> String {
     }
 
     let chars: Vec<char> = text.chars().collect();
-    let mut sentences = Vec::new();
+    let mut result = String::with_capacity(text.len());
+    let mut sentence_count = 0;
     let mut current = String::new();
 
     for (i, &ch) in chars.iter().enumerate() {
@@ -227,21 +234,28 @@ fn truncate_for_voice(text: &str, max_sentences: usize) -> String {
         };
 
         if ends_sentence {
-            sentences.push(current.trim().to_string());
+            if !result.is_empty() {
+                result.push(' ');
+            }
+            result.push_str(current.trim());
+            sentence_count += 1;
             current.clear();
-            if sentences.len() >= max_sentences {
+            if sentence_count >= max_sentences {
                 break;
             }
         }
     }
 
     // Include the trailing fragment if we still have room.
-    let trailing = current.trim().to_string();
-    if !trailing.is_empty() && sentences.len() < max_sentences {
-        sentences.push(trailing);
+    let trailing = current.trim();
+    if !trailing.is_empty() && sentence_count < max_sentences {
+        if !result.is_empty() {
+            result.push(' ');
+        }
+        result.push_str(trailing);
     }
 
-    sentences.join(" ")
+    result
 }
 
 fn is_ascii_terminator(ch: char) -> bool {
@@ -269,166 +283,20 @@ fn ends_with_abbreviation(current: &str) -> bool {
 
 /// Clean special characters that TTS engines handle poorly.
 fn clean_for_tts(text: &str) -> String {
-    text.replace("...", ", ")
+    let pre = text
+        .replace("...", ", ")
         .replace(" - ", ", ")
         .replace(" — ", ", ")
-        .replace(" – ", ", ")
-        .replace("(", ", ")
-        .replace(")", ", ")
-        .replace("[", "")
-        .replace("]", "")
-        .replace("{", "")
-        .replace("}", "")
-        .replace("\"", "")
-        .replace("'s", "s") // possessive sounds weird with some TTS
-}
+        .replace(" – ", ", ");
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn strip_bold_and_italic() {
-        assert_eq!(
-            for_voice("This is **bold** and *italic*"),
-            "This is bold and italic"
-        );
+    let mut result = String::with_capacity(pre.len());
+    for ch in pre.chars() {
+        match ch {
+            '(' | ')' => result.push_str(", "),
+            '[' | ']' | '{' | '}' | '"' => {}
+            _ => result.push(ch),
+        }
     }
 
-    #[test]
-    fn strip_markdown_headers() {
-        assert_eq!(for_voice("## Weather\nIt's sunny."), "Weather Its sunny.");
-    }
-
-    #[test]
-    fn strip_bullet_points() {
-        let input = "Here's what I found:\n- Item one\n- Item two\n- Item three";
-        let output = for_voice(input);
-        assert!(output.contains("Item one"));
-        assert!(!output.contains("- "));
-    }
-
-    #[test]
-    fn strip_code_blocks() {
-        let input = "Here's the code:\n```\nlet x = 5;\n```\nThat's it.";
-        let output = for_voice(input);
-        assert!(!output.contains("let x"));
-        assert!(output.contains("Thats it"));
-    }
-
-    #[test]
-    fn strip_links() {
-        let input = "Check [this guide](https://example.com) for details.";
-        let output = for_voice(input);
-        assert!(output.contains("this guide"));
-        assert!(!output.contains("https://"));
-    }
-
-    #[test]
-    fn strip_raw_urls_from_plain_text() {
-        let input = "Top result: ESP32-C6 supports Thread. https://example.com/thread";
-        let output = for_voice(input);
-        assert!(output.contains("ESP32-C6 supports Thread"));
-        assert!(!output.contains("https://"));
-    }
-
-    #[test]
-    fn truncate_long_response() {
-        let input =
-            "First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence.";
-        let output = for_voice(input);
-        assert!(output.contains("First"));
-        assert!(output.contains("Third"));
-        assert!(!output.contains("Fourth"));
-    }
-
-    #[test]
-    fn truncate_handles_chinese_punctuation() {
-        let input = "第一句。第二句！第三句？第四句。";
-        let output = for_voice(input);
-        assert!(output.contains("第一句"));
-        assert!(output.contains("第三句"));
-        assert!(!output.contains("第四句"));
-    }
-
-    #[test]
-    fn clean_special_chars() {
-        let input = "The temperature is 72°F (about 22°C)...nice!";
-        let output = for_voice(input);
-        assert!(!output.contains("("));
-        assert!(!output.contains("..."));
-    }
-
-    #[test]
-    fn empty_input() {
-        assert_eq!(for_voice(""), "");
-    }
-
-    #[test]
-    fn already_clean() {
-        assert_eq!(for_voice("The lights are on."), "The lights are on.");
-    }
-
-    #[test]
-    fn decimal_numbers_are_not_split() {
-        let output = for_voice("It is 72.5 degrees outside and feels warm.");
-        assert!(
-            output.contains("72.5"),
-            "decimal must stay intact, got {output:?}"
-        );
-        assert!(
-            !output.contains("72. 5"),
-            "decimal must not be split, got {output:?}"
-        );
-    }
-
-    #[test]
-    fn version_strings_are_not_split() {
-        let output = for_voice("Version v1.0.0 is installed and ready.");
-        assert!(
-            output.contains("v1.0.0"),
-            "version dots must stay intact, got {output:?}"
-        );
-    }
-
-    #[test]
-    fn abbreviations_do_not_end_a_sentence() {
-        let output = for_voice("Dinner is at 6 p.m. today in the kitchen.");
-        // "p.m." must survive intact — no split at "p." or "p.m. " mid-clause.
-        assert!(
-            output.contains("p.m."),
-            "abbreviation must stay intact, got {output:?}"
-        );
-        assert!(
-            !output.contains("p. m."),
-            "abbreviation must not be split, got {output:?}"
-        );
-        assert!(
-            output.contains("today in the kitchen"),
-            "clause after the abbreviation must remain, got {output:?}"
-        );
-    }
-
-    #[test]
-    fn cap_counts_real_sentences_not_decimal_fragments() {
-        // Before the fix, "3.50" split into two fake sentences and burned the
-        // 3-sentence budget, dropping "All systems normal." entirely.
-        let output =
-            for_voice("The CPU is at 3.50 GHz now. Memory usage is fine. All systems normal.");
-        assert!(output.contains("3.50 GHz"), "got {output:?}");
-        assert!(output.contains("Memory usage is fine"), "got {output:?}");
-        assert!(
-            output.contains("All systems normal"),
-            "the third real sentence must not be dropped, got {output:?}"
-        );
-    }
-
-    #[test]
-    fn chinese_punctuation_still_segments_immediately() {
-        // CJK terminators have no trailing space; they must still split.
-        let output = for_voice("第一句。第二句！第三句？第四句。");
-        assert!(output.contains("第一句"));
-        assert!(output.contains("第三句"));
-        assert!(!output.contains("第四句"));
-    }
+    result.replace("'s", "s")
 }

--- a/crates/genie-core/tests/voice_format_bench.rs
+++ b/crates/genie-core/tests/voice_format_bench.rs
@@ -1,0 +1,51 @@
+#![cfg(feature = "voice")]
+use genie_core::voice::format::for_voice;
+use std::hint::black_box;
+
+fn short_reply() -> String {
+    "Sure! The **living room** lights are on and set to *warm white* \
+     (about 2700K). Let me know if you'd like them dimmed."
+        .to_string()
+}
+
+fn long_reply() -> String {
+    "## Here's what I found\n\
+     The thermostat is set to 72.5 degrees — comfortable for the evening. \
+     Here are the highlights:\n\
+     - The **kitchen** lights are off.\n\
+     - The *bedroom* fan is running at low.\n\
+     - See [the energy report](https://example.com/report) for details.\n\
+     1. Living room: 21°C now.\n\
+     2. Office: 22°C now.\n\
+     Note: visit https://example.com or www.example.org to adjust schedules. \
+     It's the house's quiet hour now... everything looks normal!"
+        .to_string()
+}
+
+fn run(label: &str, input: &str, iters: u32) {
+    for _ in 0..1000 {
+        black_box(for_voice(black_box(input)));
+    }
+    let start = std::time::Instant::now();
+    let mut acc = 0usize;
+    for _ in 0..iters {
+        acc += black_box(for_voice(black_box(input))).len();
+    }
+    let elapsed = start.elapsed();
+    black_box(acc);
+    eprintln!(
+        "BENCH for_voice [{label}]: {} bytes in, {iters} calls, total {elapsed:?}, \
+         per-call {:?}",
+        input.len(),
+        elapsed / iters,
+    );
+}
+
+#[test]
+#[ignore = "benchmark; run with --release --ignored --nocapture"]
+fn bench_for_voice() {
+    let short = short_reply();
+    let long = long_reply();
+    run("short", &short, 300_000);
+    run("long", &long, 300_000);
+}

--- a/crates/genie-core/tests/voice_format_test.rs
+++ b/crates/genie-core/tests/voice_format_test.rs
@@ -1,0 +1,141 @@
+#![cfg(feature = "voice")]
+use genie_core::voice::format::for_voice;
+
+#[test]
+fn strip_bold_and_italic() {
+    assert_eq!(
+        for_voice("This is **bold** and *italic*"),
+        "This is bold and italic"
+    );
+}
+
+#[test]
+fn strip_markdown_headers() {
+    assert_eq!(for_voice("## Weather\nIt's sunny."), "Weather Its sunny.");
+}
+
+#[test]
+fn strip_bullet_points() {
+    let input = "Here's what I found:\n- Item one\n- Item two\n- Item three";
+    let output = for_voice(input);
+    assert!(output.contains("Item one"));
+    assert!(!output.contains("- "));
+}
+
+#[test]
+fn strip_code_blocks() {
+    let input = "Here's the code:\n```\nlet x = 5;\n```\nThat's it.";
+    let output = for_voice(input);
+    assert!(!output.contains("let x"));
+    assert!(output.contains("Thats it"));
+}
+
+#[test]
+fn strip_links() {
+    let input = "Check [this guide](https://example.com) for details.";
+    let output = for_voice(input);
+    assert!(output.contains("this guide"));
+    assert!(!output.contains("https://"));
+}
+
+#[test]
+fn strip_raw_urls_from_plain_text() {
+    let input = "Top result: ESP32-C6 supports Thread. https://example.com/thread";
+    let output = for_voice(input);
+    assert!(output.contains("ESP32-C6 supports Thread"));
+    assert!(!output.contains("https://"));
+}
+
+#[test]
+fn truncate_long_response() {
+    let input = "First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence.";
+    let output = for_voice(input);
+    assert!(output.contains("First"));
+    assert!(output.contains("Third"));
+    assert!(!output.contains("Fourth"));
+}
+
+#[test]
+fn truncate_handles_chinese_punctuation() {
+    let input = "第一句。第二句！第三句？第四句。";
+    let output = for_voice(input);
+    assert!(output.contains("第一句"));
+    assert!(output.contains("第三句"));
+    assert!(!output.contains("第四句"));
+}
+
+#[test]
+fn clean_special_chars() {
+    let input = "The temperature is 72°F (about 22°C)...nice!";
+    let output = for_voice(input);
+    assert!(!output.contains("("));
+    assert!(!output.contains("..."));
+}
+
+#[test]
+fn empty_input() {
+    assert_eq!(for_voice(""), "");
+}
+
+#[test]
+fn already_clean() {
+    assert_eq!(for_voice("The lights are on."), "The lights are on.");
+}
+
+#[test]
+fn decimal_numbers_are_not_split() {
+    let output = for_voice("It is 72.5 degrees outside and feels warm.");
+    assert!(
+        output.contains("72.5"),
+        "decimal must stay intact, got {output:?}"
+    );
+    assert!(
+        !output.contains("72. 5"),
+        "decimal must not be split, got {output:?}"
+    );
+}
+
+#[test]
+fn version_strings_are_not_split() {
+    let output = for_voice("Version v1.0.0 is installed and ready.");
+    assert!(
+        output.contains("v1.0.0"),
+        "version dots must stay intact, got {output:?}"
+    );
+}
+
+#[test]
+fn abbreviations_do_not_end_a_sentence() {
+    let output = for_voice("Dinner is at 6 p.m. today in the kitchen.");
+    assert!(
+        output.contains("p.m."),
+        "abbreviation must stay intact, got {output:?}"
+    );
+    assert!(
+        !output.contains("p. m."),
+        "abbreviation must not be split, got {output:?}"
+    );
+    assert!(
+        output.contains("today in the kitchen"),
+        "clause after the abbreviation must remain, got {output:?}"
+    );
+}
+
+#[test]
+fn cap_counts_real_sentences_not_decimal_fragments() {
+    let output = for_voice("The CPU is at 3.50 GHz now. Memory usage is fine. All systems normal.");
+    assert!(output.contains("3.50 GHz"), "got {output:?}");
+    assert!(output.contains("Memory usage is fine"), "got {output:?}");
+    assert!(
+        output.contains("All systems normal"),
+        "the third real sentence must not be dropped, got {output:?}"
+    );
+}
+
+#[test]
+fn chinese_punctuation_still_segments_immediately() {
+    let output = for_voice("第一句。第二句！第三句？第四句。");
+    assert!(output.contains("第一句"));
+    assert!(output.contains("第三句"));
+    assert!(!output.contains("第四句"));
+}


### PR DESCRIPTION
## Summary

`for_voice` cleans every spoken assistant reply before TTS, and it was a multi-pass, allocation-heavy pipeline. The biggest offender, `clean_for_tts`, chained **twelve** whole-buffer `String::replace` calls (one allocation each); `strip_raw_urls` built a `Vec<&str>` then `join`'d it; and `truncate_for_voice` collected a `Vec<String>` of per-sentence clones then `join`'d. This collapses the **order-independent** work into single passes while preserving the **order-sensitive** rewrites exactly, so the output is byte-for-byte identical. Measured **~1.14–1.27× faster** on the Jetson Orin Nano. Contributes under #402 (performance bucket).

## Changes

- `crates/genie-core/src/voice/format.rs`:
  - `clean_for_tts`: keep the four ordered multi-char replaces (`...`, ` - `, ` — `, ` – ` — their overlapping-space behavior is order-dependent) and the trailing possessive `'s`→`s`, but fold the seven single-char rules (`(`/`)`→`, `, and dropping `[`/`]`/`{`/`}`/`"`) into **one** char-scan pass. 12 allocations → 6.
  - `strip_raw_urls`: stream the kept tokens straight into the result `String` instead of building a `Vec<&str>` and `join`-ing it.
  - `truncate_for_voice`: accumulate the kept sentences into a single `String` with a running count instead of a `Vec<String>` + per-sentence `to_string()` clones + `join`.
- Tests: the 16 existing `for_voice` tests only exercise the public API, so they move to `crates/genie-core/tests/voice_format_test.rs` (integration). `crates/genie-core/tests/voice_format_bench.rs` adds an ignored microbench. Both are gated `#![cfg(feature = "voice")]` so the `--no-default-features` build stays green.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware.
- [ ] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

On the target **Jetson Orin Nano** (Engineering Reference Developer Kit Super, 8 GB), L4T R36.4.7, `Linux 5.15.148-tegra aarch64`, `rustc 1.95.0`, **release** profile (`opt-level="z"`, LTO disabled only to speed the build). Cloned current `main` into a tmpfs target dir, added the new ignored microbench (`voice_format_bench.rs`, two representative replies — a short one-liner and a markdown/list/link/URL/ellipsis-heavy long reply), ran it on `main`, then applied this change and reran (3× each):

```
cargo test -p genie-core --release --test voice_format_bench -- --ignored --nocapture
```

**Correctness was proven separately and exhaustively:** a differential fuzz harness ran the new `for_voice` against the original over **400,000 randomized inputs** (drawn from a charset of markdown markers, dashes, brackets, quotes, CJK terminators, URLs, digits and whitespace) plus a fixed markdown/punctuation corpus, asserting **byte-identical** output. It caught three real edge cases during development (cross-rule `'s`/`"` adjacency, hyphen/em-dash shared-space priority, and `**`/`__` removal ordering) — which is why the order-sensitive replaces are kept intact. The 16 relocated tests pass, and `cargo fmt --check` + `cargo clippy --tests` + `cargo clippy --no-default-features --tests` are clean.

### What I observed

`for_voice`, 300,000 calls/run, 3 runs each (medians shown):

| corpus | before (multi-pass) | after (single-pass) | speedup |
| --- | --- | --- | --- |
| short (117 B) | 14.71 µs/call | 11.62 µs/call | ~1.27× |
| long (439 B) | 31.16 µs/call | 27.42 µs/call | ~1.14× |

- Stable across runs (before short 14.64–14.71 µs; after short 11.61–11.62 µs). The gain is the eliminated allocations: `clean_for_tts` 12 whole-buffer passes → 6, plus the dropped `Vec` in `strip_raw_urls` and the dropped `Vec<String>` + per-sentence clones in `truncate_for_voice`.
- Output is unchanged (differential fuzz + the 16 tests). On an x86_64 dev box the same bench shows ~1.21× (short) / ~1.14× (long).

### Test plan

- `cargo test -p genie-core --test voice_format_test` (behavior unchanged; 16 tests)
- `cargo test -p genie-core --release --test voice_format_bench -- --ignored --nocapture` on `main` vs this branch to reproduce the table.

## Notes for reviewers

- **Scope is honest:** `for_voice` runs once per reply, not per audio frame, so this is a steady efficiency win on the reply path (fewer allocations, lower fragmentation), not a headline end-to-end latency change. It removes real redundant work with a reproducible on-device delta.
- **Behavior-preserving by construction:** the order-sensitive rewrites (the four multi-char replaces and possessive `'s`) are kept as-is precisely because fusing them changes output in edge cases; only the order-independent single-char rules and the `Vec`/`join` assembly were rewritten. The differential fuzz is the guarantee.
- **Test move:** `for_voice`'s tests are black-box (public API only), so they belong as an integration test in `tests/`; this also lets the microbench live beside them. No coverage is lost.
- No new behavior, config, or schema.
