### PR TITLE
fix(tools): unify web_search validation on voice and HTTP paths (#485)

### DIFF
--- a/crates/genie-core/src/server.rs
+++ b/crates/genie-core/src/server.rs
@@ -1999,20 +1999,13 @@ async fn handle_web_search(
         );
     }
 
-    let limit = parsed
-        .get("limit")
-        .and_then(|value| value.as_u64())
-        .unwrap_or(3)
-        .clamp(1, 5);
-    let fresh = parsed
-        .get("fresh")
-        .or_else(|| parsed.get("cache_bypass"))
-        .and_then(|value| value.as_bool())
-        .unwrap_or(false);
-    match tools
-        .web_search_response(query, limit as usize, fresh)
-        .await
-    {
+    let (query, limit, fresh) = match crate::tools::dispatch::parse_web_search_args(&parsed) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return (400, "application/json", format!(r#"{{"error":"{error}"}}"#));
+        }
+    };
+    match tools.web_search_response(&query, limit, fresh).await {
         Ok(result) => {
             let body = serde_json::json!({
                 "tool": "web_search",
@@ -2763,6 +2756,16 @@ mod tests {
 
         assert_eq!(status, 400);
         assert!(body.contains("missing query"));
+    }
+
+    #[tokio::test]
+    async fn web_search_endpoint_rejects_string_limit() {
+        let tools = ToolDispatcher::new(None);
+        let (status, _, body) =
+            handle_web_search(Some(r#"{"query":"rust","limit":"5"}"#), &tools).await;
+
+        assert_eq!(status, 400);
+        assert!(body.contains("web_search 'limit' must be an integer when provided"));
     }
 
     #[tokio::test]

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -2818,10 +2818,9 @@ mod tests {
         assert!(
             parse_web_search_fresh(&serde_json::json!({"query": "rust", "fresh": true})).unwrap()
         );
-        assert_eq!(
-            parse_web_search_fresh(&serde_json::json!({"query": "rust", "cache_bypass": false}))
-                .unwrap(),
-            false
+        assert!(
+            !parse_web_search_fresh(&serde_json::json!({"query": "rust", "cache_bypass": false}))
+                .unwrap()
         );
 
         for bad in [

--- a/crates/genie-core/src/tools/dispatch.rs
+++ b/crates/genie-core/src/tools/dispatch.rs
@@ -236,6 +236,26 @@ fn parse_web_search_limit(args: &serde_json::Value) -> Result<usize> {
     }
 }
 
+/// `fresh` / `cache_bypass` stay optional — absent or null defaults to false. A
+/// provided value must be a real boolean (same boundary as `get_weather` forecast).
+fn parse_web_search_fresh(args: &serde_json::Value) -> Result<bool> {
+    match args.get("fresh").or_else(|| args.get("cache_bypass")) {
+        None | Some(serde_json::Value::Null) => Ok(false),
+        Some(serde_json::Value::Bool(value)) => Ok(*value),
+        Some(_) => Err(anyhow::anyhow!(
+            "web_search 'fresh' must be a boolean when provided"
+        )),
+    }
+}
+
+pub(crate) fn parse_web_search_args(args: &serde_json::Value) -> Result<(String, usize, bool)> {
+    Ok((
+        parse_web_search_query(args)?.to_string(),
+        parse_web_search_limit(args)?,
+        parse_web_search_fresh(args)?,
+    ))
+}
+
 fn parse_get_weather_location(args: &serde_json::Value) -> Result<&str> {
     args.get("location")
         .and_then(|v| v.as_str())
@@ -2182,15 +2202,8 @@ async fn exec_weather(args: &serde_json::Value) -> Result<String> {
 }
 
 async fn exec_web_search(args: &serde_json::Value, config: &WebSearchConfig) -> Result<String> {
-    let query = parse_web_search_query(args)?;
-    let limit = parse_web_search_limit(args)?;
-    let fresh = args
-        .get("fresh")
-        .or_else(|| args.get("cache_bypass"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-
-    super::web_search::search_with_options(query, limit, config, fresh).await
+    let (query, limit, fresh) = parse_web_search_args(args)?;
+    super::web_search::search_with_options(&query, limit, config, fresh).await
 }
 
 fn get_current_time() -> String {
@@ -2797,6 +2810,43 @@ mod tests {
                 "unexpected error: {err}"
             );
         }
+    }
+
+    #[test]
+    fn web_search_fresh_must_be_boolean_when_provided() {
+        assert!(!parse_web_search_fresh(&serde_json::json!({"query": "rust"})).unwrap());
+        assert!(
+            parse_web_search_fresh(&serde_json::json!({"query": "rust", "fresh": true})).unwrap()
+        );
+        assert_eq!(
+            parse_web_search_fresh(&serde_json::json!({"query": "rust", "cache_bypass": false}))
+                .unwrap(),
+            false
+        );
+
+        for bad in [
+            serde_json::json!({"query": "rust", "fresh": "true"}),
+            serde_json::json!({"query": "rust", "fresh": 1}),
+        ] {
+            let err = parse_web_search_fresh(&bad)
+                .expect_err("non-boolean fresh must be rejected")
+                .to_string();
+            assert!(
+                err.contains("web_search 'fresh' must be a boolean when provided"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_web_search_args_rejects_string_limit() {
+        let err = parse_web_search_args(&serde_json::json!({"query": "rust", "limit": "5"}))
+            .expect_err("string limit must be rejected")
+            .to_string();
+        assert!(
+            err.contains("web_search 'limit' must be an integer when provided"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/genie-core/src/voice_loop.rs
+++ b/crates/genie-core/src/voice_loop.rs
@@ -726,26 +726,28 @@ async fn handle_quick_tool_for_voice(
             return Some(response);
         }
 
-        let query = call
-            .arguments
-            .get("query")
-            .and_then(|value| value.as_str())
-            .unwrap_or("")
-            .trim();
-        let limit = call
-            .arguments
-            .get("limit")
-            .and_then(|value| value.as_u64())
-            .unwrap_or(3) as usize;
-        let fresh = call
-            .arguments
-            .get("fresh")
-            .and_then(|value| value.as_bool())
-            .unwrap_or(false);
+        let (query, limit, fresh) =
+            match crate::tools::dispatch::parse_web_search_args(&call.arguments) {
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    let response =
+                        crate::security::sandbox::sanitize_output(&format!("Tool error: {error}"));
+                    let started = std::time::Instant::now();
+                    tools.audit_gated_tool(&call, exec_ctx, started, false, &response);
+                    conversations.append_or_log(conv_id, "assistant", &response, None);
+                    let tts_engine =
+                        tts_engine_for_language(voice_cfg, audio_device, response_language);
+                    let voice_text = format::for_voice(&response);
+                    if !voice_text.is_empty() {
+                        let _ = tts_engine.speak(&voice_text).await;
+                    }
+                    return Some(response);
+                }
+            };
 
         let started = std::time::Instant::now();
         let (response, voice_response, success) =
-            match tools.web_search_response(query, limit, fresh).await {
+            match tools.web_search_response(&query, limit, fresh).await {
                 Ok(result) => {
                     let voice_response = result.render_voice();
                     (result.response, voice_response, true)

--- a/crates/genie-core/tests/tool_gate_integration_test.rs
+++ b/crates/genie-core/tests/tool_gate_integration_test.rs
@@ -1244,6 +1244,10 @@ async fn web_search_rejects_invalid_arguments_and_audits() {
             serde_json::json!({"query": "rust news", "limit": -1}),
             "web_search 'limit' must be an integer when provided",
         ),
+        (
+            serde_json::json!({"query": "rust news", "fresh": "true"}),
+            "web_search 'fresh' must be a boolean when provided",
+        ),
     ];
     let expected_audit_count = invalid_calls.len();
 


### PR DESCRIPTION
Fixes #485
Closes #462

## Summary

Complete typed `web_search` argument validation on the voice fast-path and `POST /api/web-search` handler. Both previously used `as_u64().unwrap_or(3)` and silently coerced string limits; they now share `parse_web_search_args` with tool dispatch. Also adds `parse_web_search_fresh` so `"fresh": "true"` is rejected instead of silently becoming `false`.

## Changes

- Add `parse_web_search_fresh` and `pub(crate) parse_web_search_args` in `dispatch.rs`.
- Wire `exec_web_search`, `voice_loop` web_search fast-path, and `handle_web_search` through shared parsers.
- Unit + integration + HTTP endpoint tests for string `limit` and string `fresh`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

Linux x86_64 dev host:

```bash
cd genie-claw
cargo test -p genie-core web_search
cargo clippy -p genie-core -- -D warnings
cargo fmt --all -- --check
```

### What I observed

- `web_search_endpoint_rejects_string_limit` — HTTP 400 for `{"query":"rust","limit":"5"}`.
- `web_search_rejects_invalid_arguments_and_audits` — dispatch + audit rejection for string `limit` and string `fresh`.
- `parse_web_search_args_rejects_string_limit` / `web_search_fresh_must_be_boolean_when_provided` pass.
- Clippy and `cargo fmt --check` clean.

**Validation gap:** Voice fast-path not exercised in an end-to-end mic loop; uses same parser as dispatch/HTTP.

## Test plan

- `cargo test -p genie-core web_search`
- `cargo clippy -p genie-core -- -D warnings`
- `cargo fmt --all -- --check`

## Notes for reviewers

- Small, focused diff (~60 LOC production + tests) — completes open #462 via #485.
- No new provider stubs; same typed-tool boundary pattern as merged #408 / #411.
