### PR TITLE
ci(release): add release workflow + curl installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,148 @@
+# Build release binaries for Linux aarch64 (Jetson) + x86_64 and publish them as
+# GitHub Release assets, so GenieClaw can be installed with the curl one-liner in
+# install.sh. Triggered by pushing a `vX.Y.Z[-pre]` tag.
+#
+# Each target produces `genieclaw-<version>-<target>.tar.gz` (the five runtime
+# binaries + a default config + LICENSE), plus a combined `SHA256SUMS`. install.sh
+# is uploaded alongside so the raw URL is stable across releases.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
+
+permissions:
+  contents: write
+
+env:
+  BINARIES: genie-core genie-ctl genie-api genie-governor genie-health
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            cross: true
+          - target: x86_64-unknown-linux-gnu
+            cross: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install aarch64 cross toolchain
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build release binaries
+        env:
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: |
+          set -euo pipefail
+          cargo build --release --locked --target "${{ matrix.target }}" -p genie-core
+          cargo build --release --locked --target "${{ matrix.target }}" \
+            -p genie-ctl -p genie-governor -p genie-health -p genie-api
+
+      - name: Verify binaries
+        run: |
+          set -euo pipefail
+          out="target/${{ matrix.target }}/release"
+          for bin in $BINARIES; do
+            test -f "$out/$bin" || { echo "missing: $out/$bin"; exit 1; }
+          done
+
+      - name: Package tarball
+        id: pkg
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          target="${{ matrix.target }}"
+          name="genieclaw-${version}-${target}"
+          out="target/${target}/release"
+          stage="$(mktemp -d)/${name}"
+          mkdir -p "$stage/bin" "$stage/config"
+          for bin in $BINARIES; do install -m 0755 "$out/$bin" "$stage/bin/$bin"; done
+          install -m 0644 deploy/config/geniepod.toml "$stage/config/geniepod.toml"
+          install -m 0644 LICENSE "$stage/LICENSE"
+          echo "$version" > "$stage/VERSION"
+          tar -C "$(dirname "$stage")" -czf "${name}.tar.gz" "${name}"
+          sha256sum "${name}.tar.gz" > "${name}.tar.gz.sha256"
+          echo "tarball=${name}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.pkg.outputs.tarball }}
+          path: |
+            ${{ steps.pkg.outputs.tarball }}
+            ${{ steps.pkg.outputs.tarball }}.sha256
+          retention-days: 7
+
+  release:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Assemble assets + checksums + notes
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          mkdir -p out
+          cp dist/*.tar.gz out/
+          cp install.sh out/install.sh
+          ( cd out && sha256sum ./*.tar.gz install.sh > SHA256SUMS )
+          # Release notes = this version's CHANGELOG section, falling back to a stub.
+          notes="out/notes.md"
+          awk -v v="## ${version}" '
+            $0 ~ "^"v {p=1; next}
+            p && /^## [0-9]/ {p=0}
+            p {print}
+          ' CHANGELOG.md > "$notes" || true
+          if [ ! -s "$notes" ]; then echo "GenieClaw ${version}." > "$notes"; fi
+
+      - name: Mark prerelease for -rc / -beta / -alpha tags
+        id: pre
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            *-rc*|*-beta*|*-alpha*) echo "prerelease=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          flag=""
+          [ "${{ steps.pre.outputs.prerelease }}" = "true" ] && flag="--prerelease"
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" out/*.tar.gz out/SHA256SUMS out/install.sh --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" out/*.tar.gz out/SHA256SUMS out/install.sh \
+              $flag --title "${version}" --notes-file out/notes.md
+          fi

--- a/README.md
+++ b/README.md
@@ -258,7 +258,33 @@ The repo now has explicit code-level contract surfaces for the new direction:
   below `[agent].context_window_tokens` unless a specific test intentionally
   proves a larger-context path without weakening the Jetson baseline.
 
-## Quick Start
+## Install
+
+Install the prebuilt runtime binaries (Linux **aarch64** / Jetson and **x86_64**):
+
+```bash
+curl -fsSL https://github.com/GeniePod/genie-claw/releases/latest/download/install.sh | sh
+```
+
+This installs the five runtime binaries to `/usr/local/bin` (or `~/.local/bin`)
+and writes a starter config to `~/.config/geniepod/geniepod.toml`. Then:
+
+```bash
+GENIEPOD_CONFIG=~/.config/geniepod/geniepod.toml genie-core   # agent runtime + HTTP API
+genie-ctl --help
+```
+
+> While GenieClaw is in the release-candidate phase, `releases/latest` has no
+> stable build yet — pin the version:
+> ```bash
+> GENIECLAW_VERSION=v1.0.0-rc.1 \
+>   sh -c "$(curl -fsSL https://github.com/GeniePod/genie-claw/releases/download/v1.0.0-rc.1/install.sh)"
+> ```
+
+The full Jetson voice / Home Assistant deployment stays in
+[`GETTING_STARTED.md`](GETTING_STARTED.md) and `deploy/setup-jetson.sh`.
+
+## Quick Start (from source)
 
 ```bash
 make

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env sh
+# GenieClaw installer. Downloads the prebuilt runtime binaries for this machine
+# from the latest GitHub Release, verifies their checksum, and installs them.
+#
+#   curl -fsSL https://github.com/GeniePod/genie-claw/releases/latest/download/install.sh | sh
+#
+# Environment overrides:
+#   GENIECLAW_VERSION  pin a version, e.g. v1.0.0-rc.1   (default: latest release)
+#   GENIECLAW_PREFIX   install prefix                    (default: /usr/local, or
+#                                                          ~/.local if not writable)
+#
+# Installs the five runtime binaries (genie-core, genie-ctl, genie-api,
+# genie-governor, genie-health) to $PREFIX/bin and a starter config to
+# ~/.config/geniepod/geniepod.toml. The full Jetson/voice/Home-Assistant setup
+# stays in deploy/setup-jetson.sh — this is the agent runtime only.
+
+set -eu
+
+REPO="GeniePod/genie-claw"
+RELEASES="https://github.com/${REPO}/releases"
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$1"; }
+warn() { printf '\033[1;33mwarning:\033[0m %s\n' "$1" >&2; }
+err()  { printf '\033[1;31merror:\033[0m %s\n' "$1" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || err "required tool not found: $1"; }
+need uname
+need tar
+need install
+# one of curl/wget for downloads
+if command -v curl >/dev/null 2>&1; then DL="curl -fsSL -o"; DLO="curl -fsSL"
+elif command -v wget >/dev/null 2>&1; then DL="wget -qO";   DLO="wget -qO-"
+else err "need curl or wget"; fi
+# one of sha256sum/shasum for verification
+if command -v sha256sum >/dev/null 2>&1; then SHA="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then SHA="shasum -a 256"
+else err "need sha256sum or shasum"; fi
+
+# --- detect platform ---------------------------------------------------------
+os="$(uname -s)"
+[ "$os" = "Linux" ] || err "unsupported OS: $os (this release ships Linux binaries only)"
+arch="$(uname -m)"
+case "$arch" in
+  aarch64|arm64)  target="aarch64-unknown-linux-gnu" ;;
+  x86_64|amd64)   target="x86_64-unknown-linux-gnu" ;;
+  *) err "unsupported architecture: $arch (supported: aarch64, x86_64)" ;;
+esac
+info "Platform: ${os} ${arch} -> ${target}"
+
+# --- resolve version ---------------------------------------------------------
+# Default to the latest STABLE release via the /releases/latest redirect (this
+# excludes pre-releases). During the rc/beta phase, pin GENIECLAW_VERSION.
+version="${GENIECLAW_VERSION:-}"
+if [ -z "$version" ]; then
+  info "Resolving latest release..."
+  if command -v curl >/dev/null 2>&1; then
+    version="$(curl -fsSLo /dev/null -w '%{url_effective}' "${RELEASES}/latest" 2>/dev/null | sed -n 's#.*/tag/##p')"
+  else
+    version="$(wget -qO- "${RELEASES}/latest" 2>/dev/null | sed -n 's#.*/releases/tag/\(v[0-9][^"<> ]*\).*#\1#p' | head -n1)"
+  fi
+fi
+case "${version:-}" in
+  v*) : ;;
+  *) err "no stable release found. During the pre-release phase, pin a version, e.g.:
+     GENIECLAW_VERSION=v1.0.0-rc.1 sh install.sh" ;;
+esac
+info "Version: ${version}"
+
+tarball="genieclaw-${version#v}-${target}.tar.gz"
+base="${RELEASES}/download/${version}"
+
+# --- download + verify -------------------------------------------------------
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+info "Downloading ${tarball}..."
+$DL "${tmp}/${tarball}" "${base}/${tarball}" || err "download failed: ${base}/${tarball}"
+if $DL "${tmp}/SHA256SUMS" "${base}/SHA256SUMS" 2>/dev/null; then
+  expected="$(grep " .*${tarball}\$" "${tmp}/SHA256SUMS" | awk '{print $1}' | head -n1)"
+  [ -n "$expected" ] || err "no checksum for ${tarball} in SHA256SUMS"
+  actual="$(cd "$tmp" && $SHA "$tarball" | awk '{print $1}')"
+  [ "$expected" = "$actual" ] || err "checksum mismatch for ${tarball} (expected ${expected}, got ${actual})"
+  info "Checksum verified."
+else
+  warn "SHA256SUMS not found for ${version}; skipping checksum verification."
+fi
+
+# --- install -----------------------------------------------------------------
+tar -C "$tmp" -xzf "${tmp}/${tarball}"
+src="${tmp}/genieclaw-${version#v}-${target}"
+
+prefix="${GENIECLAW_PREFIX:-/usr/local}"
+bindir="${prefix}/bin"
+SUDO=""
+if ! mkdir -p "$bindir" 2>/dev/null || ! [ -w "$bindir" ]; then
+  if [ "$prefix" = "/usr/local" ] && command -v sudo >/dev/null 2>&1 && [ "$(id -u)" -ne 0 ]; then
+    SUDO="sudo"; info "Using sudo to install into ${bindir}"
+  else
+    prefix="${HOME}/.local"; bindir="${prefix}/bin"; mkdir -p "$bindir"
+    warn "no write access to /usr/local; installing into ${bindir}"
+  fi
+fi
+
+for bin in genie-core genie-ctl genie-api genie-governor genie-health; do
+  $SUDO install -m 0755 "${src}/bin/${bin}" "${bindir}/${bin}"
+done
+info "Installed 5 binaries to ${bindir}"
+
+cfgdir="${HOME}/.config/geniepod"
+cfg="${cfgdir}/geniepod.toml"
+if [ ! -f "$cfg" ]; then
+  mkdir -p "$cfgdir"
+  install -m 0644 "${src}/config/geniepod.toml" "$cfg"
+  info "Wrote starter config to ${cfg}"
+else
+  info "Keeping existing config at ${cfg}"
+fi
+
+# --- next steps --------------------------------------------------------------
+echo
+info "GenieClaw ${version} installed."
+case ":${PATH}:" in
+  *":${bindir}:"*) : ;;
+  *) warn "add ${bindir} to your PATH:  export PATH=\"${bindir}:\$PATH\"" ;;
+esac
+cat <<EOF
+
+Next:
+  genie-ctl --help
+  GENIEPOD_CONFIG=${cfg} genie-core      # start the agent runtime + HTTP API
+
+Jetson voice / Home Assistant setup: see GETTING_STARTED.md in the repo.
+EOF

--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,8 @@ need uname
 need tar
 need install
 # one of curl/wget for downloads
-if command -v curl >/dev/null 2>&1; then DL="curl -fsSL -o"; DLO="curl -fsSL"
-elif command -v wget >/dev/null 2>&1; then DL="wget -qO";   DLO="wget -qO-"
+if command -v curl >/dev/null 2>&1; then DL="curl -fsSL -o"
+elif command -v wget >/dev/null 2>&1; then DL="wget -qO"
 else err "need curl or wget"; fi
 # one of sha256sum/shasum for verification
 if command -v sha256sum >/dev/null 2>&1; then SHA="sha256sum"


### PR DESCRIPTION
## Summary

Adds the release pipeline so GenieClaw can be installed with a curl one-liner.

- `release.yml` — on a `vX.Y.Z[-pre]` tag, cross-builds the five runtime binaries for `aarch64-unknown-linux-gnu` (Jetson) and `x86_64-unknown-linux-gnu`, packages each as `genieclaw-<version>-<target>.tar.gz` (bins + default config + LICENSE), generates `SHA256SUMS`, and publishes a GitHub Release (pre-release for `-rc`/`-beta`/`-alpha`) with notes from the CHANGELOG.
- `install.sh` — `curl -fsSL .../install.sh | sh`: detects arch, resolves the version, downloads + sha256-verifies the tarball, installs the binaries to `/usr/local/bin` (or `~/.local/bin`), and writes a starter config.
- README — Install section (curl one-liner + rc-phase pinned form).

The full Jetson voice / Home Assistant deployment stays in `setup-jetson.sh`; this ships the agent runtime binaries.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified the end-to-end release on Jetson yet — it runs on the first tag (explained below).

Tested profile / hardware:

- [x] CI-only / docs-only

### What I ran

CI/installer change — no runtime source. Validated locally: `release.yml` parses (`yaml.safe_load`) and its `run:` blocks pass `bash -n`; `install.sh` passes `sh -n` and was reviewed for the download / checksum / prefix-fallback paths. The aarch64 cross-build reuses the toolchain already proven by `cross.yml`.

### What I observed

YAML valid (jobs: `build`, `release`); `sh -n` clean; the bundled `deploy/config/geniepod.toml` and `LICENSE` exist. The full pipeline (tag → cross-build → upload → curl-install) is exercised by the first `v1.0.0-rc.1` tag after merge — the intended rc validation.

## Test plan

After merge: push `v1.0.0-rc.1`, confirm `release.yml` builds both targets and publishes the prerelease, then run `curl … | sh` on the Jetson (aarch64) and an x86_64 host.