### PR TITLE
release: v1.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## Unreleased
 
+## 1.0.0-rc.1 - 2026-06-24
+
+First release candidate — and the first **installable** build. GenieClaw can now
+be installed with a single `curl … | sh` (prebuilt aarch64/Jetson + x86_64
+binaries). This release also adds opt-in, privacy-preserving cloud escalation
+and continues the security + performance hardening from the alpha series.
+
+### Install / release
+
+- **Curl installer + release pipeline** (#489): a tag-triggered workflow
+  cross-builds the runtime binaries for `aarch64-unknown-linux-gnu` (Jetson) and
+  `x86_64-unknown-linux-gnu` and publishes them as GitHub Release assets;
+  `install.sh` arch-detects, sha256-verifies, and installs them plus a starter
+  config. See the README **Install** section.
+
+### Features
+
+- **Opt-in cloud escalation via PrivacyProxy** (#436): when the local model
+  declines or a turn overflows the 4096-token budget, the agent can escalate
+  through a localhost anonymizing gateway. Only escalation-eligible entity names
+  are seeded for masking; `Private` / `Cautious` / health / identity memory is
+  `LocalOnly` and is never seeded or forwarded — even to the localhost proxy.
+  Disabled by default; a localhost `base_url` is enforced at startup.
+
+### Security
+
+- **Person-scoped `memory_store` gate** (#467): `memory_store` now requires the
+  same verified-identity context that `memory_recall` / `memory_forget` already
+  require before writing person-scoped facts, closing the write-side asymmetry
+  left by #433.
+
+### Reliability
+
+- **Runtime accepts OpenAI `tool_calls` wrappers** (#482): runtime dispatch now
+  parses the `tool_calls` / `function_call` wrappers and top-level JSON arrays
+  the eval path already handled (the first call is dispatched); malformed
+  wrappers route to the unparsed fallback instead of leaking raw JSON.
+
+### Performance
+
+- **Single-pass TTS text cleanup** (#483): `for_voice` collapses the 12-replace
+  TTS cleanup and the `Vec`+`join` passes into single passes — byte-for-byte
+  identical output, fewer allocations.
+- **Const relationship patterns + early-out** (#484): `extract_facts` replaces
+  57 per-call `format!` allocations with a `const` table and skips the entire
+  19-relation scan when an utterance contains no `"my "`.
+
 ## 1.0.0-alpha.12 - 2026-06-23
 
 Alpha 12 is a **performance + reliability hardening** release. The memory open

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "genie-api"
-version = "1.0.0-alpha.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",
  "genie-common",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "genie-common"
-version = "1.0.0-alpha.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",
  "rustls",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "genie-core"
-version = "1.0.0-alpha.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "genie-ctl"
-version = "1.0.0-alpha.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",
  "genie-common",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "genie-governor"
-version = "1.0.0-alpha.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",
  "genie-common",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "genie-health"
-version = "1.0.0-alpha.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",
  "genie-common",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "genie-skill-sdk"
-version = "1.0.0-alpha.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-alpha.12"
+version = "1.0.0-rc.1"
 edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/GeniePod/genie-claw"


### PR DESCRIPTION
## Summary

Release **v1.0.0-rc.1** — the first **installable** release candidate. Bumps the workspace version (1.0.0-alpha.12 → 1.0.0-rc.1) and finalizes the CHANGELOG for the 6 PRs merged since alpha.12.

After merge, tagging `v1.0.0-rc.1` triggers the new `release.yml` for the first time — cross-building the aarch64 + x86_64 binaries and publishing the prerelease so the `curl … | sh` install works.

## Changes

- `Cargo.toml` workspace version → `1.0.0-rc.1` (+ `Cargo.lock`, 7 crates).
- CHANGELOG: `## Unreleased` → `## 1.0.0-rc.1 - 2026-06-24`, documenting #489, #436, #467, #482, #483, #484.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson — release chore, explained below.

Tested profile / hardware:

- [x] CI-only / docs-only

### What I ran

Release chore — version bump + CHANGELOG only, no source changes. `cargo check` passes at `1.0.0-rc.1`; the 6 merged PRs were each verified (several on the Jetson) before merge.

### What I observed

`cargo check` clean at `1.0.0-rc.1`; `quinn-proto` stays 0.11.15 (audit clean); CHANGELOG well-formed.

## Test plan

After merge: tag `v1.0.0-rc.1`, confirm `release.yml` builds both targets and publishes the prerelease, then run `curl … | sh` on the Jetson (aarch64) and an x86_64 host.