### PR TITLE
test: uniquify prompt and governor SQLite temp paths (#487)

### DIFF
--- a/crates/genie-core/src/prompt.rs
+++ b/crates/genie-core/src/prompt.rs
@@ -321,6 +321,27 @@ fn format_memories(memory: &Memory) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static PROMPT_TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    /// Unique temp dir per test — avoids readonly SQLite flakes from fixed paths (#487).
+    fn prompt_test_memory() -> Memory {
+        let id = PROMPT_TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "geniepod-prompt-mem-{}-{}-{}",
+            std::process::id(),
+            id,
+            nanos
+        ));
+        std::fs::create_dir_all(&dir).expect("create prompt test memory dir");
+        Memory::open(&dir.join("memory.db")).unwrap()
+    }
 
     #[test]
     fn detect_nemotron() {
@@ -379,9 +400,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-qwen3-4b.db");
-        let _ = std::fs::remove_file(&mem_path);
-        let memory = Memory::open(&mem_path).unwrap();
+        let memory = prompt_test_memory();
 
         let prompt = builder.build(&tools, &memory);
         assert!(prompt.contains("ONLY a JSON object"));
@@ -413,9 +432,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test.db");
-        let _ = std::fs::remove_file(&mem_path);
-        let memory = Memory::open(&mem_path).unwrap();
+        let memory = prompt_test_memory();
 
         let prompt = builder.build(&tools, &memory);
         assert!(prompt.contains("ONLY a JSON object"));
@@ -430,9 +447,7 @@ mod tests {
             description: "Get system status".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-system-info.db");
-        let _ = std::fs::remove_file(&mem_path);
-        let memory = Memory::open(&mem_path).unwrap();
+        let memory = prompt_test_memory();
 
         let prompt = builder.build(&tools, &memory);
         assert!(prompt.contains("always use the system_info tool"));
@@ -454,9 +469,7 @@ mod tests {
                 parameters: serde_json::json!({"type": "object", "properties": {"query": {"type": "string"}}}),
             },
         ];
-        let mem_path = std::env::temp_dir().join("prompt-test-small.db");
-        let _ = std::fs::remove_file(&mem_path);
-        let memory = Memory::open(&mem_path).unwrap();
+        let memory = prompt_test_memory();
 
         let prompt = builder.build(&tools, &memory);
         assert!(prompt.contains("EXAMPLES:"));
@@ -476,9 +489,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-no-home.db");
-        let _ = std::fs::remove_file(&mem_path);
-        let memory = Memory::open(&mem_path).unwrap();
+        let memory = prompt_test_memory();
 
         let prompt = builder.build(&tools, &memory);
         assert!(prompt.contains("Home control is currently unavailable"));
@@ -493,9 +504,7 @@ mod tests {
             description: "Demo greeting skill".into(),
             parameters: serde_json::json!({"type": "object", "properties": {"name": {"type": "string"}}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-hello-world.db");
-        let _ = std::fs::remove_file(&mem_path);
-        let memory = Memory::open(&mem_path).unwrap();
+        let memory = prompt_test_memory();
 
         let prompt = builder.build(&tools, &memory);
         assert!(prompt.contains("Only use hello_world when the user explicitly asks"));
@@ -525,9 +534,7 @@ mod tests {
                 parameters: serde_json::json!({"type": "object", "properties": {"content": {"type": "string"}}}),
             },
         ];
-        let mem_path = std::env::temp_dir().join("prompt-test-memory-tools.db");
-        let _ = std::fs::remove_file(&mem_path);
-        let memory = Memory::open(&mem_path).unwrap();
+        let memory = prompt_test_memory();
 
         let prompt = builder.build(&tools, &memory);
         assert!(prompt.contains("did you remember my name?"));
@@ -547,9 +554,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-phi.db");
-        let _ = std::fs::remove_file(&mem_path);
-        let memory = Memory::open(&mem_path).unwrap();
+        let memory = prompt_test_memory();
 
         let prompt = builder.build(&tools, &memory);
         assert!(prompt.contains("ONLY a JSON object"));
@@ -593,9 +598,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-gemma4-e2b.db");
-        let _ = std::fs::remove_file(&mem_path);
-        let memory = Memory::open(&mem_path).unwrap();
+        let memory = prompt_test_memory();
 
         let prompt = builder.build(&tools, &memory);
         assert!(prompt.contains("ONLY a JSON object"));
@@ -611,9 +614,7 @@ mod tests {
             description: "Get current time".into(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         }];
-        let mem_path = std::env::temp_dir().join("prompt-test-policy-filter.db");
-        let _ = std::fs::remove_file(&mem_path);
-        let memory = Memory::open(&mem_path).unwrap();
+        let memory = prompt_test_memory();
         memory
             .store("person_preference", "Maya likes oat milk")
             .unwrap();

--- a/crates/genie-governor/src/governor.rs
+++ b/crates/genie-governor/src/governor.rs
@@ -529,6 +529,18 @@ mod tests {
         Governor::new(config, store)
     }
 
+    fn test_store(label: &str) -> Store {
+        let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let db_path = std::env::temp_dir().join(format!(
+            "geniepod-test-gov-{}-{}-{}.db",
+            label,
+            std::process::id(),
+            id
+        ));
+        let _ = std::fs::remove_file(&db_path);
+        Store::open(&db_path).unwrap()
+    }
+
     #[test]
     fn determine_mode_day_with_plenty_of_memory() {
         let gov = make_governor();
@@ -588,8 +600,7 @@ mod tests {
     fn night_model_swap_config() {
         let mut config = test_config();
         config.governor.night_model_swap = true;
-        let db_path = std::env::temp_dir().join("geniepod-test-gov2.db");
-        let store = Store::open(&db_path).unwrap();
+        let store = test_store("night-swap");
         let mut gov = Governor::new(config, store);
         gov.config.governor.night_start_hour = 0;
         gov.config.governor.day_start_hour = 0;
@@ -629,8 +640,7 @@ mod tests {
     fn resolves_llm_alias_to_configured_service_unit() {
         let mut config = test_config();
         config.services.llm.systemd_unit = "genie-ai-runtime.service".into();
-        let db_path = std::env::temp_dir().join("geniepod-test-gov-llm-unit.db");
-        let store = Store::open(&db_path).unwrap();
+        let store = test_store("llm-unit");
         let gov = Governor::new(config, store);
 
         assert_eq!(


### PR DESCRIPTION
Fixes #487
Closes #463

## Summary

Replace fixed temp SQLite paths in `prompt.rs` unit tests and two `genie-governor` tests with per-run unique directories (pid + counter + nanos), matching the existing `temp_memory_path` / `make_governor()` convention. Stops readonly-database flakes when WAL sidecars linger at shared paths.

## Changes

- `prompt.rs`: add `prompt_test_memory()` helper; migrate 10 tests off `prompt-test-*.db` fixed paths.
- `genie-governor`: add `test_store()` helper; migrate `night_model_swap_config` and `resolves_llm_alias_to_configured_service_unit`.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [ ] `jetson`
- [ ] `raspberry_pi`
- [ ] `portable_sbc`
- [x] `laptop`
- [ ] `mac`
- [ ] CI-only / docs-only
- [ ] Not run locally

### What I ran

```bash
cd genie-claw
cargo test -p genie-core --lib prompt_
cargo test -p genie-governor night_model_swap
cargo test -p genie-governor resolves_llm
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo fmt --all -- --check
```

### What I observed

All prompt and governor tests pass. Full workspace clippy and fmt clean.

**Validation gap:** Tests-only; no runtime/Jetson behavior change.

## Test plan

- `cargo test -p genie-core --lib prompt_`
- `cargo test -p genie-governor`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`

## Notes for reviewers

- Tests-only; completes #463 via #487.
- No production code touched.
