### PR TITLE
fix(quick-router): parse the full spoken-number range for durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Full spoken-number durations** (#490): the quick-router only mapped a sparse
+  set of number words, so "set a timer for thirteen minutes" set no timer
+  (thirteen, fourteen, sixteen–nineteen were missing, and hundreds/thousands
+  were unsupported). A real English cardinal parser now folds units, teens,
+  tens, `hundred`, `thousand`, and the `and` connector into one value, so
+  "one hundred and twenty seconds" and the like resolve correctly. Digit forms
+  and the existing "forty five" compound are unchanged.
+
 ## 1.0.0-rc.1 - 2026-06-24
 
 First release candidate — and the first **installable** build. GenieClaw can now

--- a/crates/genie-core/src/tools/quick.rs
+++ b/crates/genie-core/src/tools/quick.rs
@@ -2389,75 +2389,105 @@ fn parse_decimal_token(token: &str) -> Option<f64> {
 }
 
 fn parse_duration(tokens: &[&str]) -> Option<(u64, usize)> {
-    for (idx, token) in tokens.iter().enumerate() {
-        let Some(amount) = parse_number(token) else {
+    let mut start = 0;
+    while start < tokens.len() {
+        let Some((amount, unit_index)) = parse_spoken_number(tokens, start) else {
+            start += 1;
             continue;
         };
-        // Combine a spoken compound cardinal like "forty five" (45) into a
-        // single amount. Worded numbers arrive as separate whitespace tokens,
-        // so the tens word and the ones word must be stitched here.
-        let (amount, unit_index) = match tokens.get(idx + 1).and_then(|next| ones_digit(next)) {
-            Some(ones) if is_tens_word(token) => (amount + ones, idx + 2),
-            _ => (amount, idx + 1),
+        let multiplier = match tokens.get(unit_index).copied() {
+            Some("second" | "seconds" | "sec" | "secs") => 1,
+            Some("minute" | "minutes" | "min" | "mins") => 60,
+            Some("hour" | "hours" | "hr" | "hrs") => 3600,
+            _ => {
+                start += 1;
+                continue;
+            }
         };
-        let unit = tokens.get(unit_index)?;
-        let multiplier = match *unit {
-            "second" | "seconds" | "sec" | "secs" => 1,
-            "minute" | "minutes" | "min" | "mins" => 60,
-            "hour" | "hours" | "hr" | "hrs" => 3600,
-            _ => continue,
-        };
-        return Some((amount * multiplier, unit_index));
+        return Some((amount.saturating_mul(multiplier), unit_index));
     }
     None
 }
 
-/// True when `token` is a spoken tens word that can lead a compound cardinal
-/// such as "forty five".
-fn is_tens_word(token: &str) -> bool {
-    matches!(
-        token,
-        "twenty" | "thirty" | "forty" | "fifty" | "sixty" | "seventy" | "eighty" | "ninety"
-    )
+enum CardinalWord {
+    Value(u64),
+    Hundred,
+    Thousand,
 }
 
-/// The trailing ones digit of a compound cardinal ("forty *five*"), 1-9.
-fn ones_digit(token: &str) -> Option<u64> {
-    match parse_number(token) {
-        Some(value @ 1..=9) => Some(value),
-        _ => None,
+fn parse_spoken_number(tokens: &[&str], start: usize) -> Option<(u64, usize)> {
+    if let Some(Ok(value)) = tokens.get(start).map(|token| token.parse::<u64>()) {
+        return Some((value, start + 1));
     }
+
+    let mut total: u64 = 0;
+    let mut group: u64 = 0;
+    let mut index = start;
+    let mut matched = false;
+
+    while let Some(&token) = tokens.get(index) {
+        if matched
+            && token == "and"
+            && tokens
+                .get(index + 1)
+                .is_some_and(|next| cardinal_word(next).is_some())
+        {
+            index += 1;
+            continue;
+        }
+        let Some(word) = cardinal_word(token) else {
+            break;
+        };
+        match word {
+            CardinalWord::Value(value) => group = group.saturating_add(value),
+            CardinalWord::Hundred => group = group.max(1).saturating_mul(100),
+            CardinalWord::Thousand => {
+                total = total.saturating_add(group.max(1).saturating_mul(1000));
+                group = 0;
+            }
+        }
+        matched = true;
+        index += 1;
+    }
+
+    matched.then(|| (total.saturating_add(group), index))
 }
 
-fn parse_number(token: &str) -> Option<u64> {
-    if let Ok(value) = token.parse::<u64>() {
-        return Some(value);
-    }
-
-    match token {
-        "one" | "a" | "an" => Some(1),
-        "two" => Some(2),
-        "three" => Some(3),
-        "four" => Some(4),
-        "five" => Some(5),
-        "six" => Some(6),
-        "seven" => Some(7),
-        "eight" => Some(8),
-        "nine" => Some(9),
-        "ten" => Some(10),
-        "eleven" => Some(11),
-        "twelve" => Some(12),
-        "fifteen" => Some(15),
-        "twenty" => Some(20),
-        "thirty" => Some(30),
-        "forty" => Some(40),
-        "fifty" => Some(50),
-        "sixty" => Some(60),
-        "seventy" => Some(70),
-        "eighty" => Some(80),
-        "ninety" => Some(90),
-        _ => None,
-    }
+fn cardinal_word(token: &str) -> Option<CardinalWord> {
+    use CardinalWord::{Hundred, Thousand, Value};
+    Some(match token {
+        "zero" => Value(0),
+        "one" | "a" | "an" => Value(1),
+        "two" => Value(2),
+        "three" => Value(3),
+        "four" => Value(4),
+        "five" => Value(5),
+        "six" => Value(6),
+        "seven" => Value(7),
+        "eight" => Value(8),
+        "nine" => Value(9),
+        "ten" => Value(10),
+        "eleven" => Value(11),
+        "twelve" => Value(12),
+        "thirteen" => Value(13),
+        "fourteen" => Value(14),
+        "fifteen" => Value(15),
+        "sixteen" => Value(16),
+        "seventeen" => Value(17),
+        "eighteen" => Value(18),
+        "nineteen" => Value(19),
+        "twenty" => Value(20),
+        "thirty" => Value(30),
+        "forty" => Value(40),
+        "fifty" => Value(50),
+        "sixty" => Value(60),
+        "seventy" => Value(70),
+        "eighty" => Value(80),
+        "ninety" => Value(90),
+        "hundred" => Hundred,
+        "thousand" => Thousand,
+        _ => return None,
+    })
 }
 
 fn reminder_label(tokens: &[&str], unit_end_index: usize) -> Option<String> {
@@ -4186,6 +4216,45 @@ mod tests {
         let call = route("remind me in forty five minutes to check the oven").unwrap();
         assert_eq!(call.arguments["seconds"], 2700);
         assert_eq!(call.arguments["label"], "check the oven");
+    }
+
+    #[test]
+    fn routes_teen_worded_durations() {
+        for (word, value) in [
+            ("thirteen", 13),
+            ("fourteen", 14),
+            ("sixteen", 16),
+            ("seventeen", 17),
+            ("eighteen", 18),
+            ("nineteen", 19),
+        ] {
+            let call = route(&format!("set a timer for {word} minutes"))
+                .unwrap_or_else(|| panic!("'{word} minutes' should route"));
+            assert_eq!(call.name, "set_timer");
+            assert_eq!(call.arguments["seconds"], value * 60, "{word}");
+        }
+    }
+
+    #[test]
+    fn routes_hundreds_and_thousands_worded_durations() {
+        let call = route("set a timer for one hundred seconds").unwrap();
+        assert_eq!(call.arguments["seconds"], 100);
+
+        let call = route("set a timer for two hundred thirty seconds").unwrap();
+        assert_eq!(call.arguments["seconds"], 230);
+
+        let call = route("set a timer for one hundred twenty minutes").unwrap();
+        assert_eq!(call.arguments["seconds"], 120 * 60);
+
+        let call = route("set a timer for one thousand seconds").unwrap();
+        assert_eq!(call.arguments["seconds"], 1000);
+
+        let call = route("set a timer for one hundred and twenty seconds").unwrap();
+        assert_eq!(call.arguments["seconds"], 120);
+
+        let call = route("remind me in ninety nine seconds to stretch").unwrap();
+        assert_eq!(call.arguments["seconds"], 99);
+        assert_eq!(call.arguments["label"], "stretch");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The deterministic quick-router's spoken-duration parser only recognized a sparse, hand-picked set of number words, so common phrasings silently failed to set a timer. "set a timer for **thirteen** minutes" did nothing, because `thirteen`, `fourteen`, `sixteen`, `seventeen`, `eighteen`, and `nineteen` were missing from the word list — and there was no support for `hundred`/`thousand` at all. This replaces the sparse lookup with a real English cardinal parser.

## Changes

- The old `parse_number` mapped a sparse word set (it lacked the teens above twelve except fifteen), and an ad-hoc `is_tens_word`/`ones_digit` special case stitched only tens+ones compounds — nothing past ninety-nine.
- New `parse_spoken_number(tokens, start)` consumes a maximal run of number words and folds units, teens, tens, `hundred`, `thousand`, and the connector `and` into a single value, returning the value and the index just past the run. `cardinal_word` is the single classifier.
- `parse_duration` now drives that parser and then checks a time unit follows.
- Digit forms (`"10 minutes"`) and every previously handled phrasing — including the `"forty five"` compound — are preserved; new coverage adds the missing teens and arbitrary hundreds/thousands (e.g. `"one hundred and twenty seconds"`).
- All arithmetic is saturating, so adversarial input can't overflow.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have NOT verified on Jetson hardware, and I explain the equivalent verification path or validation gap below.

Tested profile / hardware (check all that apply):

- [x] `laptop`

This is a deterministic, hardware-independent change to the quick-router's duration parsing. No Jetson, audio, model, or network dependency — an x86_64 Linux dev box exercises the exact code path that runs on-device, and the parser is fully covered by unit tests.

### What I ran

On x86_64 Linux (Ubuntu, kernel 6.8), rustc 1.96.0:

```
cargo test -p genie-core
cargo test -p genie-core --lib tools::quick::tests::routes
cargo clippy -p genie-core --tests
cargo clippy -p genie-core --no-default-features --tests
cargo fmt -p genie-core -- --check
```

I added the regression tests first and confirmed they **fail on the current code** before applying the fix (e.g. `'thirteen minutes' should route` panicked).

### What I observed

- Before: `route("set a timer for thirteen minutes")` returned `None` (no timer); hundreds/thousands likewise unhandled.
- After:
  - `thirteen / fourteen / sixteen / seventeen / eighteen / nineteen minutes` → correct `n * 60` seconds.
  - `"one hundred seconds"` → 100; `"two hundred thirty seconds"` → 230; `"one hundred and twenty seconds"` → 120; `"one hundred twenty minutes"` → 7200; `"one thousand seconds"` → 1000; `"ninety nine seconds"` → 99.
  - Existing phrasings unchanged: `"10 minutes"` → 600, `"forty five minutes"` → 2700, `"twenty five seconds"` → 25, `"fifty minutes"` → 3000, and the labelled-reminder boundary still extracts `"check the oven"`.
- `cargo test -p genie-core` — **787 passed, 0 failed** (1 pre-existing ignored), so no regression.
- `clippy` clean in both default and `--no-default-features`; `cargo fmt --check` clean.

## Test plan

1. `cargo test -p genie-core --lib tools::quick::tests::routes` — all routing tests pass, including `routes_teen_worded_durations` and `routes_hundreds_and_thousands_worded_durations`.
2. Manually route "set a timer for thirteen minutes" and confirm `set_timer { seconds: 780 }`.

## Notes for reviewers

`parse_number`, `is_tens_word`, and `ones_digit` were used only by `parse_duration`, so this is fully contained to duration parsing — no other routing path changes. The parser handles "and" only as an in-number connector (when a number word follows), so a trailing conjunction like "set a timer for ten minutes and turn on the lights" is unaffected (the unit is matched before "and" is reached).
