### PR TITLE
fix(release): build on ubuntu-22.04 for Jetson glibc compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,10 @@ env:
 jobs:
   build:
     name: build ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    # Build on 22.04 (glibc 2.35) so the binaries run on the Jetson (L4T 36 /
+    # Ubuntu 22.04, glibc 2.35). ubuntu-latest (24.04, glibc 2.39) produces
+    # binaries that fail with "GLIBC_2.39 not found" on the device.
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
## Summary

The `v1.0.0-rc.1` binaries installed correctly but **failed to run on the Jetson** with `/lib/aarch64-linux-gnu/libc.so.6: version \`GLIBC_2.39' not found`. `release.yml` built on `ubuntu-latest` (24.04, glibc 2.39); the Jetson is L4T 36 / Ubuntu 22.04 (glibc 2.35), confirmed on-device.

Pinning the build job to `ubuntu-22.04` (glibc 2.35) makes both the aarch64 and x86_64 binaries link against glibc 2.35 — they run on the Jetson and stay forward-compatible with newer x86 hosts.

## Real Behavior Proof

- [x] I have built and run the affected code locally (or noted why I could not).
- [x] I have verified the change end-to-end on Jetson hardware.
- [ ] N/A

Tested profile / hardware:

- [x] `jetson`
- [x] `x86_64`

### What I ran / observed

Caught by testing the rc.1 `curl … | sh` install on both hosts: x86_64 installed + `genie-ctl v1.0.0-rc.1` ran; aarch64 installed but `genie-ctl` failed with `GLIBC_2.39 not found`. `ldd --version` on the Jetson confirms glibc 2.35 (Ubuntu 22.04.5). This pins the build to a matching glibc. The fix is exercised by the next rc tag.