### PR TITLE
fix(cli): make --version work without a config file

### DIFF
--- a/crates/genie-core/src/main.rs
+++ b/crates/genie-core/src/main.rs
@@ -15,6 +15,17 @@ use tracing_subscriber::EnvFilter;
 /// 3. Voice pipeline (wake word → STT → LLM → TTS → speaker)
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
+    // `--version` must work on a fresh install before any config exists, so
+    // handle it before Config::load() (which would otherwise fail to read
+    // /etc/geniepod/geniepod.toml).
+    if std::env::args()
+        .skip(1)
+        .any(|a| a == "--version" || a == "-v")
+    {
+        println!("genie-core v{}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),

--- a/crates/genie-core/tests/version_flag_test.rs
+++ b/crates/genie-core/tests/version_flag_test.rs
@@ -1,0 +1,26 @@
+// `genie-core --version` must work on a fresh install, before any config file
+// exists — it is handled before Config::load(). Regression test for the
+// "failed to read config /etc/geniepod/geniepod.toml" error on fresh installs.
+
+use std::process::Command;
+
+#[test]
+fn version_flag_succeeds_without_config() {
+    let exe = env!("CARGO_BIN_EXE_genie-core");
+    let out = Command::new(exe)
+        .arg("--version")
+        .env_remove("GENIEPOD_CONFIG")
+        .output()
+        .expect("run genie-core --version");
+
+    assert!(
+        out.status.success(),
+        "genie-core --version must exit 0 without a config; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("genie-core v"),
+        "expected version line, got: {stdout:?}"
+    );
+}

--- a/crates/genie-ctl/src/main.rs
+++ b/crates/genie-ctl/src/main.rs
@@ -328,7 +328,7 @@ fn cmd_version() {
     println!("genie-ctl v{}", env!("CARGO_PKG_VERSION"));
     match load_core_addr() {
         Ok(addr) => println!("  core: {}", addr),
-        Err(err) => println!("  core: (config error: {err})"),
+        Err(_) => println!("  core: (not configured; set GENIEPOD_CONFIG)"),
     }
     println!("  governor: {}", GOVERNOR_SOCK);
 }


### PR DESCRIPTION
## Summary

`--version` should work on a fresh install, before any config exists. It didn't:

- `genie-core --version` loaded the config first, so a fresh install (no `/etc/geniepod/geniepod.toml`, `GENIEPOD_CONFIG` unset) errored with `failed to read config … Permission denied`.
- `genie-ctl --version` printed the raw OS error in its `core:` line.

Fix:
- `genie-core`: handle `--version` / `-v` **before** `Config::load()` — print the version and exit 0.
- `genie-ctl`: the `core:` line shows `(not configured; set GENIEPOD_CONFIG)` instead of the raw config error.

Caught while testing the `v1.0.0-rc.1` curl-install on the Jetson — a fresh-install paper-cut.

## Real Behavior Proof

- [x] I have built and run the affected code locally.
- [ ] I have verified the change end-to-end on Jetson hardware.
- [x] I have NOT verified on Jetson — CLI flag handling, arch-independent, covered by a regression test.

Tested profile / hardware:

- [x] `laptop`

### What I ran

`env -u GENIEPOD_CONFIG genie-core --version` and `genie-ctl --version`; `cargo test -p genie-core --test version_flag_test`.

### What I observed

`genie-core --version` → `genie-core v1.0.0-rc.1` (exit 0; previously errored on config read). `genie-ctl --version` → version + `core: (not configured; set GENIEPOD_CONFIG)` + governor (exit 0). New regression test passes; `cargo fmt` clean; clippy 0.

## Test plan

`cargo test -p genie-core --test version_flag_test`; manually `env -u GENIEPOD_CONFIG genie-core --version` on a host with no `/etc/geniepod/geniepod.toml`.